### PR TITLE
fix: 修复 No tool call found for function call 

### DIFF
--- a/src/server/transformers/openai/responses/conversion.test.ts
+++ b/src/server/transformers/openai/responses/conversion.test.ts
@@ -863,6 +863,51 @@ describe('convertOpenAiBodyToResponsesBody', () => {
     ]);
   });
 
+  it('drops tool outputs whose prior tool call cannot be converted into an OpenAI-compatible tool call', () => {
+    const result = convertResponsesBodyToOpenAiBody(
+      {
+        model: 'gpt-5',
+        input: [
+          {
+            type: 'function_call',
+            call_id: 'call_invalid',
+            name: '   ',
+            arguments: '{"plan":true}',
+          },
+          {
+            type: 'function_call_output',
+            call_id: 'call_invalid',
+            output: 'unsupported call',
+          },
+          {
+            type: 'message',
+            role: 'assistant',
+            content: [
+              {
+                type: 'output_text',
+                text: 'continue normally',
+              },
+            ],
+          },
+        ],
+      },
+      'gpt-5',
+      false,
+    );
+
+    expect(result.messages).toEqual([
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'text',
+            text: 'continue normally',
+          },
+        ],
+      },
+    ]);
+  });
+
   it('shortens long MCP tool names consistently across tools, tool_choice and assistant tool calls', () => {
     const sharedSuffix = 'server__execute_super_long_nested_tool_name_that_needs_shortening';
     const firstName = `mcp__alpha_workspace__${sharedSuffix}`;

--- a/src/server/transformers/openai/responses/conversion.ts
+++ b/src/server/transformers/openai/responses/conversion.ts
@@ -844,9 +844,14 @@ export function convertResponsesBodyToOpenAiBody(
   const input = stripOrphanedResponsesToolOutputs(normalizedBody.input);
   let functionCallIndex = 0;
   let pendingToolCalls: OpenAiToolCall[] = [];
+  const emittedToolCallIds = new Set<string>();
 
   const flushPendingToolCalls = () => {
     if (pendingToolCalls.length <= 0) return;
+    for (const toolCall of pendingToolCalls) {
+      const callId = asTrimmedString(toolCall.id);
+      if (callId) emittedToolCallIds.add(callId);
+    }
     messages.push({
       role: 'assistant',
       content: '',
@@ -894,7 +899,9 @@ export function convertResponsesBodyToOpenAiBody(
 
     if (itemType === 'function_call_output' || itemType === 'custom_tool_call_output') {
       flushPendingToolCalls();
-      pushToolOutputMessage(item.call_id ?? item.id, item.output ?? item.content);
+      const toolCallId = asTrimmedString(item.call_id ?? item.id);
+      if (!toolCallId || !emittedToolCallIds.has(toolCallId)) return;
+      pushToolOutputMessage(toolCallId, item.output ?? item.content);
       return;
     }
 
@@ -924,7 +931,9 @@ export function convertResponsesBodyToOpenAiBody(
     const content = toOpenAiMessageContent(item.content ?? item.input ?? item);
 
     if (normalizedRole === 'tool') {
-      pushToolOutputMessage(item.tool_call_id ?? item.call_id ?? item.id, item.content);
+      const toolCallId = asTrimmedString(item.tool_call_id ?? item.call_id ?? item.id);
+      if (!toolCallId || !emittedToolCallIds.has(toolCallId)) return;
+      pushToolOutputMessage(toolCallId, item.content);
       return;
     }
 


### PR DESCRIPTION
## 概要

修复了 `/v1/responses` 降级到 `/v1/messages` 时的一处工具调用转换问题。

当由于网络错误等原因（特别是用中转站时），导致会话历史里存在无效的 `function_call`，并且这个调用在转换过程中实际上无法变成有效的 OpenAI 兼容 tool call 时，Metapi 之前仍然可能继续透传对应的 `function_call_output`。这样会在 
 Messages 请求里形成没有对应 `tool_use` 的 `tool_result`，从而导致上游返回 400，例如：

`No tool call found for function call output with call_id ...`

## 改动内容

- 仅记录那些真正成功转换并输出的 tool call ID
- 对 `function_call_output` 和 `role: "tool"` 类型消息增加校验
- 如果其 `call_id` 没有对应到一个真实已输出的 tool call，则直接丢弃
- 补充回归测试，覆盖“前面存在同 `call_id` 的 `function_call`，但该调用本身无效，output 也必须一起丢弃”的场景

## 问题原因

之前的孤儿 output 过滤逻辑只检查：

- 在原始 Responses 输入里是否出现过同 `call_id` 的 `function_call`

但它没有进一步判断：

- 这个 `function_call` 最终是否真的成功转换成了有效的 tool call

因此在异常历史下，可能出现这种情况：

- 无效 `function_call` 在转换时被丢弃
- 对应的 `function_call_output` 却被保留下来
- 最终向上游发送了孤立的 `tool_result`

上游会直接拒绝这种请求。

## 验证情况

- 新增了回归测试覆盖该异常场景
- 手动验证了两类行为：
  - 无效 tool call 对应的 output 会被正确过滤
  - 合法的 tool call / output 配对仍然会正常保留


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced tool call output validation to ensure tool outputs are only emitted when their corresponding tool calls have been successfully processed, preventing orphaned or invalid messages from being sent to the API.

* **Tests**
  * Added test coverage for proper handling of tool output messages when corresponding tool calls cannot be converted to valid format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->