### PR TITLE
fix: detect openclaw user-agent in proxy logs

### DIFF
--- a/src/server/routes/proxy/downstreamClientContext.test.ts
+++ b/src/server/routes/proxy/downstreamClientContext.test.ts
@@ -125,6 +125,21 @@ describe('detectDownstreamClientContext', () => {
     });
   });
 
+  it('treats explicit OpenClaw user-agent headers as self-reported app names', () => {
+    expect(detectDownstreamClientContext({
+      downstreamPath: '/v1/responses',
+      headers: {
+        'openai-beta': 'responses-2025-03-11',
+        'user-agent': 'OpenClaw/1.0',
+      },
+    })).toEqual({
+      clientKind: 'codex',
+      clientAppId: 'openclaw',
+      clientAppName: 'OpenClaw',
+      clientConfidence: 'exact',
+    });
+  });
+
   it('recognizes Claude Code requests from metadata.user_id without mutating the body', () => {
     const body = {
       model: 'claude-opus-4-6',

--- a/src/server/routes/proxy/downstreamClientContext.ts
+++ b/src/server/routes/proxy/downstreamClientContext.ts
@@ -263,6 +263,16 @@ function detectExplicitClientSelfReport(headers: NormalizedClientHeaders): Downs
     };
   }
 
+  for (const value of headers['user-agent'] || []) {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized.startsWith('openclaw/')) continue;
+    return {
+      clientAppId: 'openclaw',
+      clientAppName: 'OpenClaw',
+      clientConfidence: 'exact',
+    };
+  }
+
   return null;
 }
 


### PR DESCRIPTION
## Summary
- treat explicit `User-Agent: OpenClaw/<version>` headers as downstream self-reported app names in proxy log detection
- keep the existing `x-openai-client-user-agent` self-report logic and protocol-family fallback behavior unchanged for other clients
- add regression coverage for the OpenClaw user-agent path so proxy logs no longer fall back to `Codex / 推测` for this case

## Test Plan
- [x] `npm test -- src/server/routes/proxy/downstreamClientContext.test.ts`
- [x] `npm test -- src/server/routes/proxy/responses.codex-oauth.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for client detection verification.

* **Bug Fixes**
  * Improved detection of specific client applications in server requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->