### PR TITLE
[codex] Handle mislabeled responses SSE bodies

### DIFF
--- a/src/server/proxy-core/surfaces/chatSurface.ts
+++ b/src/server/proxy-core/surfaces/chatSurface.ts
@@ -39,7 +39,12 @@ import {
 import { getOauthInfoFromExtraConfig } from '../../services/oauth/oauthAccount.js';
 import { recordOauthQuotaResetHint } from '../../services/oauth/quota.js';
 import { refreshOauthAccessTokenSingleflight } from '../../services/oauth/refreshSingleflight.js';
-import { collectResponsesFinalPayloadFromSse } from '../../routes/proxy/responsesSseFinal.js';
+import {
+  collectResponsesFinalPayloadFromSse,
+  collectResponsesFinalPayloadFromSseText,
+  createSingleChunkStreamReader,
+  looksLikeResponsesSseText,
+} from '../../routes/proxy/responsesSseFinal.js';
 import {
   createGeminiCliStreamReader,
   unwrapGeminiCliPayload,
@@ -394,6 +399,37 @@ export async function handleChatSurfaceRequest(
         if (!upstreamContentType.includes('text/event-stream')) {
           const fallbackText = await upstream.text();
           rawText = fallbackText;
+          if (looksLikeResponsesSseText(fallbackText)) {
+            startSseResponse();
+            const streamResult = await streamSession.run(
+              createSingleChunkStreamReader(fallbackText),
+              reply.raw,
+            );
+            const latency = Date.now() - startTime;
+            if (streamResult.status === 'failed') {
+              tokenRouter.recordFailure(selected.channel.id);
+              logProxy(
+                selected,
+                requestedModel,
+                'failed',
+                200,
+                latency,
+                streamResult.errorMessage,
+                retryCount,
+                downstreamPath,
+                parsedUsage.promptTokens,
+                parsedUsage.completionTokens,
+                parsedUsage.totalTokens,
+                0,
+                null,
+                successfulUpstreamPath,
+                clientContext,
+                logDownstreamApiKeyId ? downstreamApiKeyId : null,
+              );
+              return;
+            }
+            return;
+          }
           let fallbackData: unknown = null;
           try {
             fallbackData = JSON.parse(fallbackText);
@@ -580,11 +616,15 @@ export async function handleChatSurfaceRequest(
         upstreamData = collected.payload;
       } else {
         rawText = await upstream.text();
-        upstreamData = rawText;
-        try {
-          upstreamData = JSON.parse(rawText);
-        } catch {
+        if (looksLikeResponsesSseText(rawText)) {
+          upstreamData = collectResponsesFinalPayloadFromSseText(rawText, modelName).payload;
+        } else {
           upstreamData = rawText;
+          try {
+            upstreamData = JSON.parse(rawText);
+          } catch {
+            upstreamData = rawText;
+          }
         }
       }
       if (String(selected.site.platform || '').trim().toLowerCase() === 'gemini-cli') {

--- a/src/server/proxy-core/surfaces/openAiResponsesSurface.ts
+++ b/src/server/proxy-core/surfaces/openAiResponsesSurface.ts
@@ -34,7 +34,12 @@ import {
 import { getOauthInfoFromExtraConfig } from '../../services/oauth/oauthAccount.js';
 import { recordOauthQuotaResetHint } from '../../services/oauth/quota.js';
 import { refreshOauthAccessTokenSingleflight } from '../../services/oauth/refreshSingleflight.js';
-import { collectResponsesFinalPayloadFromSse } from '../../routes/proxy/responsesSseFinal.js';
+import {
+  collectResponsesFinalPayloadFromSse,
+  collectResponsesFinalPayloadFromSseText,
+  createSingleChunkStreamReader,
+  looksLikeResponsesSseText,
+} from '../../routes/proxy/responsesSseFinal.js';
 import {
   createGeminiCliStreamReader,
   unwrapGeminiCliPayload,
@@ -541,6 +546,39 @@ export async function handleOpenAiResponsesSurfaceRequest(
           });
           if (!upstreamContentType.includes('text/event-stream')) {
             const rawText = await upstream.text();
+            if (looksLikeResponsesSseText(rawText)) {
+              startSseResponse();
+              const streamResult = await streamSession.run(
+                createSingleChunkStreamReader(rawText),
+                reply.raw,
+              );
+              const latency = Date.now() - startTime;
+              if (streamResult.status === 'failed') {
+                tokenRouter.recordFailure(selected.channel.id);
+                logProxy(
+                  selected,
+                  requestedModel,
+                  'failed',
+                  200,
+                  latency,
+                  streamResult.errorMessage,
+                  retryCount,
+                  downstreamPath,
+                  parsedUsage.promptTokens,
+                  parsedUsage.completionTokens,
+                  parsedUsage.totalTokens,
+                  0,
+                  null,
+                  successfulUpstreamPath,
+                  clientContext,
+                  logDownstreamApiKeyId ? downstreamApiKeyId : null,
+                );
+                return;
+              }
+
+              await finalizeStreamSuccess(parsedUsage, latency);
+              return;
+            }
             let upstreamData: unknown = rawText;
             try {
               upstreamData = JSON.parse(rawText);
@@ -692,11 +730,15 @@ export async function handleOpenAiResponsesSurfaceRequest(
           upstreamData = collected.payload;
         } else {
           rawText = await upstream.text();
-          upstreamData = rawText;
-          try {
-            upstreamData = JSON.parse(rawText);
-          } catch {
+          if (looksLikeResponsesSseText(rawText)) {
+            upstreamData = collectResponsesFinalPayloadFromSseText(rawText, modelName).payload;
+          } else {
             upstreamData = rawText;
+            try {
+              upstreamData = JSON.parse(rawText);
+            } catch {
+              upstreamData = rawText;
+            }
           }
         }
         if (String(selected.site.platform || '').trim().toLowerCase() === 'gemini-cli') {

--- a/src/server/routes/proxy/chat.codex-oauth.test.ts
+++ b/src/server/routes/proxy/chat.codex-oauth.test.ts
@@ -245,4 +245,38 @@ describe('chat proxy codex oauth compatibility', () => {
     expect(response.body).not.toContain('event: response.created');
     expect(response.body).not.toContain('"type":"response.output_text.delta"');
   });
+
+  it('still translates raw codex SSE into OpenAI chat completion chunks when upstream mislabels the content-type', async () => {
+    fetchMock.mockResolvedValue(new Response([
+      'event: response.created\n',
+      'data: {"type":"response.created","response":{"id":"resp_codex_openai_stream_header_miss","model":"gpt-5.4","created_at":1706000000,"status":"in_progress","output":[]}}\n\n',
+      'event: response.output_item.added\n',
+      'data: {"type":"response.output_item.added","output_index":0,"item":{"id":"msg_codex_openai_stream_header_miss","type":"message","role":"assistant","status":"in_progress","content":[]}}\n\n',
+      'event: response.output_text.delta\n',
+      'data: {"type":"response.output_text.delta","output_index":0,"item_id":"msg_codex_openai_stream_header_miss","delta":"pong from codex"}\n\n',
+      'event: response.completed\n',
+      'data: {"type":"response.completed","response":{"id":"resp_codex_openai_stream_header_miss","model":"gpt-5.4","status":"completed","usage":{"input_tokens":9,"output_tokens":3,"total_tokens":12}}}\n\n',
+      'data: [DONE]\n\n',
+    ].join(''), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }));
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/v1/chat/completions',
+      payload: {
+        model: 'gpt-5.4',
+        stream: true,
+        messages: [{ role: 'user', content: 'hello codex' }],
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['content-type']).toContain('text/event-stream');
+    expect(response.body).toContain('"object":"chat.completion.chunk"');
+    expect(response.body).toContain('pong from codex');
+    expect(response.body).not.toContain('event: response.created');
+    expect(response.body).not.toContain('"type":"response.output_text.delta"');
+  });
 });

--- a/src/server/routes/proxy/responses.codex-oauth.test.ts
+++ b/src/server/routes/proxy/responses.codex-oauth.test.ts
@@ -615,4 +615,39 @@ describe('responses proxy codex oauth refresh', () => {
     expect(recordFailureMock).not.toHaveBeenCalled();
     expect(recordSuccessMock).toHaveBeenCalledTimes(1);
   });
+
+  it('replays raw codex SSE when upstream mislabels a streaming responses body as application/json', async () => {
+    fetchMock.mockResolvedValue(new Response([
+      'event: response.created\n',
+      'data: {"type":"response.created","response":{"id":"resp_codex_stream_header_miss","model":"gpt-5.4","created_at":1706000000,"status":"in_progress","output":[]}}\n\n',
+      'event: response.output_item.added\n',
+      'data: {"type":"response.output_item.added","output_index":0,"item":{"id":"msg_codex_stream_header_miss","type":"message","role":"assistant","status":"in_progress","content":[]}}\n\n',
+      'event: response.output_text.delta\n',
+      'data: {"type":"response.output_text.delta","output_index":0,"item_id":"msg_codex_stream_header_miss","delta":"pong"}\n\n',
+      'event: response.completed\n',
+      'data: {"type":"response.completed","response":{"id":"resp_codex_stream_header_miss","model":"gpt-5.4","status":"completed","usage":{"input_tokens":3,"output_tokens":1,"total_tokens":4}}}\n\n',
+      'data: [DONE]\n\n',
+    ].join(''), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }));
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/v1/responses',
+      payload: {
+        model: 'gpt-5.4',
+        input: 'hello codex',
+        stream: true,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toContain('event: response.output_text.delta');
+    expect(response.body).toContain('"delta":"pong"');
+    expect(response.body).not.toContain('"output_text":"event: response.created');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(recordFailureMock).not.toHaveBeenCalled();
+    expect(recordSuccessMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/server/routes/proxy/responsesSseFinal.ts
+++ b/src/server/routes/proxy/responsesSseFinal.ts
@@ -120,11 +120,43 @@ function materializeCompletedPayloadFromAggregate(
   return null;
 }
 
-export async function collectResponsesFinalPayloadFromSse(
-  upstream: { text(): Promise<string> },
+export function looksLikeResponsesSseText(rawText: string): boolean {
+  const { events, rest } = openAiResponsesTransformer.pullSseEvents(rawText);
+  if (events.length === 0 || rest.trim().length > 0) return false;
+  return events.some((event) => {
+    if (event.data === '[DONE]') return true;
+    if (event.event === 'error' || event.event.startsWith('response.')) return true;
+    const payload = parseResponsesSsePayload(event.data);
+    const payloadType = typeof payload?.type === 'string' ? payload.type : '';
+    return payloadType === 'error' || payloadType.startsWith('response.');
+  });
+}
+
+export function createSingleChunkStreamReader(rawText: string): {
+  read(): Promise<{ done: boolean; value?: Uint8Array }>;
+  cancel(reason?: unknown): Promise<unknown>;
+  releaseLock(): void;
+} {
+  const chunk = Buffer.from(rawText, 'utf8');
+  let done = false;
+  return {
+    async read() {
+      if (done) return { done: true };
+      done = true;
+      return { done: false, value: chunk };
+    },
+    async cancel() {
+      done = true;
+      return undefined;
+    },
+    releaseLock() {},
+  };
+}
+
+export function collectResponsesFinalPayloadFromSseText(
+  rawText: string,
   modelName: string,
-): Promise<{ payload: Record<string, unknown>; rawText: string }> {
-  const rawText = await upstream.text();
+): { payload: Record<string, unknown>; rawText: string } {
   const { events } = openAiResponsesTransformer.pullSseEvents(rawText);
   const streamContext = openAiResponsesTransformer.createStreamContext(modelName);
   const aggregateState = openAiResponsesTransformer.aggregator.createState(modelName);
@@ -222,4 +254,11 @@ export async function collectResponsesFinalPayloadFromSse(
   }
 
   throw new Error('stream disconnected before response.completed');
+}
+
+export async function collectResponsesFinalPayloadFromSse(
+  upstream: { text(): Promise<string> },
+  modelName: string,
+): Promise<{ payload: Record<string, unknown>; rawText: string }> {
+  return collectResponsesFinalPayloadFromSseText(await upstream.text(), modelName);
 }


### PR DESCRIPTION
## Summary

This fixes a false-success streaming compatibility bug in the responses proxy path. Some upstreams returned a real OpenAI Responses SSE transcript but mislabeled the HTTP response as `application/json`. metapi trusted the header, treated the raw SSE transcript as a final text payload, and then wrapped that transcript into a synthetic completion event. Downstream clients received `[DONE]` with no usable streamed text, or saw the entire `event: response.created ... response.completed` transcript stuffed into `output_text`.

The user-visible effect was especially bad for Codex and ModelTester style streaming flows. The UI would report that streaming finished with empty content even though the upstream had actually sent a valid SSE sequence.

## Root Cause

Both `chatSurface.ts` and `openAiResponsesSurface.ts` had a stream fallback branch that only looked at `content-type`. When the header did not contain `text/event-stream`, those paths read the entire body as plain text and tried to parse it as JSON. If that parse failed, the raw SSE transcript string was forwarded as a normal final payload. That is why `response.output_text.delta` content got nested inside a later `response.completed.output_text` instead of being replayed as stream events.

## Fix

The proxy now detects when a body looks like a Responses SSE transcript even if the response header is wrong.

- Added shared helpers in `responsesSseFinal.ts` to:
  - detect likely Responses SSE text
  - replay a raw SSE transcript through a single-chunk reader
  - aggregate a final Responses payload directly from raw SSE text
- Updated `chatSurface.ts` so mislabeled Responses SSE bodies are replayed through the existing stream transformer instead of being treated as final text.
- Updated `openAiResponsesSurface.ts` with the same recovery path for streaming requests and the same SSE-aware aggregation path for non-stream finalization.
- Added regression coverage for both `/v1/chat/completions` and `/v1/responses` Codex-compatible streaming flows when upstream returns raw SSE with `application/json`.

## Validation

I verified the change with fresh local checks on this branch:

- `node node_modules/vitest/vitest.mjs run --root D:\Desktop\temp\metapi D:\Desktop\temp\metapi\src\server\routes\proxy\chat.codex-oauth.test.ts D:\Desktop\temp\metapi\src\server\routes\proxy\responses.codex-oauth.test.ts`
- `node node_modules/vitest/vitest.mjs run --root D:\Desktop\temp\metapi D:\Desktop\temp\metapi\src\server\routes\proxy\responsesSseFinal.test.ts D:\Desktop\temp\metapi\src\server\routes\proxy\chat.codex-oauth.test.ts D:\Desktop\temp\metapi\src\server\routes\proxy\responses.codex-oauth.test.ts`
- `node node_modules/typescript/bin/tsc -p D:\Desktop\temp\metapi\tsconfig.server.json`
