### PR TITLE
[codex] detect latest digest updates in update center

### DIFF
--- a/src/server/shared/updateCenterReminder.ts
+++ b/src/server/shared/updateCenterReminder.ts
@@ -34,10 +34,18 @@ function normalizeStableTag(value?: string | null): string {
   return normalizeStableVersion(value);
 }
 
-function hasSameStableTag(left?: string | null, right?: string | null): boolean {
-  const normalizedLeft = normalizeStableTag(left);
-  const normalizedRight = normalizeStableTag(right);
-  return !!normalizedLeft && normalizedLeft === normalizedRight;
+function hasSameImageTag(left?: string | null, right?: string | null): boolean {
+  const rawLeft = normalizeString(left);
+  const rawRight = normalizeString(right);
+  if (!rawLeft || !rawRight) return false;
+
+  const stableLeft = normalizeStableTag(left);
+  const stableRight = normalizeStableTag(right);
+  if (stableLeft && stableRight) {
+    return stableLeft === stableRight;
+  }
+
+  return rawLeft === rawRight;
 }
 
 export function normalizeStableVersion(value?: string | null): string {
@@ -76,7 +84,7 @@ export function isSameImageTarget(
     return currentDigest === targetDigest;
   }
 
-  return hasSameStableTag(current?.imageTag, target.tag);
+  return hasSameImageTag(current?.imageTag, target.tag);
 }
 
 export function buildUpdateReminderCandidateKey(
@@ -138,7 +146,7 @@ export function resolveUpdateReminderCandidate(input: {
   }
 
   const helperDigest = normalizeDigest(input.helper?.imageDigest);
-  if (dockerDigest && helperDigest && hasSameStableTag(input.helper?.imageTag, dockerTag) && helperDigest !== dockerDigest) {
+  if (dockerDigest && helperDigest && hasSameImageTag(input.helper?.imageTag, dockerTag) && helperDigest !== dockerDigest) {
     return {
       source: 'docker-hub-tag',
       kind: 'new-digest',

--- a/src/shared/updateCenterReminder.test.ts
+++ b/src/shared/updateCenterReminder.test.ts
@@ -73,6 +73,27 @@ describe('updateCenterReminder shared logic', () => {
     }));
   });
 
+  it('treats alias tags like latest as digest-tracked targets when the digest changes', () => {
+    expect(resolveUpdateReminderCandidate({
+      currentVersion: '1.2.3',
+      helper: {
+        imageTag: 'latest',
+        imageDigest: 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      },
+      githubRelease: null,
+      dockerHubTag: {
+        normalizedVersion: 'latest',
+        displayVersion: 'latest @ sha256:bbbbbbbbbbbb',
+        tagName: 'latest',
+        digest: 'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      },
+    })).toEqual(expect.objectContaining({
+      source: 'docker-hub-tag',
+      kind: 'new-digest',
+      candidateKey: 'docker-hub-tag:latest@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    }));
+  });
+
   it('does not return an older GitHub candidate when the helper is already ahead of it', () => {
     expect(resolveUpdateReminderCandidate({
       currentVersion: '1.2.3',

--- a/src/web/pages/helpers/updateCenterPresentation.test.ts
+++ b/src/web/pages/helpers/updateCenterPresentation.test.ts
@@ -61,6 +61,27 @@ describe('updateCenterPresentation', () => {
     expect(state.canDeploy).toBe(true);
   });
 
+  it('treats alias tags like latest as a new digest deploy target when the digest changes', () => {
+    const state = describeDockerDeployState({
+      enabled: true,
+      helperHealthy: true,
+      currentVersion: '1.2.3',
+      helper: {
+        imageTag: 'latest',
+        imageDigest: 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      },
+      candidate: {
+        normalizedVersion: 'latest',
+        tagName: 'latest',
+        digest: 'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      },
+    });
+
+    expect(state.kind).toBe('new-digest');
+    expect(state.canDeploy).toBe(true);
+    expect(state.badgeLabel).toBe('发现新 digest');
+  });
+
   it('does not advertise an older GitHub reminder when the helper is already ahead', () => {
     expect(buildUpdateReminder({
       currentVersion: '1.2.3',


### PR DESCRIPTION
This PR fixes an update-center regression where Docker Hub alias tags such as `latest` were shown as merely deployable instead of being highlighted as a new digest update.

From a user perspective, the update center could show the current runtime image as `latest @ sha256:ec94...` and Docker Hub as `latest @ sha256:f96f...`, but the UI would not surface an update reminder even though the remote digest had advanced. That made the update center look stale and hid the main signal users care about when they follow mutable container tags.

The root cause was that the shared reminder logic only treated tags as comparable when they could be normalized into stable semantic versions. Alias tags like `latest` and `main` therefore fell through the stable-tag comparison path, which prevented the code from recognizing a same-tag, different-digest update target. The Docker status card then degraded to a generic available state instead of reporting a new digest.

The fix introduces a shared image-tag comparison helper that still prefers normalized stable-version matching when both sides are semver-like, but falls back to exact raw tag matching for alias tags. With that in place, same-tag digest changes on Docker Hub are now treated as `new-digest` candidates consistently across the shared reminder logic and the update-center presentation layer.

I also added focused regression tests for the exact `latest + changed digest` scenario in both the shared reminder tests and the update-center presentation tests so this behavior stays covered going forward.

Validation:
- `npm test -- src/shared/updateCenterReminder.test.ts src/web/pages/helpers/updateCenterPresentation.test.ts`
- `npm run repo:drift-check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of Docker image updates when using alias tags (e.g., "latest"). The system now correctly identifies new image digests even when the helper tag differs from the target tag, ensuring you're notified of available updates more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->