### PR TITLE
fix(chatFormats): suppress content when it duplicates reasoning_content

### DIFF
--- a/src/server/routes/proxy/chatFormats.ts
+++ b/src/server/routes/proxy/chatFormats.ts
@@ -736,7 +736,7 @@ export function normalizeUpstreamStreamEvent(
     const delta = isRecord(choice?.delta) ? choice.delta : {};
     const deltaParsed = extractTextAndReasoning(delta.content ?? delta);
 
-    const contentDelta =
+    const rawContentDelta =
       deltaParsed.content
       || (typeof choice?.message?.content === 'string' ? choice.message.content : '')
       || '';
@@ -746,6 +746,14 @@ export function normalizeUpstreamStreamEvent(
       || (typeof (delta as any).reasoning === 'string' ? (delta as any).reasoning : '')
       || deltaParsed.reasoning
       || '';
+
+    // Some upstream providers (e.g. certain OpenAI-compatible aggregators) emit thinking
+    // tokens with the same text duplicated in both delta.content and delta.reasoning_content.
+    // When the two values are identical it means content is just echoing the reasoning —
+    // suppress it so internal thinking is never leaked to downstream consumers.
+    const contentDelta = (reasoningDelta && rawContentDelta === reasoningDelta)
+      ? ''
+      : rawContentDelta;
 
     const rawToolCalls = Array.isArray((delta as any).tool_calls)
       ? ((delta as any).tool_calls as unknown[])


### PR DESCRIPTION
## Problem

Some upstream providers (e.g. certain OpenAI-compatible aggregators) emit thinking/reasoning tokens with **the same text written to both `delta.content` and `delta.reasoning_content` simultaneously**.

When metapi forwarded these chunks downstream, clients that read `delta.content` (such as chat gateway applications) would display the internal reasoning narration to end users. This manifested as word-by-word "thinking text" appearing in chat interfaces like Telegram bots:

```
> **Preparing
> for
> startup
> memory
> reading
> **
> (actual answer here)
```

The issue affects all models that produce reasoning tokens this way — not just specific model families.

## Root Cause

In `normalizeUpstreamStreamEvent`, `contentDelta` and `reasoningDelta` are resolved independently:

```ts
const contentDelta =
  deltaParsed.content || ...;   // reads delta.content

const reasoningDelta =
  delta.reasoning_content || ...; // reads delta.reasoning_content
```

When an upstream sends `delta.content == delta.reasoning_content == "**Preparing"`, both fields are set identically and both get forwarded in the output chunk.

## Fix

After resolving both values, suppress `contentDelta` when it is non-empty and identical to `reasoningDelta`. This covers the duplicate-write pattern without affecting any legitimate case (a provider would never intentionally set `content == reasoning_content` for a meaningful response chunk).

```ts
const contentDelta = (reasoningDelta && rawContentDelta === reasoningDelta)
  ? ''
  : rawContentDelta;
```

## Testing

Verified against a live metapi instance by hot-patching the compiled output and confirming:
- Reasoning-phase chunks: only `reasoning_content` in the SSE delta, `content` absent
- Normal response chunks: `content` present as before, unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where duplicate content could appear in chat responses by suppressing redundant output.
  * Improved content filtering to prevent internal processing details from appearing in user-facing output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->