### PR TITLE
[codex] fix site announcement timezone

### DIFF
--- a/src/server/routes/api/settings.events.test.ts
+++ b/src/server/routes/api/settings.events.test.ts
@@ -122,8 +122,10 @@ describe('settings and auth events', () => {
     });
 
     expect(response.statusCode).toBe(200);
-    const body = response.json() as { currentAdminIp?: string };
+    const body = response.json() as { currentAdminIp?: string; serverTimeZone?: string };
     expect(body.currentAdminIp).toBe('203.0.113.5');
+    expect(typeof body.serverTimeZone).toBe('string');
+    expect((body.serverTimeZone || '').length).toBeGreaterThan(0);
   });
 
   it('rejects proxy token that does not start with sk-', async () => {

--- a/src/server/routes/api/settings.ts
+++ b/src/server/routes/api/settings.ts
@@ -15,7 +15,7 @@ import {
   testDatabaseConnection,
   type MigrationDialect,
 } from '../../services/databaseMigrationService.js';
-import { formatUtcSqlDateTime } from '../../services/localTimeService.js';
+import { formatUtcSqlDateTime, getResolvedTimeZone } from '../../services/localTimeService.js';
 import { extractClientIp, isIpAllowed } from '../../middleware/auth.js';
 import { invalidateSiteProxyCache, normalizeSiteProxyUrl } from '../../services/siteProxy.js';
 import { performFactoryReset } from '../../services/factoryResetService.js';
@@ -442,6 +442,7 @@ function getRuntimeSettingsResponse(currentAdminIp = '') {
     notifyCooldownSec: config.notifyCooldownSec,
     adminIpAllowlist: config.adminIpAllowlist,
     currentAdminIp,
+    serverTimeZone: getResolvedTimeZone(),
     systemProxyUrl: config.systemProxyUrl,
     proxyErrorKeywords: config.proxyErrorKeywords,
     proxyEmptyContentFailEnabled: config.proxyEmptyContentFailEnabled,

--- a/src/web/pages/SiteAnnouncements.tsx
+++ b/src/web/pages/SiteAnnouncements.tsx
@@ -39,10 +39,12 @@ export default function SiteAnnouncements() {
   const [refreshing, setRefreshing] = useState(false);
   const [clearing, setClearing] = useState(false);
   const [markingAll, setMarkingAll] = useState(false);
+  const [serverTimeZone, setServerTimeZone] = useState<string | undefined>(undefined);
   const [highlightAnnouncementId, setHighlightAnnouncementId] = useState<number | null>(null);
   const rowRefs = useRef<Map<number, HTMLDivElement>>(new Map());
   const highlightTimerRef = useRef<number | null>(null);
   const viewerTimeZone = useMemo(() => readClientTimeZone(), []);
+  const displayTimeZone = serverTimeZone || viewerTimeZone;
 
   const siteNameById = useMemo(() => {
     const map = new Map<number, string>();
@@ -56,12 +58,17 @@ export default function SiteAnnouncements() {
     if (silent) setRefreshing(true);
     else setLoading(true);
     try {
-      const [announcementRows, siteRows] = await Promise.all([
+      const [announcementRows, siteRows, runtimeInfo] = await Promise.all([
         api.getSiteAnnouncements(),
         api.getSites(),
+        api.getRuntimeSettings().catch(() => null),
       ]);
       setRows(Array.isArray(announcementRows) ? announcementRows : []);
       setSites(Array.isArray(siteRows) ? siteRows : []);
+      const nextServerTimeZone = typeof runtimeInfo?.serverTimeZone === 'string'
+        ? runtimeInfo.serverTimeZone.trim()
+        : '';
+      setServerTimeZone(nextServerTimeZone || undefined);
     } catch (error: any) {
       toast.error(error?.message || '加载站点公告失败');
     } finally {
@@ -219,9 +226,9 @@ export default function SiteAnnouncements() {
               <SiteAnnouncementContent content={row.content} />
               <div
                 style={{ marginTop: 8, fontSize: 12, color: 'var(--color-text-muted)' }}
-                title={viewerTimeZone ? `本地时区：${viewerTimeZone}` : undefined}
+                title={displayTimeZone ? `本地时区：${displayTimeZone}` : undefined}
               >
-                首次发现：{formatSiteAnnouncementSeenAt(row.firstSeenAt || row.lastSeenAt || '', viewerTimeZone)}
+                首次发现：{formatSiteAnnouncementSeenAt(row.firstSeenAt || row.lastSeenAt || '', displayTimeZone)}
               </div>
             </div>
           ))

--- a/src/web/pages/siteAnnouncements.test.tsx
+++ b/src/web/pages/siteAnnouncements.test.tsx
@@ -9,6 +9,7 @@ const { apiMock } = vi.hoisted(() => ({
   apiMock: {
     getSiteAnnouncements: vi.fn(),
     getSites: vi.fn(),
+    getRuntimeSettings: vi.fn(),
     markSiteAnnouncementRead: vi.fn(),
     markAllSiteAnnouncementsRead: vi.fn(),
     clearSiteAnnouncements: vi.fn(),
@@ -41,6 +42,9 @@ describe('SiteAnnouncements page', () => {
     apiMock.getSites.mockResolvedValue([
       { id: 9, name: 'Sub Site', platform: 'sub2api' },
     ]);
+    apiMock.getRuntimeSettings.mockResolvedValue({
+      serverTimeZone: 'UTC',
+    });
     apiMock.getSiteAnnouncements.mockResolvedValue([
       {
         id: 12,
@@ -50,8 +54,8 @@ describe('SiteAnnouncements page', () => {
         title: 'Maintenance',
         content: 'Window starts at 10:00',
         level: 'info',
-        firstSeenAt: '2026-03-20 10:00:00',
-        lastSeenAt: '2026-03-20 10:00:00',
+        firstSeenAt: '2026-03-20 04:23:27',
+        lastSeenAt: '2026-03-20 04:23:27',
         readAt: null,
       },
     ]);
@@ -100,8 +104,10 @@ describe('SiteAnnouncements page', () => {
 
       expect(apiMock.getSiteAnnouncements).toHaveBeenCalled();
       expect(apiMock.getSites).toHaveBeenCalled();
+      expect(apiMock.getRuntimeSettings).toHaveBeenCalled();
       expect(JSON.stringify(root!.toJSON())).toContain('站点公告');
       expect(JSON.stringify(root!.toJSON())).toContain('Maintenance');
+      expect(JSON.stringify(root!.toJSON())).toContain('2026/03/20 04:23:27');
 
       const highlightedRows = root!.root.findAll((node) => {
         const className = typeof node.props.className === 'string' ? node.props.className : '';


### PR DESCRIPTION
## Summary
Fixes the site announcement timestamp display introduced after the site announcement page shipped.

站点公告页在正文展示层已经支持 HTML 和 Markdown，但“首次发现”时间仍然依赖浏览器自己报告的时区。运行环境如果把渲染层时区识别成 `UTC`，页面就会把数据库里的 UTC 时间原样显示出来，表现为 `04:23:27` 这一类值没有转换到站点实际使用的本地时区。

这次修改把运行时设置接口补充为返回服务端解析到的时区，并让站点公告页在显示“首次发现”时优先使用这个服务端时区；只有服务端时区缺失时才回退到浏览器时区。这样公告时间会与服务端的本地时间配置保持一致，避免浏览器环境误报时区时继续显示成 UTC。

## Cause And Effect
原来的时间格式化函数本身支持指定时区，但公告页传入的是浏览器时区。运行在某些桌面或部署环境时，浏览器侧时区可能保持为 `UTC`，最终让公告页继续显示原始 UTC 时间，造成“已经改了代码但画面还是没变”的现象。

## Root Cause
站点公告页缺少稳定的时区来源，只从前端运行时读取 `Intl.DateTimeFormat().resolvedOptions().timeZone`。而服务端已经拥有更稳定的本地时区解析能力，却没有通过运行时设置接口暴露给页面使用。

## Validation
已重新执行以下校验：

- `node node_modules/vitest/vitest.mjs run src/web/pages/siteAnnouncements.test.tsx src/web/pages/helpers/siteAnnouncementPresentation.test.tsx src/web/pages/helpers/checkinLogTime.test.ts src/server/routes/api/settings.events.test.ts`
- `node node_modules/typescript/bin/tsc -p tsconfig.server.json --noEmit`
- `node scripts/desktop/generate-icons.mjs`
- `node node_modules/vite/bin/vite.js build`

Vitest 共 `4` 个测试文件、`33` 个测试通过；服务端 TypeScript 检查通过；前端直接入口构建通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Server timezone information is now available through the API settings endpoint.
  * Site announcements now display timestamps using the server's configured timezone instead of the viewer's local timezone.

* **Tests**
  * Updated test fixtures and assertions to verify server timezone functionality across the settings API and announcements page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->