### PR TITLE
[codex] fix explicit-group source-model fallback

### DIFF
--- a/src/server/services/tokenRouter.patterns.test.ts
+++ b/src/server/services/tokenRouter.patterns.test.ts
@@ -93,6 +93,27 @@ describe('TokenRouter patterns and model mapping', () => {
     return { route, channel };
   }
 
+  async function createExplicitGroupRoute(
+    displayName: string,
+    sourceRouteIds: number[],
+  ) {
+    const route = await db.insert(schema.tokenRoutes).values({
+      modelPattern: displayName,
+      displayName,
+      routeMode: 'explicit_group',
+      enabled: true,
+    }).returning().get();
+
+    await db.insert(schema.routeGroupSources).values(
+      sourceRouteIds.map((sourceRouteId) => ({
+        groupRouteId: route.id,
+        sourceRouteId,
+      })),
+    ).run();
+
+    return route;
+  }
+
   it('matches routes with re: regex patterns', async () => {
     await createRouteWithSingleChannel('re:^claude-(opus|sonnet)-4-6$');
     const router = new TokenRouter();
@@ -180,5 +201,20 @@ describe('TokenRouter patterns and model mapping', () => {
     expect(selected?.channel.id).toBe(exact.channel.id);
     expect(selected?.actualModel).toBe('claude-opus-4-6');
     expect(decision.actualModel).toBe('claude-opus-4-6');
+  });
+
+  it('falls back to the source exact-route model when explicit-group channels omit sourceModel', async () => {
+    const source = await createRouteWithSingleChannel('claude-opus-4-5');
+    await createExplicitGroupRoute('claude-test-4.6-sonnet', [source.route.id]);
+    const router = new TokenRouter();
+
+    const selected = await router.selectChannel('claude-test-4.6-sonnet');
+    const decision = await router.explainSelection('claude-test-4.6-sonnet');
+
+    expect(selected).toBeTruthy();
+    expect(selected?.actualModel).toBe('claude-opus-4-5');
+    expect(decision.actualModel).toBe('claude-opus-4-5');
+    expect(decision.summary).toContain('按显示名命中：claude-test-4.6-sonnet');
+    expect(decision.summary).toContain('实际转发模型：claude-opus-4-5');
   });
 });

--- a/src/server/services/tokenRouter.ts
+++ b/src/server/services/tokenRouter.ts
@@ -748,21 +748,26 @@ async function loadRouteMatch(route: RouteRow, nowMs = Date.now()): Promise<Rout
     return cached.match;
   }
 
+  const enabledRoutes = await loadEnabledRoutes(nowMs);
   const routeIds = (() => {
     if (!isExplicitGroupRoute(route)) {
       return [route.id];
     }
     return Array.from(new Set(route.sourceRouteIds.filter((routeId) => Number.isFinite(routeId) && routeId > 0)));
   })();
-  const enabledSourceRouteIds = isExplicitGroupRoute(route)
-    ? (await loadEnabledRoutes(nowMs))
-      .filter((item) => (
-        routeIds.includes(item.id)
-        && !isExplicitGroupRoute(item)
-        && isExactRouteModelPattern(item.modelPattern)
-      ))
-      .map((item) => item.id)
-    : routeIds;
+  const enabledSourceRoutes = isExplicitGroupRoute(route)
+    ? enabledRoutes.filter((item) => (
+      routeIds.includes(item.id)
+      && !isExplicitGroupRoute(item)
+      && isExactRouteModelPattern(item.modelPattern)
+    ))
+    : enabledRoutes.filter((item) => routeIds.includes(item.id));
+  const enabledSourceRouteIds = enabledSourceRoutes.map((item) => item.id);
+  const fallbackSourceModelByRouteId = new Map<number, string>(
+    enabledSourceRoutes
+      .filter((item) => isExactRouteModelPattern(item.modelPattern))
+      .map((item) => [item.id, (item.modelPattern || '').trim()]),
+  );
   const channels = enabledSourceRouteIds.length > 0
     ? await db
       .select()
@@ -775,7 +780,12 @@ async function loadRouteMatch(route: RouteRow, nowMs = Date.now()): Promise<Rout
     : [];
 
   const mapped = channels.map((row) => ({
-    channel: row.route_channels,
+    channel: {
+      ...row.route_channels,
+      sourceModel: normalizeChannelSourceModel(row.route_channels.sourceModel)
+        || fallbackSourceModelByRouteId.get(row.route_channels.routeId)
+        || null,
+    },
     account: row.accounts,
     site: row.sites,
     token: row.account_tokens,


### PR DESCRIPTION
## 问题
issue #200 里的显式群组场景会把群组显示名当作上游模型名继续转发。用户请求类似 `claude-test-4.6-sonnet` 这样的群组别名时，Metapi 已经命中了显式群组，但如果来源精确路由的通道记录没有保存 `sourceModel`，最终 `actualModel` 仍会保留为群组别名。上游站点通常并不存在这个别名模型，于是日志里会出现 `No available channel for model ... under group default` 这类 503 失败。

## 根因
`src/server/services/tokenRouter.ts` 在加载显式群组的匹配结果时，只把来源路由的通道行原样带入选择过程。对于自动发现或历史生成的精确路由，`route_channels.source_model` 可能为空；后续 `resolveActualModelForSelectedChannel` 只能看到空值，于是保留请求别名作为 `actualModel`，没有回退到来源精确路由的 `modelPattern`。

## 修改
这次修改只收在服务端路由解析层：

1. 显式群组加载来源通道时，先构建来源精确路由 `id -> modelPattern` 的回填映射。
2. 如果某条来源通道缺少 `sourceModel`，就在内存中的匹配结果里用来源精确路由的 `modelPattern` 回填。
3. 新增回归测试，覆盖“显式群组来源通道缺少 `sourceModel` 时，转发模型仍应回退到来源精确模型”这一场景。

这样处理后，请求群组别名时，上游真正收到的会是来源模型名，而不是群组显示名。

## 验证
已运行以下验证命令并通过：

```bash
node node_modules/vitest/vitest.mjs run --root . src/server/services/tokenRouter.test.ts src/server/services/tokenRouter.cache.test.ts src/server/services/tokenRouter.downstream-policy.test.ts src/server/services/tokenRouter.patterns.test.ts src/server/services/tokenRouter.selection.test.ts src/server/services/tokenRouter.session-decoupling.test.ts src/server/services/tokenRouter.siteStatus.test.ts src/server/routes/api/tokens.route-update-rebuild.test.ts
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for explicit-group route channel configuration and model resolution behavior.

* **Bug Fixes**
  * Optimized route loading performance by reusing cached enabled routes.
  * Improved fallback model resolution for explicit-group routes to ensure accurate model selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->