### PR TITLE
fix: restore armv7 docker base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,7 @@
 # syntax=docker/dockerfile:1.7
-FROM node:25-bookworm-slim AS builder
+# Keep the Docker base on Node 22 because the official Node 24/25 slim images
+# no longer publish linux/arm/v7 manifests, which breaks our armv7 Docker jobs.
+FROM node:22-bookworm-slim AS builder
 
 WORKDIR /app
 
@@ -17,7 +19,7 @@ COPY . .
 RUN npm run build:web && npm run build:server
 RUN --mount=type=cache,target=/root/.npm npm prune --omit=dev --no-audit --no-fund
 
-FROM node:25-bookworm-slim
+FROM node:22-bookworm-slim
 
 WORKDIR /app
 

--- a/scripts/dev/docker.workflow.test.ts
+++ b/scripts/dev/docker.workflow.test.ts
@@ -19,10 +19,8 @@ describe('docker workflows', () => {
   it('uses an armv7-capable node base image in the Dockerfile', () => {
     const dockerfile = readFileSync(resolve(process.cwd(), 'docker/Dockerfile'), 'utf8');
 
-    const fromMatches = [...dockerfile.matchAll(/^FROM node:(\d+)-bookworm-slim(?: AS builder)?$/gm)];
-
-    expect(fromMatches).toHaveLength(2);
-    expect(fromMatches[0]?.[1]).toBe(fromMatches[1]?.[1]);
+    expect(dockerfile).toContain('FROM node:22-bookworm-slim AS builder');
+    expect(dockerfile).toContain('FROM node:22-bookworm-slim');
   });
 
   it('keeps server docker builds isolated from desktop packaging dependencies', () => {


### PR DESCRIPTION
## Summary
- restore the Dockerfile base image to `node:22-bookworm-slim` for both stages so `linux/arm/v7` builds can resolve a supported upstream manifest again
- tighten the Docker workflow regression test so it fails if the armv7-capable base image drifts away again
- keep the repo-wide Node 25 CI/runtime alignment unchanged outside the Docker publish path

## Root cause
The `chore: sweep dependabot updates and align Node 25 (#329)` change moved the Dockerfile from `node:22-bookworm-slim` to `node:25-bookworm-slim`. GitHub Actions push runs on `main` then started failing in `Publish Docker Image (armv7)` before any image push step because the official Node 25 slim image no longer publishes a `linux/arm/v7` manifest.

## Verification
- `npx vitest run --root . scripts/dev/docker.workflow.test.ts`
- `npm run repo:drift-check`

## Notes
- I could not run a full local `docker buildx build --platform linux/arm/v7 ...` smoke build because the local Docker daemon was unavailable at `/Users/apple/.orbstack/run/docker.sock`.
- the real Docker publish path is only exercised on `push` to `main`, so the final confirmation will come from post-merge CI on `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker base image from Node.js 25 to Node.js 22 for build and runtime stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->