### PR TITLE
[codex] Prioritize collapsed route group labels over regex badges

### DIFF
--- a/src/web/pages/token-routes/RouteCard.test.tsx
+++ b/src/web/pages/token-routes/RouteCard.test.tsx
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest';
+import { create, type ReactTestInstance } from 'react-test-renderer';
+import RouteCard from './RouteCard.js';
+import type { RouteSummaryRow } from './types.js';
+
+function collectText(node: ReactTestInstance): string {
+  return (node.children || []).map((child) => {
+    if (typeof child === 'string') return child;
+    return collectText(child);
+  }).join('');
+}
+
+const LONG_REGEX_PATTERN = 're:(?:.*|.*/)(minimax-m2.1)$';
+
+function buildRoute(overrides: Partial<RouteSummaryRow> = {}): RouteSummaryRow {
+  return {
+    id: 42,
+    modelPattern: LONG_REGEX_PATTERN,
+    displayName: 'm.',
+    displayIcon: null,
+    modelMapping: null,
+    routingStrategy: 'weighted',
+    enabled: true,
+    channelCount: 4,
+    enabledChannelCount: 4,
+    siteNames: ['site-a'],
+    decisionSnapshot: null,
+    decisionRefreshedAt: null,
+    ...overrides,
+  };
+}
+
+describe('RouteCard', () => {
+  it('truncates the collapsed regex badge while keeping the group name primary', () => {
+    const root = create(
+      <RouteCard
+        route={buildRoute()}
+        brand={null}
+        expanded={false}
+        onToggleExpand={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onToggleEnabled={vi.fn()}
+        onRoutingStrategyChange={vi.fn()}
+        updatingRoutingStrategy={false}
+        channels={undefined}
+        loadingChannels={false}
+        routeDecision={null}
+        loadingDecision={false}
+        candidateView={{ routeCandidates: [], accountOptions: [], tokenOptionsByAccountId: {} }}
+        channelTokenDraft={{}}
+        updatingChannel={{}}
+        savingPriority={false}
+        onTokenDraftChange={vi.fn()}
+        onSaveToken={vi.fn()}
+        onDeleteChannel={vi.fn()}
+        onToggleChannelEnabled={vi.fn()}
+        onChannelDragEnd={vi.fn()}
+        missingTokenSiteItems={[]}
+        missingTokenGroupItems={[]}
+        onCreateTokenForMissing={vi.fn()}
+        onAddChannel={vi.fn()}
+        onSiteBlockModel={vi.fn()}
+        expandedSourceGroupMap={{}}
+        onToggleSourceGroup={vi.fn()}
+      />,
+    );
+
+    expect(collectText(root.root)).toContain('m.');
+
+    const regexBadge = root.root.find((node) => (
+      node.type === 'span'
+      && typeof node.props.className === 'string'
+      && node.props.className.includes('badge-muted')
+      && collectText(node) === LONG_REGEX_PATTERN
+    ));
+
+    expect(regexBadge.props.style).toMatchObject({
+      maxWidth: 180,
+      minWidth: 0,
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+      flexShrink: 1,
+    });
+  });
+});

--- a/src/web/pages/token-routes/RouteCard.tsx
+++ b/src/web/pages/token-routes/RouteCard.tsx
@@ -205,7 +205,21 @@ function RouteCardInner({
           </code>
 
           {route.displayName && route.displayName.trim() !== route.modelPattern ? (
-            <span className="badge badge-muted" style={{ fontSize: 10, flexShrink: 0 }}>{route.modelPattern}</span>
+            <span
+              className="badge badge-muted"
+              title={route.modelPattern}
+              style={{
+                fontSize: 10,
+                flexShrink: 1,
+                minWidth: 0,
+                maxWidth: 180,
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              {route.modelPattern}
+            </span>
           ) : null}
 
           {readOnlyRoute ? (


### PR DESCRIPTION
This change fixes the collapsed token-route summary for named route groups where the underlying model pattern is a long regex. In the current UI, the group display name is resolved correctly, but the secondary muted `modelPattern` badge still renders at full width with `flex-shrink: 0`. For regex-backed groups, that makes the badge visually dominate the row and pushes the actual group name out of focus, which makes the route list harder to scan.

The root cause is limited to the collapsed `RouteCard` summary: the secondary regex badge was treated like a fixed-width status chip instead of secondary metadata. Because it could not shrink and had no overflow handling, long regex patterns expanded across the summary row.

The fix keeps the existing information hierarchy but makes it behave like secondary metadata. The collapsed summary still shows the group name as the primary label, and still exposes the underlying `modelPattern` when it differs from the display name, but the badge now has a constrained width, ellipsis truncation, and a `title` attribute so the full pattern remains available on hover. Expanded cards were intentionally left unchanged so this PR stays tightly scoped to the list-scanning problem.

A focused regression test was added for `RouteCard` to verify that a named regex route keeps the group name primary and applies truncation styling to the secondary regex badge. The nearby mobile layout route test was also re-run to make sure the summary-card interaction flow still behaves as expected.

Checks used for validation:

- `npm test -- src/web/pages/token-routes/RouteCard.test.tsx src/web/pages/tokenRoutes.mobile-layout.test.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for route card badge display and truncation behavior.

* **Style**
  * Enhanced route model pattern badge display with improved text truncation and hover tooltip for full pattern visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->