### PR TITLE
[codex] fix checkin settings styling and empty updates

### DIFF
--- a/src/server/services/checkinService.autoRelogin.test.ts
+++ b/src/server/services/checkinService.autoRelogin.test.ts
@@ -340,6 +340,40 @@ describe('checkinService auto relogin', () => {
     expect(notifyMock).not.toHaveBeenCalled();
   });
 
+  it('skips account updates when unsupported checkin responses do not change account state', async () => {
+    selectAllMock.mockReturnValue([
+      {
+        accounts: {
+          id: 18,
+          username: 'plain-user',
+          accessToken: 'token',
+          status: 'active',
+          extraConfig: null,
+        },
+        sites: {
+          id: 18,
+          name: 'done-hub',
+          url: 'https://done.example.com',
+          platform: 'donehub',
+        },
+      },
+    ]);
+
+    adapterMock.checkin.mockResolvedValue({
+      success: false,
+      message: 'checkin endpoint not found',
+    });
+
+    const { checkinAccount } = await import('./checkinService.js');
+    const result = await checkinAccount(18);
+
+    expect(result.success).toBe(true);
+    expect(result.status).toBe('skipped');
+    expect(updateSetMock).not.toHaveBeenCalled();
+    const firstInsertPayload = insertValuesMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(firstInsertPayload?.status).toBe('skipped');
+  });
+
   it('treats sub2api checkin unsupported message as skipped', async () => {
     selectAllMock.mockReturnValue([
       {

--- a/src/server/services/checkinService.ts
+++ b/src/server/services/checkinService.ts
@@ -226,10 +226,12 @@ export async function checkinAccount(accountId: number, options?: { skipEvent?: 
       updates.updatedAt = new Date().toISOString();
     }
 
-    await db.update(schema.accounts)
-      .set(updates)
-      .where(eq(schema.accounts.id, accountId))
-      .run();
+    if (Object.keys(updates).length > 0) {
+      await db.update(schema.accounts)
+        .set(updates)
+        .where(eq(schema.accounts.id, accountId))
+        .run();
+    }
 
     if (shouldRefreshBalance) {
       try {

--- a/src/web/pages/Settings.tsx
+++ b/src/web/pages/Settings.tsx
@@ -22,6 +22,17 @@ const PROXY_TOKEN_PREFIX = 'sk-';
 const ROUTE_BRAND_ICON_PREFIX = 'brand:';
 const FACTORY_RESET_ADMIN_TOKEN = 'change-me-admin-token';
 const FACTORY_RESET_CONFIRM_SECONDS = 3;
+const CHECKIN_SCHEDULE_MODE_OPTIONS = [
+  { value: 'cron', label: 'Cron' },
+  { value: 'interval', label: '间隔签到' },
+] as const;
+const CHECKIN_INTERVAL_OPTIONS = Array.from({ length: 24 }, (_, index) => {
+  const hour = index + 1;
+  return {
+    value: String(hour),
+    label: `${hour} 小时`,
+  };
+});
 type DbDialect = 'sqlite' | 'mysql' | 'postgres';
 
 type RuntimeSettings = {
@@ -979,36 +990,33 @@ export default function Settings() {
           <div style={{ display: 'grid', gridTemplateColumns: '180px 180px auto', gap: 12, alignItems: 'end', marginBottom: 12 }}>
             <div>
               <div style={{ fontSize: 12, color: 'var(--color-text-muted)', marginBottom: 6 }}>签到方式</div>
-              <select
+              <ModernSelect
                 value={runtime.checkinScheduleMode}
-                onChange={(e) => setRuntime((prev) => ({
+                onChange={(value) => setRuntime((prev) => ({
                   ...prev,
-                  checkinScheduleMode: e.target.value === 'interval' ? 'interval' : 'cron',
+                  checkinScheduleMode: value === 'interval' ? 'interval' : 'cron',
                 }))}
-                style={inputStyle}
-              >
-                <option value="cron">Cron</option>
-                <option value="interval">间隔签到</option>
-              </select>
+                options={CHECKIN_SCHEDULE_MODE_OPTIONS.map((item) => ({ ...item }))}
+              />
             </div>
             <div>
               <div style={{ fontSize: 12, color: 'var(--color-text-muted)', marginBottom: 6 }}>签到间隔</div>
-              <select
+              <ModernSelect
                 value={String(runtime.checkinIntervalHours)}
-                onChange={(e) => setRuntime((prev) => ({
+                onChange={(value) => setRuntime((prev) => ({
                   ...prev,
-                  checkinIntervalHours: Math.min(24, Math.max(1, Math.trunc(Number(e.target.value) || 1))),
+                  checkinIntervalHours: Math.min(24, Math.max(1, Math.trunc(Number(value) || 1))),
                 }))}
-                style={inputStyle}
                 disabled={runtime.checkinScheduleMode !== 'interval'}
-              >
-                {Array.from({ length: 24 }, (_, index) => {
-                  const hour = index + 1;
-                  return <option key={hour} value={hour}>{hour} 小时</option>;
-                })}
-              </select>
+                options={CHECKIN_INTERVAL_OPTIONS}
+              />
             </div>
-            <button onClick={triggerScheduleCheckin} disabled={testingCheckin} className="btn btn-secondary">
+            <button
+              onClick={triggerScheduleCheckin}
+              disabled={testingCheckin}
+              className="btn btn-ghost"
+              style={{ border: '1px solid var(--color-border)', whiteSpace: 'nowrap' }}
+            >
               {testingCheckin ? '触发中...' : '测试一次签到'}
             </button>
           </div>

--- a/src/web/pages/settings.schedule-log-cleanup.test.tsx
+++ b/src/web/pages/settings.schedule-log-cleanup.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, create, type ReactTestInstance } from 'react-test-renderer';
 import { MemoryRouter } from 'react-router-dom';
 import { ToastProvider } from '../components/Toast.js';
+import ModernSelect from '../components/ModernSelect.js';
 import Settings from './Settings.js';
 
 const { apiMock } = vi.hoisted(() => ({
@@ -141,6 +142,34 @@ describe('Settings log cleanup schedule', () => {
       await flushMicrotasks();
 
       expect(apiMock.triggerCheckinAll).toHaveBeenCalledTimes(1);
+    } finally {
+      root?.unmount();
+    }
+  });
+
+  it('renders schedule mode controls with modern selects and ghost action styling', async () => {
+    let root: ReturnType<typeof create> | null = null;
+    try {
+      await act(async () => {
+        root = create(
+          <MemoryRouter>
+            <ToastProvider>
+              <Settings />
+            </ToastProvider>
+          </MemoryRouter>,
+        );
+      });
+      await flushMicrotasks();
+
+      const triggerButton = root.root.find((node) => (
+        node.type === 'button'
+        && typeof node.props.onClick === 'function'
+        && collectText(node).trim() === '测试一次签到'
+      ));
+
+      expect(root.root.findAllByType('select')).toHaveLength(0);
+      expect(root.root.findAllByType(ModernSelect).length).toBeGreaterThanOrEqual(3);
+      expect(String(triggerButton.props.className || '')).toContain('btn-ghost');
     } finally {
       root?.unmount();
     }


### PR DESCRIPTION
## 背景
签到设置页当前包含“签到方式”“签到间隔”和“测试一次签到”三个操作入口，但界面仍在混用原生 select 与次级按钮样式，和页面已经采用的现代化表单体系不一致。与此同时，点击“测试一次签到”时，部分站点会返回“checkin endpoint not found”这类跳过型结果，后台随后抛出 No values to set，导致前端出现失败提示。

## 对使用者的影响
使用者会在系统设置页看到风格突兀的原生下拉框与按钮，签到配置区域的视觉一致性被打断。更严重的是，手动触发一次签到时，即使只是遇到“不支持签到接口”的站点，后台也可能把整个任务标记为失败，误导使用者判断实际状态。

## 根因
前端根因有两点。第一，设置页在引入签到方式与签到间隔后，直接使用了原生 select，没有接入现有 ModernSelect。第二，“测试一次签到”按钮使用了不同于当前页面主视觉的样式类。

后端根因在 checkinService。当签到结果属于跳过类成功，并且账号本身既不需要推进 lastCheckinAt，也不需要写回 xtraConfig 或 status 时，代码仍然会调用 db.update(...).set({})。Drizzle 在空更新对象上会抛出 No values to set，于是一次本应记录为 skipped 的签到被包装成了任务失败。

## 修复内容
修复将签到方式与签到间隔都切换为 ModernSelect，并复用已有的现代化选择器样式；“测试一次签到”按钮改为现有按钮体系中的 tn btn-ghost，同时保留边框与单行布局，以保持配置区的视觉平衡。

后端在执行账号更新前增加了空对象保护。只有当签到流程确实生成了待写回字段时，才调用 db.update(...).set(updates)；纯跳过型结果仍然会写签到日志和事件，但不会因为空更新对象而抛错。

## 验证
已经新增并通过两条回归测试：

1. src/server/services/checkinService.autoRelogin.test.ts
   覆盖“不支持签到接口且账号状态无变化”时，签到结果应保持 skipped，同时不触发账号更新。
2. src/web/pages/settings.schedule-log-cleanup.test.tsx
   覆盖设置页定时任务区域必须使用 ModernSelect，且“测试一次签到”按钮应接入现有 tn-ghost 样式。

已执行的验证命令：

- 
ode node_modules/vitest/vitest.mjs run --root . src/web/pages/settings.schedule-log-cleanup.test.tsx src/server/services/checkinService.autoRelogin.test.ts
- 
pm run build:web

补充说明：全量 
ode node_modules/typescript/bin/tsc -p tsconfig.json --noEmit 在当前 origin/main 基线本身存在既有类型错误，失败点主要位于 untimeSchemaBootstrap*.test.ts、多处 eact-test-renderer 类型声明缺失，以及 Tokens.tsx 的历史类型问题；这批报错与本次修复无直接关联。
