### PR TITLE
[daily] Wire site-created dialog cancel cleanup

### DIFF
--- a/src/web/components/SiteCreatedModal.test.tsx
+++ b/src/web/components/SiteCreatedModal.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+import { act, create } from 'react-test-renderer';
+import SiteCreatedModal from './SiteCreatedModal.js';
+
+describe('SiteCreatedModal', () => {
+  it('routes native dialog cancel events through onClose cleanup', async () => {
+    const onChoice = vi.fn();
+    const onClose = vi.fn();
+    const root = create(
+      <SiteCreatedModal
+        siteName="Demo Site"
+        platform="new-api"
+        onChoice={onChoice}
+        onClose={onClose}
+      />,
+    );
+
+    const dialog = root.root.findByType('dialog');
+    expect(typeof dialog.props.onCancel).toBe('function');
+
+    const preventDefault = vi.fn();
+    await act(async () => {
+      dialog.props.onCancel({ preventDefault });
+    });
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onChoice).not.toHaveBeenCalled();
+  });
+});

--- a/src/web/components/SiteCreatedModal.tsx
+++ b/src/web/components/SiteCreatedModal.tsx
@@ -27,18 +27,14 @@ export default function SiteCreatedModal({ siteName, platform, onChoice, onClose
     };
   }, []);
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      e.preventDefault();
-      onChoice('later');
-    }
-  };
-
   return (
     <dialog
       ref={dialogRef}
       className="modal"
-      onKeyDown={handleKeyDown}
+      onCancel={(event) => {
+        event.preventDefault();
+        onClose();
+      }}
       onClick={(e) => {
         if (e.target === dialogRef.current) {
           onChoice('later');


### PR DESCRIPTION
## Source Delta Reviewed
- Mainline window reviewed: `03ca1154a0baf6cf8ef332a99c730fbfbe1d56c0..618ca0b9bf32c36670bac1f9fc1d38607616fc22`
- Finding came from the recent site-creation follow-up flow introduced in `9212b76 feat: 新站点创建后显示选择对话框 (#302)`.

## Problem
- After a site is created, the new `SiteCreatedModal` only handled the explicit buttons and backdrop click.
- If the native `<dialog>` cancel path fired, the modal could dismiss without running the cleanup path that closes the editor and reloads the site list.
- That makes the new post-create flow user-visible brittle right after site creation.

## Root Cause
- `SiteCreatedModal` used a React `onKeyDown` Escape handler, but it never wired the dialog's native `cancel` event.
- The parent already provided an `onClose` cleanup callback, but that callback was unreachable from the native cancel path.

## Fix
- Replace the ad-hoc Escape keydown handling with a native `onCancel` handler on the dialog.
- Route that handler through the existing `onClose` cleanup callback.
- Add a focused regression test that asserts native cancel events call `onClose` and do not incorrectly count as an explicit choice.

## Verification
- `NODE_PATH=/Users/apple/code/metapi/node_modules /Users/apple/code/metapi/node_modules/.bin/tsx --tsconfig /Users/apple/.codex/worktrees/9757/metapi-daily-site-created-modal-cancel/tsconfig.json -e "import React from 'react'; import { act, create } from 'react-test-renderer'; import SiteCreatedModal from '/Users/apple/.codex/worktrees/9757/metapi-daily-site-created-modal-cancel/src/web/components/SiteCreatedModal.tsx'; let choiceCalls = 0; let closeCalls = 0; let prevented = 0; const root = create(React.createElement(SiteCreatedModal, { siteName: 'Demo Site', platform: 'new-api', onChoice: () => { choiceCalls += 1; }, onClose: () => { closeCalls += 1; } })); const dialog = root.root.findByType('dialog'); if (typeof dialog.props.onCancel !== 'function') throw new Error('onCancel missing'); (async () => { await act(async () => { dialog.props.onCancel({ preventDefault: () => { prevented += 1; } }); if (prevented !== 1 || closeCalls !== 1 || choiceCalls !== 0) { throw new Error(JSON.stringify({ prevented, closeCalls, choiceCalls })); } }); })().catch((error) => { console.error(error); process.exit(1); });"`

## Residual Risk
- The isolated automation worktree does not have its own `node_modules`, so I could not run the repo-local `vitest` command directly in this worktree.
- Coverage here is intentionally narrow: one dialog event path plus one focused regression test.

## Why This Is Safe To Merge
- Blast radius is limited to one component and one test file.
- No route, API, persistence, or cross-page behavior changed.
- The fix only reconnects an existing cleanup callback to the native dialog event the component had been missing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test coverage for modal behavior and escape key handling

* **Bug Fixes**
  * Updated modal escape key behavior to properly close the dialog

<!-- end of auto-generated comment: release notes by coderabbit.ai -->