### PR TITLE
[codex] match proxy log model badge width to model name

### DIFF
--- a/src/web/pages/ProxyLogs.server-driven.test.tsx
+++ b/src/web/pages/ProxyLogs.server-driven.test.tsx
@@ -193,6 +193,33 @@ describe('ProxyLogs server-driven page', () => {
     }
   });
 
+  it('keeps the model badge sized to the model name in desktop rows', async () => {
+    let root: ReturnType<typeof create> | null = null;
+
+    try {
+      await act(async () => {
+        root = create(
+          <MemoryRouter initialEntries={['/logs']}>
+            <ToastProvider>
+              <ProxyLogs />
+            </ToastProvider>
+          </MemoryRouter>,
+        );
+      });
+      await flushMicrotasks();
+
+      const modelBadge = root!.root.find((node) => (
+        node.type === 'span'
+        && collectText(node) === 'gpt-4o'
+        && node.props.style?.display === 'inline-flex'
+      ));
+
+      expect(modelBadge.props.style?.alignSelf).toBe('flex-start');
+    } finally {
+      root?.unmount();
+    }
+  });
+
   it('re-queries the server for status, client, and search changes instead of filtering locally', async () => {
     let root: ReturnType<typeof create> | null = null;
 

--- a/src/web/pages/ProxyLogs.tsx
+++ b/src/web/pages/ProxyLogs.tsx
@@ -823,7 +823,7 @@ export default function ProxyLogs() {
                       </td>
                       <td>
                         <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-                          <ModelBadge model={log.modelRequested} />
+                          <ModelBadge model={log.modelRequested} style={{ alignSelf: 'flex-start' }} />
                           {downstreamKeySummary ? (
                             <div style={{ fontSize: 11, lineHeight: 1.45, color: 'var(--color-text-muted)' }}>
                               {downstreamKeySummary}


### PR DESCRIPTION
This change fixes the usage log model badge so the background width matches the rendered model name instead of stretching to the full table-cell width.

On the usage log page, the model cell wraps the badge in a column flex container. The container defaults to stretch on the cross axis, so the inline-flex `ModelBadge` was being expanded to the full column width. That made short model names such as `gpt-5.4` look like they were inside a fixed-length background block.

The fix keeps the change local to the usage log page by passing `alignSelf: 'flex-start'` to `ModelBadge` in `src/web/pages/ProxyLogs.tsx`. This preserves the existing shared badge behavior everywhere else while making the usage log badge shrink to its content width.

A regression test was added in `src/web/pages/ProxyLogs.server-driven.test.tsx` to assert that the desktop usage-log row renders the model badge with `alignSelf: 'flex-start'`, so the page keeps the content-sized behavior across future refactors.

Validation used the focused Vitest suite for the usage log page and a fresh web build:

- `node node_modules/vitest/vitest.mjs run --exclude .worktrees/** src/web/pages/ProxyLogs.server-driven.test.tsx src/web/pages/logs.mobile.test.tsx`
- `npm run build:web`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted model badge alignment in the proxy logs table for improved desktop layout.
* **Tests**
  * Added test coverage for model badge alignment and sizing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->