### PR TITLE
[codex] preserve repeated short responses deltas

### DIFF
--- a/src/server/routes/proxy/chat.stream.test.ts
+++ b/src/server/routes/proxy/chat.stream.test.ts
@@ -2007,6 +2007,51 @@ describe('chat proxy stream behavior', () => {
     expect(response.body).toContain('"text":"The user asked \\"whoru\\" which is a common internet slang and shorthand for who are you."');
   });
 
+  it('preserves legitimate repeated short deltas when /v1/responses is converted from /v1/messages stream', async () => {
+    fetchModelPricingCatalogMock.mockResolvedValue({
+      models: [
+        {
+          modelName: 'upstream-gpt',
+          supportedEndpointTypes: ['/v1/messages'],
+        },
+      ],
+      groupRatio: {},
+    });
+
+    const encoder = new TextEncoder();
+    const upstreamBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode('event: message_start\ndata: {"type":"message_start","message":{"id":"msg_repeat_short_1","model":"upstream-gpt"}}\n\n'));
+        controller.enqueue(encoder.encode('event: content_block_delta\ndata: {"type":"content_block_delta","delta":{"type":"text_delta","text":"ha"}}\n\n'));
+        controller.enqueue(encoder.encode('event: content_block_delta\ndata: {"type":"content_block_delta","delta":{"type":"text_delta","text":"ha"}}\n\n'));
+        controller.enqueue(encoder.encode('event: message_stop\ndata: {"type":"message_stop"}\n\n'));
+        controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+        controller.close();
+      },
+    });
+
+    fetchMock.mockResolvedValue(new Response(upstreamBody, {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream; charset=utf-8' },
+    }));
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/v1/responses',
+      payload: {
+        model: 'claude-sonnet-4-6',
+        stream: true,
+        input: 'laugh',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const deltaMatches = response.body.match(/event: response\.output_text\.delta/g) || [];
+    expect(deltaMatches.length).toBe(2);
+    expect(response.body).toContain('"delta":"ha"');
+    expect(response.body).toContain('"text":"haha"');
+  });
+
   it('preserves function_call/function_call_output when /v1/responses falls back to /v1/chat/completions', async () => {
     fetchModelPricingCatalogMock.mockResolvedValue({
       models: [

--- a/src/server/transformers/openai/responses/aggregator.ts
+++ b/src/server/transformers/openai/responses/aggregator.ts
@@ -656,13 +656,21 @@ function mergeImageGenerationFields(
 }
 
 function computeNovelDelta(existingText: string, incomingDelta: string): string {
+  const replayWindowMinLength = 24;
   if (!incomingDelta) return '';
   if (!existingText) return incomingDelta;
-  if (existingText.endsWith(incomingDelta)) return '';
+  if (existingText.endsWith(incomingDelta)) {
+    return incomingDelta.length >= replayWindowMinLength ? '' : incomingDelta;
+  }
   if (incomingDelta.startsWith(existingText)) {
     return incomingDelta.slice(existingText.length);
   }
-  if (existingText.includes(incomingDelta)) return '';
+  if (
+    incomingDelta.length >= replayWindowMinLength
+    && existingText.includes(incomingDelta)
+  ) {
+    return '';
+  }
 
   const maxOverlap = Math.min(existingText.length, incomingDelta.length);
   for (let overlap = maxOverlap; overlap > 0; overlap -= 1) {


### PR DESCRIPTION
## Summary
This change fixes a user-visible truncation bug in the `/v1/responses` compatibility path when the proxy is backed by `/v1/messages` or `/v1/chat/completions` style streaming text deltas.

The root cause was over-aggressive deduplication in `computeNovelDelta(...)` inside the responses aggregator. That helper treated any incoming delta as a replay if the same text had appeared anywhere in the previously accumulated output. In practice, that was safe for large cumulative snapshots and overlapping replay windows, but it was not safe for normal short deltas. When the upstream legitimately emitted the same short token twice, the second one was dropped, so downstream users saw missing text even though the UTF-8 stream itself was healthy.

The fix narrows replay suppression to larger chunks that actually look like cumulative or overlapping window replays, while preserving repeated short deltas as normal output. This keeps the existing protection against cumulative and overlapping text windows, but avoids swallowing legitimate repeated text.

## Testing
- `npm exec vitest -- run --root . src/server/routes/proxy/chat.stream.test.ts src/server/transformers/openai/responses/aggregator.test.ts`
- Added a regression test that verifies repeated short deltas are preserved when `/v1/responses` is synthesized from a `/v1/messages` stream.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed streaming text output to properly preserve short repeated text sequences. Previously, when streaming responses contained repeated short text (e.g., "ha" appearing twice), they were incorrectly consolidated into a single occurrence. Responses now correctly maintain all text occurrences.

* **Tests**
  * Added test coverage to verify repeated short text chunks in streaming responses are preserved correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->