### PR TITLE
fix: use allowlist for Gemini native request fields to prevent 400 on unknown fields

### DIFF
--- a/src/server/transformers/gemini/generate-content/inbound.ts
+++ b/src/server/transformers/gemini/generate-content/inbound.ts
@@ -194,14 +194,22 @@ export const geminiGenerateContentInbound = {
       next.generationConfig = generationConfig;
     }
 
-    const strippedKeys = new Set([
-      'reasoning',
-      'reasoning_effort',
-      'reasoning_budget',
+    // Only forward fields that Gemini API supports. Unknown fields
+    // (e.g. requestId, frequency_penalty) cause upstream 400 errors.
+    const allowedPassthroughKeys = new Set([
+      'contents',
+      'systemInstruction',
+      'cachedContent',
+      'safetySettings',
+      'generationConfig',
+      'tools',
+      'toolConfig',
+      'labels',
+      'model',
     ]);
 
     for (const [key, value] of Object.entries(body)) {
-      if (strippedKeys.has(key)) continue;
+      if (!allowedPassthroughKeys.has(key)) continue;
       if (next[key] !== undefined) continue;
       next[key] = cloneJsonValue(value);
     }


### PR DESCRIPTION
## Problem

Fixes #130

Gemini native 路径的 `inbound.ts` 用黑名单过滤请求字段，只屏蔽了 3 个字段（`reasoning`、`reasoning_effort`、`reasoning_budget`）。客户端自带的字段（如 `requestId`、`frequency_penalty`）被原样透传到 Gemini API，导致 400。

## Fix

改为白名单，只转发 Gemini API 支持的字段：`contents`、`systemInstruction`、`cachedContent`、`safetySettings`、`generationConfig`、`tools`、`toolConfig`、`labels`、`model`。

改动 1 个文件，13 行增 5 行删。59 个相关测试全过。

## 本地试用

合并前可以本地拉下来测：
\`\`\`bash
git remote add weijiafu14 https://github.com/weijiafu14/metapi.git
git fetch weijiafu14 fix/gemini-strip-unknown-request-fields
git cherry-pick weijiafu14/fix/gemini-strip-unknown-request-fields
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Gemini API integration errors by implementing proper request parameter validation. The system now filters and forwards only supported parameters to the Gemini API, preventing invalid fields from being transmitted. This improves reliability when using Gemini-powered features and eliminates upstream communication errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->