### PR TITLE
Disable npm rebuild during desktop packaging and remove AppImage prefetch step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,20 +114,6 @@ jobs:
           name: metapi-dist-${{ github.sha }}
           path: .
 
-      - name: Prefetch AppImage tools
-        if: runner.os == 'Linux'
-        shell: bash
-        env:
-          APPIMAGE_TOOLS_URL: https://github.com/electron-userland/electron-builder-binaries/releases/download/appimage%401.0.2/appimage-tools-runtime-20251108.tar.gz
-        run: |
-          set -euo pipefail
-          APPIMAGE_TOOLS_DIR="${{ runner.temp }}/.cache/appimage-tools"
-          if [ -x "$APPIMAGE_TOOLS_DIR/mksquashfs" ]; then
-            exit 0
-          fi
-          mkdir -p "$APPIMAGE_TOOLS_DIR"
-          curl -fL --retry 5 --retry-all-errors --retry-delay 5 "$APPIMAGE_TOOLS_URL" | tar -xz -C "$APPIMAGE_TOOLS_DIR"
-
       - name: Build desktop artifacts (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
@@ -145,7 +131,7 @@ jobs:
           if ($env:WIN_CSC_KEY_PASSWORD_INPUT) { $env:WIN_CSC_KEY_PASSWORD = $env:WIN_CSC_KEY_PASSWORD_INPUT }
           for ($attempt = 1; $attempt -le 2; $attempt++) {
             Write-Host "Desktop build attempt $attempt/2"
-            npm run package:desktop
+            npm run package:desktop -- --config.npmRebuild=false
             if ($LASTEXITCODE -eq 0) {
               break
             }
@@ -165,12 +151,11 @@ jobs:
           ELECTRON_BUILDER_CACHE: ${{ runner.temp }}/.cache/electron-builder
           ELECTRON_BUILDER_BINARIES_MIRROR: https://github.com/electron-userland/electron-builder-binaries/releases/download/
           npm_config_electron_builder_binaries_mirror: https://github.com/electron-userland/electron-builder-binaries/releases/download/
-          APPIMAGE_TOOLS_PATH: ${{ runner.temp }}/.cache/appimage-tools
         run: |
           set -euo pipefail
           for attempt in 1 2; do
             echo "Desktop build attempt ${attempt}/2"
-            if npm run package:desktop; then
+            if npm run package:desktop -- --config.npmRebuild=false; then
               break
             fi
             if [ "$attempt" -eq 2 ]; then
@@ -199,7 +184,7 @@ jobs:
           if [ -n "${APPLE_TEAM_ID_INPUT:-}" ]; then export APPLE_TEAM_ID="$APPLE_TEAM_ID_INPUT"; fi
           for attempt in 1 2; do
             echo "Desktop build attempt ${attempt}/2"
-            if npm run package:desktop; then
+            if npm run package:desktop -- --config.npmRebuild=false; then
               break
             fi
             if [ "$attempt" -eq 2 ]; then


### PR DESCRIPTION
### Motivation
- Prevent intermittent build failures and reduce CI time by disabling automatic `npm rebuild` during Electron packaging. 
- Remove an unnecessary/fragile prefetch step for AppImage tools that duplicated binary caching logic.

### Description
- Added `-- --config.npmRebuild=false` to the `npm run package:desktop` invocation on Windows, Linux, and macOS so the electron-builder packaging step skips `npm rebuild`.
- Removed the `Prefetch AppImage tools` job step and the `APPIMAGE_TOOLS_PATH` environment variable, eliminating a hardcoded AppImage tools download and cache entry.
- Kept retry logic for packaging attempts and existing cache variables for Electron and electron-builder.

### Testing
- Executed the GitHub Actions `release` workflow to run the `Build desktop artifacts` jobs for Windows, Linux, and macOS with the updated packaging command, and the packaging steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aad05ee784832c90e9a69bed2f061a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized the desktop package build workflow by simplifying build configuration and removing unnecessary preprocessing steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->