### PR TITLE
[daily] fix gemini oauth validation site proxy

### DIFF
--- a/src/server/services/modelService.discovery.test.ts
+++ b/src/server/services/modelService.discovery.test.ts
@@ -75,7 +75,12 @@ describe('refreshModelsForAccount credential discovery', () => {
     await db.delete(schema.modelAvailability).run();
     await db.delete(schema.accountTokens).run();
     await db.delete(schema.accounts).run();
+    await db.delete(schema.settings).run();
     await db.delete(schema.sites).run();
+    const { config } = await import('../config.js');
+    config.systemProxyUrl = '';
+    const { invalidateSiteProxyCache } = await import('./siteProxy.js');
+    invalidateSiteProxyCache();
   });
 
   afterAll(() => {
@@ -868,6 +873,62 @@ describe('refreshModelsForAccount credential discovery', () => {
     expect(undiciFetchMock).toHaveBeenCalledTimes(1);
     expect(proxyAgentCtorMock).toHaveBeenCalledWith('http://127.0.0.1:1080');
     expect(String(undiciFetchMock.mock.calls[0]?.[0] || '')).toContain('/projects/project-proxy-demo/services/');
+    expect(undiciFetchMock.mock.calls[0]?.[1]).toMatchObject({
+      method: 'GET',
+      dispatcher: expect.any(MockProxyAgent),
+    });
+  });
+
+  it('inherits site system proxy for gemini oauth validation requests', async () => {
+    getApiTokenMock.mockResolvedValue(null);
+    getModelsMock.mockRejectedValue(new Error('gemini oauth validation should not call adapter.getModels'));
+    undiciFetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        state: 'ENABLED',
+      }),
+      text: async () => JSON.stringify({ state: 'ENABLED' }),
+    });
+
+    const { config } = await import('../config.js');
+    config.systemProxyUrl = 'http://127.0.0.1:1081';
+
+    const site = await db.insert(schema.sites).values({
+      name: 'gemini-site-proxy-site',
+      url: 'https://cloudcode-pa.googleapis.com',
+      platform: 'gemini-cli',
+      status: 'active',
+      useSystemProxy: true,
+    }).returning().get();
+
+    const account = await db.insert(schema.accounts).values({
+      siteId: site.id,
+      username: 'gemini-site-proxy-user@example.com',
+      accessToken: 'gemini-access-token',
+      apiToken: null,
+      status: 'active',
+      extraConfig: JSON.stringify({
+        credentialMode: 'session',
+        oauth: {
+          provider: 'gemini-cli',
+          projectId: 'project-site-proxy-demo',
+          email: 'gemini-site-proxy-user@example.com',
+        },
+      }),
+    }).returning().get();
+
+    const result = await refreshModelsForAccount(account.id);
+
+    expect(result).toMatchObject({
+      accountId: account.id,
+      refreshed: true,
+      status: 'success',
+      modelCount: expect.any(Number),
+    });
+    expect(undiciFetchMock).toHaveBeenCalledTimes(1);
+    expect(proxyAgentCtorMock).toHaveBeenCalledWith('http://127.0.0.1:1081');
+    expect(String(undiciFetchMock.mock.calls[0]?.[0] || '')).toContain('/projects/project-site-proxy-demo/services/');
     expect(undiciFetchMock.mock.calls[0]?.[1]).toMatchObject({
       method: 'GET',
       dispatcher: expect.any(MockProxyAgent),

--- a/src/server/services/modelService.ts
+++ b/src/server/services/modelService.ts
@@ -529,7 +529,7 @@ export async function refreshModelsForAccount(
       try {
         await withTimeout(
           () => withAccountProxyOverride(accountProxyUrl,
-            () => validateGeminiCliOauthConnection({ account: discoveryAccount })),
+            () => validateGeminiCliOauthConnection({ site, account: discoveryAccount })),
           MODEL_DISCOVERY_TIMEOUT_MS,
           `gemini cli oauth validation timeout (${Math.round(MODEL_DISCOVERY_TIMEOUT_MS / 1000)}s)`,
         );
@@ -548,7 +548,7 @@ export async function refreshModelsForAccount(
         };
         await withTimeout(
           () => withAccountProxyOverride(accountProxyUrl,
-            () => validateGeminiCliOauthConnection({ account: discoveryAccount })),
+            () => validateGeminiCliOauthConnection({ site, account: discoveryAccount })),
           MODEL_DISCOVERY_TIMEOUT_MS,
           `gemini cli oauth validation timeout (${Math.round(MODEL_DISCOVERY_TIMEOUT_MS / 1000)}s)`,
         );

--- a/src/server/services/platformDiscoveryRegistry.ts
+++ b/src/server/services/platformDiscoveryRegistry.ts
@@ -1,7 +1,6 @@
 import { fetch } from 'undici';
 import { schema } from '../db/index.js';
-import { getProxyUrlFromExtraConfig } from './accountExtraConfig.js';
-import { withExplicitProxyRequestInit, withSiteRecordProxyRequestInit } from './siteProxy.js';
+import { withSiteRecordProxyRequestInit } from './siteProxy.js';
 import { getOauthInfoFromAccount } from './oauth/oauthAccount.js';
 import { CLAUDE_DEFAULT_ANTHROPIC_VERSION } from './oauth/claudeProvider.js';
 import {
@@ -175,6 +174,7 @@ export async function discoverClaudeModelsFromCloud(input: {
 }
 
 export async function validateGeminiCliOauthConnection(input: {
+  site: PlatformDiscoverySite;
   account: PlatformDiscoveryAccount;
 }): Promise<void> {
   const accessToken = (input.account.accessToken || '').trim();
@@ -188,7 +188,7 @@ export async function validateGeminiCliOauthConnection(input: {
   }
   const response = await fetch(
     `https://serviceusage.googleapis.com/v1/projects/${encodeURIComponent(projectId)}/services/${encodeURIComponent(GEMINI_CLI_REQUIRED_SERVICE)}`,
-    withExplicitProxyRequestInit(getProxyUrlFromExtraConfig(input.account.extraConfig), {
+    withSiteRecordProxyRequestInit(input.site, {
       method: 'GET',
       headers: {
         Authorization: `Bearer ${accessToken}`,
@@ -196,7 +196,7 @@ export async function validateGeminiCliOauthConnection(input: {
         'User-Agent': GEMINI_CLI_USER_AGENT,
         'X-Goog-Api-Client': GEMINI_CLI_GOOGLE_API_CLIENT,
       },
-    }, true),
+    }),
   );
   if (!response.ok) {
     const text = await response.text().catch(() => '');


### PR DESCRIPTION
## Source Delta Reviewed
- `5ae452ab45acaef12837c99b466b68410831b880` (`[codex] inherit site proxy settings for oauth (#296)`)
- Replayed on current `origin/main` head `3bf3cd162236a7d9de0dcc30e2efea35624d9aa5` (`feat: 新增路由批量禁用/启用功能 (#295)`)

## Problem
The March 28 OAuth proxy inheritance change routed token exchange and refresh through site proxy settings, but Gemini CLI validation still built its request from account-level proxy overrides only.

That left a user-visible gap: if the Gemini CLI OAuth site is configured to use a site proxy or the shared system proxy, the token exchange can succeed and the immediate post-login validation can still bypass the proxy. On first connect, that validation failure can roll back the newly created OAuth account.

## Root Cause
`validateGeminiCliOauthConnection()` only had the account record and called `withExplicitProxyRequestInit(getProxyUrlFromExtraConfig(account.extraConfig), ...)`.

Because it never received the site record, it could not honor `site.proxyUrl` or `site.useSystemProxy`. That left one adjacent OAuth cloud-validation path on a parallel proxy-resolution implementation instead of the canonical site-aware helper.

## Fix
Pass the site record into Gemini CLI validation from `refreshModelsForAccount()`.

Switch the validation request to `withSiteRecordProxyRequestInit(site, ...)`, so Gemini validation now reuses the same site/account proxy precedence as the other cloud discovery paths.

Add a regression test that covers Gemini OAuth validation through a site-level system proxy, and reset runtime proxy state between discovery tests so the proxy assertions stay isolated.

## Verification
- `vitest run --root . src/server/services/modelService.discovery.test.ts`
- `tsx scripts/dev/repo-drift-check.ts`
- Replayed commit `36da0fbdadba696f0ff345f753bcc7dc30e6fc7a` on top of current `origin/main` and reran the focused checks

## Residual Risk
This change is intentionally narrow. It only fixes the Gemini CLI OAuth validation path and does not alter token exchange behavior for other OAuth providers.

## Why This Is Safe To Merge
The patch changes one request-construction path in discovery-only Gemini OAuth validation, keeps the existing call shape everywhere else, and adds a focused regression test for the site-system-proxy case that was previously uncovered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for system proxy behavior in Gemini OAuth validation requests.

* **Refactor**
  * Improved Gemini OAuth validation to correctly inherit and apply system proxy configuration for outbound requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->