### PR TITLE
[codex] persist proxy trace panel state

### DIFF
--- a/src/web/pages/ProxyLogs.server-driven.test.tsx
+++ b/src/web/pages/ProxyLogs.server-driven.test.tsx
@@ -97,11 +97,28 @@ function buildListResponse(overrides?: Partial<{
 describe('ProxyLogs server-driven page', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    const localStorageState = new Map<string, string>();
     Object.defineProperty(globalThis, 'navigator', {
       value: {
         clipboard: {
           writeText: vi.fn().mockResolvedValue(undefined),
         },
+      },
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: {
+        getItem: vi.fn((key: string) => (localStorageState.has(key) ? localStorageState.get(key)! : null)),
+        setItem: vi.fn((key: string, value: string) => {
+          localStorageState.set(String(key), String(value));
+        }),
+        removeItem: vi.fn((key: string) => {
+          localStorageState.delete(String(key));
+        }),
+        clear: vi.fn(() => {
+          localStorageState.clear();
+        }),
       },
       configurable: true,
       writable: true,
@@ -453,6 +470,67 @@ describe('ProxyLogs server-driven page', () => {
 
       expect(expandedToggleButton.props['aria-expanded']).toBe(true);
       expect(String(expandedPanelBody.props.className || '')).toContain('is-open');
+    } finally {
+      root?.unmount();
+    }
+  });
+
+  it('remembers the collapsed debug trace panel state across remounts', async () => {
+    let root!: WebTestRenderer;
+
+    try {
+      await act(async () => {
+        root = create(
+          <MemoryRouter initialEntries={['/logs']}>
+            <ToastProvider>
+              <ProxyLogs />
+            </ToastProvider>
+          </MemoryRouter>,
+        );
+      });
+      await flushMicrotasks();
+
+      const toggleButton = root.root.find((node) => (
+        node.type === 'button'
+        && typeof node.props.onClick === 'function'
+        && node.props['data-debug-trace-panel-toggle'] === true
+      ));
+
+      await act(async () => {
+        toggleButton.props.onClick();
+      });
+      await flushMicrotasks();
+
+      expect(globalThis.localStorage.setItem).toHaveBeenCalledWith('metapi.proxyLogs.debugTracePanelExpanded', 'false');
+
+      await act(async () => {
+        root.unmount();
+      });
+
+      await act(async () => {
+        root = create(
+          <MemoryRouter initialEntries={['/logs']}>
+            <ToastProvider>
+              <ProxyLogs />
+            </ToastProvider>
+          </MemoryRouter>,
+        );
+      });
+      await flushMicrotasks();
+
+      const restoredToggleButton = root.root.find((node) => (
+        node.type === 'button'
+        && typeof node.props.onClick === 'function'
+        && node.props['data-debug-trace-panel-toggle'] === true
+      ));
+      const restoredPanelBody = root.root.find((node) => (
+        node.type === 'div'
+        && node.props['data-debug-trace-panel-body'] === true
+      ));
+
+      expect(globalThis.localStorage.getItem).toHaveBeenCalledWith('metapi.proxyLogs.debugTracePanelExpanded');
+      expect(restoredToggleButton.props['aria-expanded']).toBe(false);
+      expect(String(restoredPanelBody.props.className || '')).not.toContain('is-open');
     } finally {
       root?.unmount();
     }

--- a/src/web/pages/ProxyLogs.tsx
+++ b/src/web/pages/ProxyLogs.tsx
@@ -75,6 +75,7 @@ const PAGE_SIZES = [20, 50, 100];
 const DEFAULT_PAGE_SIZE = 50;
 const TRACE_TABLE_LIMIT = 20;
 const DEBUG_TRACE_PAGE_SIZE = 5;
+const PROXY_LOGS_DEBUG_TRACE_PANEL_STORAGE_KEY = 'metapi.proxyLogs.debugTracePanelExpanded';
 const PROXY_LOG_CLIENT_FAMILY_LABELS: Record<string, string> = {
   codex: 'Codex',
   claude_code: 'Claude Code',
@@ -596,6 +597,24 @@ function CompactSummaryMetric({
   );
 }
 
+function readStoredDebugTracePanelExpanded(): boolean {
+  try {
+    const stored = globalThis.localStorage?.getItem(PROXY_LOGS_DEBUG_TRACE_PANEL_STORAGE_KEY);
+    if (stored == null) return true;
+    return stored !== 'false';
+  } catch {
+    return true;
+  }
+}
+
+function persistDebugTracePanelExpanded(expanded: boolean) {
+  try {
+    globalThis.localStorage?.setItem(PROXY_LOGS_DEBUG_TRACE_PANEL_STORAGE_KEY, expanded ? 'true' : 'false');
+  } catch {
+    // Ignore storage write failures and keep UI responsive.
+  }
+}
+
 export default function ProxyLogs() {
   const location = useLocation();
   const navigate = useNavigate();
@@ -622,7 +641,7 @@ export default function ProxyLogs() {
   const [showDebugSettingsModal, setShowDebugSettingsModal] = useState(false);
   const [debugPanelLoading, setDebugPanelLoading] = useState(false);
   const [debugPanelSaving, setDebugPanelSaving] = useState(false);
-  const [debugTracePanelExpanded, setDebugTracePanelExpanded] = useState(true);
+  const [debugTracePanelExpanded, setDebugTracePanelExpanded] = useState(() => readStoredDebugTracePanelExpanded());
   const [debugSettings, setDebugSettings] = useState<ProxyDebugSettingsState>(DEFAULT_PROXY_DEBUG_SETTINGS);
   const [debugDraftSettings, setDebugDraftSettings] = useState<ProxyDebugSettingsState>(DEFAULT_PROXY_DEBUG_SETTINGS);
   const [debugTraces, setDebugTraces] = useState<ProxyDebugTraceListItem[]>([]);
@@ -985,6 +1004,10 @@ export default function ProxyLogs() {
     }, DEBUG_REFRESH_INTERVAL_MS);
     return () => clearInterval(timer);
   }, [debugSettings.proxyDebugTraceEnabled, loadDebugTraceList]);
+
+  useEffect(() => {
+    persistDebugTracePanelExpanded(debugTracePanelExpanded);
+  }, [debugTracePanelExpanded]);
 
   const persistDebugSettings = useCallback(async (
     nextSettings: ProxyDebugSettingsState,


### PR DESCRIPTION
## Summary
The trace panel on Proxy Logs could be collapsed, but that preference was only stored in component state. After switching pages and returning, the panel always expanded again, which made the page feel noisy for operators who intentionally hid the trace list to focus on the main usage log filters and summaries.

The root cause was that the collapse state lived only in `useState`, so a remount reset it back to the default expanded state. That behavior was inconsistent with other `metapi` surfaces such as `ModelTester`, where user-facing panel preferences are restored from local storage.

This follow-up stores the Proxy Logs trace-panel preference in `localStorage`, restores it on mount, and keeps the existing safety behavior that re-expands the panel when tracing is explicitly enabled again. The tests now cover both manual collapse/expand and the remount restore path.

## Testing
- `npm test -- src/web/pages/ProxyLogs.server-driven.test.tsx`
- `npm run typecheck -- --pretty false`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Debug trace panel state persistence: The debug trace panel now remembers your preference for whether it should be expanded or collapsed. This setting is automatically saved and restored whenever you access the proxy logs page, eliminating the need to reconfigure it on each visit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->