### PR TITLE
[codex] fix downstream key whitelist select-all persistence

### DIFF
--- a/src/server/services/downstreamApiKeyService.test.ts
+++ b/src/server/services/downstreamApiKeyService.test.ts
@@ -116,6 +116,12 @@ describe('downstreamApiKeyService', () => {
     expect(service.isModelAllowedByPolicy('gemini-2.0-flash', result.policy)).toBe(false);
   });
 
+  it('keeps all explicitly selected supported models when list exceeds 200 items', () => {
+    const selectedModels = Array.from({ length: 260 }, (_, index) => `model-${String(index + 1).padStart(3, '0')}`);
+
+    expect(service.normalizeSupportedModelsInput(selectedModels)).toEqual(selectedModels);
+  });
+
   it('treats selected groups as additional allowed exposed route scope (union semantics)', async () => {
     const claudeGroup = await db.insert(schema.tokenRoutes).values({
       modelPattern: 're:^claude-(opus|sonnet)-4-6$',

--- a/src/server/services/downstreamApiKeyService.ts
+++ b/src/server/services/downstreamApiKeyService.ts
@@ -131,16 +131,14 @@ export function normalizeSupportedModelsInput(input: unknown): string[] {
   if (Array.isArray(input)) {
     return input
       .map((item) => (typeof item === 'string' ? item.trim() : ''))
-      .filter((item, index, arr) => item.length > 0 && arr.indexOf(item) === index)
-      .slice(0, 200);
+      .filter((item, index, arr) => item.length > 0 && arr.indexOf(item) === index);
   }
 
   if (typeof input === 'string') {
     return input
       .split(/\r?\n|,/g)
       .map((item) => item.trim())
-      .filter((item, index, arr) => item.length > 0 && arr.indexOf(item) === index)
-      .slice(0, 200);
+      .filter((item, index, arr) => item.length > 0 && arr.indexOf(item) === index);
   }
 
   return [];


### PR DESCRIPTION
## 背景

下游密钥编辑弹窗中的模型白名单支持“全选”。当精确模型数量超过 200 个时，界面保存后再次进入会只剩 200 个已选模型，表现为“全选”状态无法持久化。

## 影响

这会让管理端误以为白名单已完整放开，但实际保存结果只保留了前 200 个模型。超过该数量的精确模型会在重新进入编辑界面后消失，并且对应下游密钥的显式模型白名单范围被意外收窄。

## 根因

服务层 `normalizeSupportedModelsInput(...)` 在处理数组和字符串输入时都会去重后执行 `.slice(0, 200)`。前端“全选”会把全部精确模型提交为 `supportedModels`，保存与回显都会经过这段归一化逻辑，因此最终稳定截断到 200 项。

## 修改内容

移除了 `normalizeSupportedModelsInput(...)` 中针对 `supportedModels` 的 200 项裁剪，保留完整的显式模型白名单。
新增回归测试，覆盖“显式选择超过 200 个模型时仍需完整保留”的场景，防止后续再次引入同类截断。

## 验证

`node node_modules/vitest/vitest.mjs run --exclude .worktrees/** src/server/services/downstreamApiKeyService.test.ts`
`npm run build:server`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the 200-item limit that was previously truncating supported models lists. Users can now configure and utilize supported models lists of any size without experiencing data loss due to automatic truncation.

* **Tests**
  * Added test coverage to verify the system correctly handles and processes supported models lists with more than 200 items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->