### PR TITLE
Handle codex OAuth usage-limit cooldowns

### DIFF
--- a/src/server/services/tokenRouter.cache.test.ts
+++ b/src/server/services/tokenRouter.cache.test.ts
@@ -468,6 +468,80 @@ describe('TokenRouter runtime cache', () => {
     expect(record?.failCount).toBe(1);
   });
 
+  it('applies short-window cooldown to sibling channels that share the same account-level credential', async () => {
+    const site = await db.insert(schema.sites).values({
+      name: 'shared-credential-site',
+      url: 'https://shared-credential.example.com',
+      platform: 'codex',
+      status: 'active',
+    }).returning().get();
+
+    const account = await db.insert(schema.accounts).values({
+      siteId: site.id,
+      username: 'shared-credential-user',
+      accessToken: 'shared-credential-access-token',
+      status: 'active',
+      oauthProvider: 'codex',
+      extraConfig: JSON.stringify({
+        credentialMode: 'session',
+        oauth: {
+          provider: 'codex',
+        },
+      }),
+    }).returning().get();
+
+    const primaryRoute = await db.insert(schema.tokenRoutes).values({
+      modelPattern: 'gpt-5.4',
+      routingStrategy: 'weighted',
+      enabled: true,
+    }).returning().get();
+
+    const siblingRoute = await db.insert(schema.tokenRoutes).values({
+      modelPattern: 'gpt-4o-mini',
+      routingStrategy: 'weighted',
+      enabled: true,
+    }).returning().get();
+
+    const primaryChannel = await db.insert(schema.routeChannels).values({
+      routeId: primaryRoute.id,
+      accountId: account.id,
+      priority: 0,
+      weight: 10,
+      enabled: true,
+    }).returning().get();
+
+    const siblingChannel = await db.insert(schema.routeChannels).values({
+      routeId: siblingRoute.id,
+      accountId: account.id,
+      priority: 0,
+      weight: 10,
+      enabled: true,
+    }).returning().get();
+
+    const router = new TokenRouter();
+    const initialSiblingSelection = await router.selectChannel('gpt-4o-mini');
+    expect(initialSiblingSelection?.channel.id).toBe(siblingChannel.id);
+
+    await router.recordFailure(primaryChannel.id, {
+      status: 429,
+      errorText: JSON.stringify({
+        error: {
+          type: 'usage_limit_reached',
+          message: 'The usage limit has been reached',
+        },
+      }),
+      modelName: 'gpt-5.4',
+    });
+
+    const cooledSibling = await db.select().from(schema.routeChannels)
+      .where(eq(schema.routeChannels.id, siblingChannel.id))
+      .get();
+
+    expect(cooledSibling?.cooldownUntil).toBeTruthy();
+    expect(cooledSibling?.failCount).toBe(0);
+    expect(await router.selectChannel('gpt-4o-mini')).toBeNull();
+  });
+
   it('round robins across all available channels regardless of priority', async () => {
     const site = await db.insert(schema.sites).values({
       name: 'round-robin-site',

--- a/src/server/services/tokenRouter.ts
+++ b/src/server/services/tokenRouter.ts
@@ -1,4 +1,4 @@
-﻿import { eq, inArray } from 'drizzle-orm';
+﻿import { and, eq, inArray, isNull } from 'drizzle-orm';
 import { db, schema } from '../db/index.js';
 import { upsertSetting } from '../db/upsertSetting.js';
 import { config } from '../config.js';
@@ -317,6 +317,28 @@ function resolveShortWindowLimitCooldown(
   }
 
   return new Date(nowMs + SHORT_WINDOW_LIMIT_COOLDOWN_MS).toISOString();
+}
+
+async function loadCredentialScopedChannelIds(
+  channel: typeof schema.routeChannels.$inferSelect,
+  accountId: number,
+): Promise<number[]> {
+  if (typeof channel.tokenId === 'number' && channel.tokenId > 0) {
+    const rows = await db.select({ id: schema.routeChannels.id })
+      .from(schema.routeChannels)
+      .where(eq(schema.routeChannels.tokenId, channel.tokenId))
+      .all();
+    return rows.map((row) => row.id);
+  }
+
+  const rows = await db.select({ id: schema.routeChannels.id })
+    .from(schema.routeChannels)
+    .where(and(
+      eq(schema.routeChannels.accountId, accountId),
+      isNull(schema.routeChannels.tokenId),
+    ))
+    .all();
+  return rows.map((row) => row.id);
 }
 
 function getDecayedSiteRuntimePenalty(state: SiteRuntimeHealthState, nowMs: number): number {
@@ -1767,6 +1789,9 @@ export class TokenRouter {
     const shortWindowLimitCooldownUntil = resolveShortWindowLimitCooldown(account, normalizedContext, nowMs);
     const failCount = shortWindowLimitCooldownUntil ? 0 : ((ch.failCount ?? 0) + 1);
     const routeStrategy = resolveRouteStrategy(route);
+    const affectedChannelIds = shortWindowLimitCooldownUntil
+      ? await loadCredentialScopedChannelIds(ch, account.id)
+      : [channelId];
     let cooldownUntil: string | null = null;
     let consecutiveFailCount = Math.max(0, ch.consecutiveFailCount ?? 0) + 1;
     let cooldownLevel = Math.max(0, ch.cooldownLevel ?? 0);
@@ -1795,15 +1820,17 @@ export class TokenRouter {
       consecutiveFailCount,
       cooldownLevel,
       cooldownUntil,
-    }).where(eq(schema.routeChannels.id, channelId)).run();
+    }).where(inArray(schema.routeChannels.id, affectedChannelIds)).run();
 
-    patchCachedChannel(channelId, (channel) => {
-      channel.failCount = failCount;
-      channel.lastFailAt = nowIso;
-      channel.cooldownUntil = cooldownUntil;
-      channel.consecutiveFailCount = consecutiveFailCount;
-      channel.cooldownLevel = cooldownLevel;
-    });
+    for (const affectedChannelId of affectedChannelIds) {
+      patchCachedChannel(affectedChannelId, (channel) => {
+        channel.failCount = failCount;
+        channel.lastFailAt = nowIso;
+        channel.cooldownUntil = cooldownUntil;
+        channel.consecutiveFailCount = consecutiveFailCount;
+        channel.cooldownLevel = cooldownLevel;
+      });
+    }
 
     recordSiteRuntimeFailure(account.siteId, normalizedContext, nowMs);
   }


### PR DESCRIPTION
## Summary
- route Codex OAuth `usage_limit_reached` 429 failures through reset-aware cooldown handling instead of Fibonacci backoff
- reuse stored quota reset hints when upstream omits reset timing and fall back to a short cooldown window
- add cache-level tests covering reset hints, stored reset reuse, and short-window fallback

## Test Plan
- npm test -- src/server/services/tokenRouter.cache.test.ts src/server/services/oauth/quota.test.ts src/server/proxy-core/surfaces/sharedSurface.test.ts src/server/routes/proxy/responses.codex-oauth.test.ts
- npm run repo:drift-check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Better detection and classification of usage-limit (HTTP 429) failures with distinct penalties.
  * New shorter-window cooldowns that prefer reported reset hints or stored quota reset times, falling back to sensible defaults.
  * State updates now apply credential-scoped cooldowns across sibling channels and avoid incrementing failure counters for quota-triggered cooldowns.

* **Tests**
  * Added tests validating multiple 429/usage-limit scenarios, cooldown durations, cross-channel cooldown propagation, and failure-count behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->