### PR TITLE
[codex] prefer client timezone for site announcements

### DIFF
--- a/src/web/pages/SiteAnnouncements.tsx
+++ b/src/web/pages/SiteAnnouncements.tsx
@@ -6,6 +6,7 @@ import { clearFocusParams, readFocusAnnouncementId } from './helpers/navigationF
 import {
   formatSiteAnnouncementSeenAt,
   readClientTimeZone,
+  resolveSiteAnnouncementTimeZone,
   SiteAnnouncementContent,
 } from './helpers/siteAnnouncementPresentation.js';
 import { tr } from '../i18n.js';
@@ -44,7 +45,7 @@ export default function SiteAnnouncements() {
   const rowRefs = useRef<Map<number, HTMLDivElement>>(new Map());
   const highlightTimerRef = useRef<number | null>(null);
   const viewerTimeZone = useMemo(() => readClientTimeZone(), []);
-  const displayTimeZone = serverTimeZone || viewerTimeZone;
+  const displayTimeZone = resolveSiteAnnouncementTimeZone(viewerTimeZone, serverTimeZone);
 
   const siteNameById = useMemo(() => {
     const map = new Map<number, string>();

--- a/src/web/pages/helpers/siteAnnouncementPresentation.test.tsx
+++ b/src/web/pages/helpers/siteAnnouncementPresentation.test.tsx
@@ -5,6 +5,7 @@ import {
   SiteAnnouncementContent,
   formatSiteAnnouncementSeenAt,
   readClientTimeZone,
+  resolveSiteAnnouncementTimeZone,
 } from './siteAnnouncementPresentation.js';
 
 type BrowserGlobals = {
@@ -83,6 +84,11 @@ describe('siteAnnouncementPresentation helpers', () => {
 
   it('formats first-seen time in the requested local timezone', () => {
     expect(formatSiteAnnouncementSeenAt('2026-03-20 04:23:27', 'Asia/Shanghai')).toBe('2026/03/20 12:23:27');
+  });
+
+  it('prefers client timezone over server timezone', () => {
+    expect(resolveSiteAnnouncementTimeZone('Asia/Shanghai', 'UTC')).toBe('Asia/Shanghai');
+    expect(resolveSiteAnnouncementTimeZone('', 'UTC')).toBe('UTC');
   });
 
   it('reads the browser timezone when available', () => {

--- a/src/web/pages/helpers/siteAnnouncementPresentation.tsx
+++ b/src/web/pages/helpers/siteAnnouncementPresentation.tsx
@@ -340,6 +340,17 @@ export function readClientTimeZone(): string | undefined {
   }
 }
 
+export function resolveSiteAnnouncementTimeZone(
+  clientTimeZone?: string | null,
+  serverTimeZone?: string | null,
+): string | undefined {
+  const client = String(clientTimeZone || '').trim();
+  if (client) return client;
+
+  const server = String(serverTimeZone || '').trim();
+  return server || undefined;
+}
+
 export function formatSiteAnnouncementSeenAt(
   value: string | null | undefined,
   timeZone = readClientTimeZone(),

--- a/src/web/pages/siteAnnouncements.test.tsx
+++ b/src/web/pages/siteAnnouncements.test.tsx
@@ -21,6 +21,14 @@ vi.mock('../api.js', () => ({
   api: apiMock,
 }));
 
+vi.mock('./helpers/siteAnnouncementPresentation.js', async () => {
+  const actual = await vi.importActual<typeof import('./helpers/siteAnnouncementPresentation.js')>('./helpers/siteAnnouncementPresentation.js');
+  return {
+    ...actual,
+    readClientTimeZone: () => 'Asia/Shanghai',
+  };
+});
+
 async function flushMicrotasks() {
   await act(async () => {
     await Promise.resolve();
@@ -107,7 +115,7 @@ describe('SiteAnnouncements page', () => {
       expect(apiMock.getRuntimeSettings).toHaveBeenCalled();
       expect(JSON.stringify(root!.toJSON())).toContain('站点公告');
       expect(JSON.stringify(root!.toJSON())).toContain('Maintenance');
-      expect(JSON.stringify(root!.toJSON())).toContain('2026/03/20 04:23:27');
+      expect(JSON.stringify(root!.toJSON())).toContain('2026/03/20 12:23:27');
 
       const highlightedRows = root!.root.findAll((node) => {
         const className = typeof node.props.className === 'string' ? node.props.className : '';


### PR DESCRIPTION
## Summary
Follow-up to #190.

上一轮修正把运行时设置接口补充了 `serverTimeZone`，但公告页仍然把服务端时区放在浏览器时区之前。服务端处于 `UTC` 时，页面依旧会把“首次发现”显示成 `05:54:07` 这一类 UTC 时间，没有转换为当前查看者所在环境的本地时间。

这次修改把站点公告页的时间选择顺序改成“浏览器时区优先，服务端时区回退”。当客户端本身能解析出本地时区时，公告页会按当前设备的本地时间显示；只有浏览器无法提供时区时，才使用服务端返回的时区。这样 `首次发现` 才真正符合页面本地时间的预期。

## Cause And Effect
原来的优先级把服务端时区置于前面。对于默认使用 `UTC` 的部署环境，即使当前访问设备处在本地时区，页面仍会继续显示 UTC 时间，形成“正文已经变成富文本，但时间仍没变”的现象。

## Root Cause
时区来源本身并非缺失，问题出在选择顺序。浏览器时区和服务端时区都已可用，但公告页错误地优先使用了服务端值，从而把 `UTC` 长期保留下来。

## Validation
已重新执行以下校验：

- `node node_modules/vitest/vitest.mjs run src/web/pages/siteAnnouncements.test.tsx src/web/pages/helpers/siteAnnouncementPresentation.test.tsx src/web/pages/helpers/checkinLogTime.test.ts src/server/routes/api/settings.events.test.ts`
- `node node_modules/typescript/bin/tsc -p tsconfig.server.json --noEmit`
- `node scripts/desktop/generate-icons.mjs`
- `node node_modules/vite/bin/vite.js build`

Vitest 共 `4` 个测试文件、`34` 个测试通过；服务端 TypeScript 检查通过；前端直接入口构建通过。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced timezone resolution for site announcement timestamps to correctly prioritize client-side timezone settings over server defaults, ensuring accurate timestamp display across different regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->