### PR TITLE
chore: tighten dependabot major update policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,12 +7,40 @@ updates:
       day: monday
       time: "03:00"
       timezone: Asia/Shanghai
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 6
+    ignore:
+      - dependency-name: "vite"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "@vitejs/plugin-react"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "vitest"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "react-router-dom"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "undici"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "cross-env"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "drizzle-orm"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "drizzle-kit"
+        update-types:
+          - "version-update:semver-major"
     groups:
       drizzle-risk:
         patterns:
           - "drizzle-orm"
           - "drizzle-kit"
+        update-types:
+          - minor
+          - patch
       build-tooling:
         patterns:
           - "vite"
@@ -20,15 +48,27 @@ updates:
           - "vitest"
           - "tsx"
           - "typescript"
+        update-types:
+          - minor
+          - patch
       routing:
         patterns:
           - "react-router-dom"
+        update-types:
+          - minor
+          - patch
       runtime-http:
         patterns:
           - "undici"
+        update-types:
+          - minor
+          - patch
       node-runtime-sensitive:
         patterns:
           - "cross-env"
+        update-types:
+          - minor
+          - patch
       minor-and-patch:
         patterns:
           - "*"
@@ -50,6 +90,9 @@ updates:
         dependency-type: development
         patterns:
           - "*"
+        update-types:
+          - minor
+          - patch
         exclude-patterns:
           - "drizzle-kit"
           - "vite"


### PR DESCRIPTION
## Summary
- ignore semver-major updates for high-risk dependencies in Dependabot
- keep risk-based groups but limit them to minor/patch updates
- lower npm open PR limit to reduce noisy review queues

## Validation
- parsed .github/dependabot.yml with Python YAML
- verified all required high-risk packages have semver-major ignore rules
- verified risk groups and fallback groups are restricted to minor/patch where intended

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to adjust update frequency and version constraints for various dependencies, improving control over automated dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->