### PR TITLE
fix: avoid armv7 desktop postinstall in docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update \
 ENV PYTHON=/usr/bin/python3
 
 COPY package.json package-lock.json ./
-RUN --mount=type=cache,target=/root/.npm npm ci --no-audit --no-fund
+RUN --mount=type=cache,target=/root/.npm npm ci --ignore-scripts --no-audit --no-fund
+RUN npm rebuild esbuild sharp better-sqlite3 --no-audit --no-fund
 
 COPY . .
 RUN npm run build:web && npm run build:server

--- a/scripts/dev/docker.workflow.test.ts
+++ b/scripts/dev/docker.workflow.test.ts
@@ -26,9 +26,9 @@ describe('docker workflows', () => {
   it('keeps server docker builds isolated from desktop packaging dependencies', () => {
     const dockerfile = readFileSync(resolve(process.cwd(), 'docker/Dockerfile'), 'utf8');
 
-    expect(dockerfile).toContain('npm ci --no-audit --no-fund');
-    expect(dockerfile).not.toContain('npm ci --omit=peer --no-audit --no-fund');
-    expect(dockerfile).not.toContain('npm ci --include=dev --omit=peer --no-audit --no-fund');
+    expect(dockerfile).toContain('npm ci --ignore-scripts --no-audit --no-fund');
+    expect(dockerfile).toContain('npm rebuild esbuild sharp better-sqlite3 --no-audit --no-fund');
+    expect(dockerfile).not.toContain('npm ci --no-audit --no-fund');
     expect(dockerfile).toContain('RUN npm run build:web && npm run build:server');
     expect(dockerfile).toContain('npm prune --omit=dev --no-audit --no-fund');
   });


### PR DESCRIPTION
## Summary
- skip package postinstall scripts during the docker builder install step
- rebuild only esbuild, sharp, and better-sqlite3 so web/server docker builds keep the binaries they need
- add a regression test that locks the docker builder install path

## Test Plan
- npm test -- scripts/dev/docker.workflow.test.ts
- npm run build:web
- npm run build:server
- temp install: npm ci --ignore-scripts && npm rebuild esbuild sharp better-sqlite3 && verify vite/sharp/better-sqlite3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build process to improve dependency installation efficiency and native module rebuild reliability. Docker builds now skip package lifecycle scripts during initial dependency installation and explicitly rebuild specific native modules in isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->