### PR TITLE
[codex] fix anyrouter checkin session failure classification

### DIFF
--- a/src/server/services/platforms/newApi.test.ts
+++ b/src/server/services/platforms/newApi.test.ts
@@ -17,6 +17,7 @@ const COOKIE_REQUIRES_USER_TOKEN = 'cookie-requires-user';
 const CHECKIN_ALREADY_TOKEN = 'checkin-already-token';
 const CHECKIN_INVALID_URL_TOKEN = 'checkin-invalid-url-token';
 const CHECKIN_INVALID_URL_EXPIRED_SESSION_TOKEN = 'checkin-invalid-url-expired-session-token';
+const CHECKIN_INVALID_URL_FORBIDDEN_SESSION_TOKEN = 'checkin-invalid-url-forbidden-session-token';
 const CHECKIN_CLOUDFLARE_530_TOKEN = 'checkin-cloudflare-530-token';
 const BALANCE_FAIL_TOKEN = 'balance-fail-token';
 const GROUP_EXPIRED_TOKEN = 'group-expired-token';
@@ -355,9 +356,25 @@ describe('NewApiAdapter', () => {
           return;
         }
 
+        if (
+          typeof req.headers.cookie === 'string'
+          && (
+            req.headers.cookie.includes(`session=${CHECKIN_INVALID_URL_TOKEN}`)
+            || req.headers.cookie.includes(`token=${CHECKIN_INVALID_URL_TOKEN}`)
+          )
+        ) {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ success: false, message: 'temporary self probe failure' }));
+          return;
+        }
         if (typeof req.headers.cookie === 'string' && req.headers.cookie.includes(`session=${CHECKIN_INVALID_URL_EXPIRED_SESSION_TOKEN}`)) {
           res.writeHead(200, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ success: false, message: '无权进行此操作，未登录且未提供 access token' }));
+          return;
+        }
+        if (typeof req.headers.cookie === 'string' && req.headers.cookie.includes(`session=${CHECKIN_INVALID_URL_FORBIDDEN_SESSION_TOKEN}`)) {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ success: false, message: 'forbidden' }));
           return;
         }
 
@@ -388,6 +405,16 @@ describe('NewApiAdapter', () => {
           return;
         }
         if (typeof req.headers.cookie === 'string' && req.headers.cookie.includes(`session=${CHECKIN_INVALID_URL_EXPIRED_SESSION_TOKEN}`)) {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: { message: 'Invalid URL (POST /api/user/checkin)' } }));
+          return;
+        }
+        if (typeof req.headers.authorization === 'string' && req.headers.authorization === `Bearer ${CHECKIN_INVALID_URL_FORBIDDEN_SESSION_TOKEN}`) {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ error: { message: 'Invalid URL (POST /api/user/checkin)' } }));
+          return;
+        }
+        if (typeof req.headers.cookie === 'string' && req.headers.cookie.includes(`session=${CHECKIN_INVALID_URL_FORBIDDEN_SESSION_TOKEN}`)) {
           res.writeHead(200, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ error: { message: 'Invalid URL (POST /api/user/checkin)' } }));
           return;
@@ -439,6 +466,11 @@ describe('NewApiAdapter', () => {
 
       if (req.url === '/api/user/sign_in') {
         if (typeof req.headers.cookie === 'string' && req.headers.cookie.includes(`session=${CHECKIN_INVALID_URL_EXPIRED_SESSION_TOKEN}`)) {
+          res.writeHead(401, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({}));
+          return;
+        }
+        if (typeof req.headers.cookie === 'string' && req.headers.cookie.includes(`session=${CHECKIN_INVALID_URL_FORBIDDEN_SESSION_TOKEN}`)) {
           res.writeHead(401, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({}));
           return;
@@ -645,6 +677,15 @@ describe('NewApiAdapter', () => {
 
     expect(result.success).toBe(false);
     expect(result.message).toContain('access token');
+    expect(result.message).not.toContain('Invalid URL');
+  });
+
+  it('treats forbidden self probe responses as cookie session auth failures', async () => {
+    const adapter = new NewApiAdapter();
+    const result = await adapter.checkin(baseUrl, CHECKIN_INVALID_URL_FORBIDDEN_SESSION_TOKEN, 131936);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('forbidden');
     expect(result.message).not.toContain('Invalid URL');
   });
 

--- a/src/server/services/platforms/newApi.ts
+++ b/src/server/services/platforms/newApi.ts
@@ -648,10 +648,13 @@ export class NewApiAdapter extends BasePlatformAdapter {
     const text = message.toLowerCase();
     return (
       text.includes('access token') ||
+      text.includes('unauthorized') ||
+      text.includes('forbidden') ||
       text.includes('new-api-user') ||
       text.includes('user id') ||
       text.includes('invalid token') ||
       text.includes('expired') ||
+      text.includes('无权') ||
       text.includes('未登录') ||
       text.includes('未提供') ||
       text.includes('未授权') ||


### PR DESCRIPTION
## Summary

This fixes a misleading AnyRouter checkin failure mode in Metapi.

When an upstream returns `Invalid URL (POST /api/user/checkin)`, the adapter used to treat that as an unsupported checkin endpoint and stop there. In practice, AnyRouter can return that response even when the underlying cookie session has already expired, which hides the real cause from users and prevents the existing session-recovery path from engaging.

This patch keeps the existing fallback flow, but after the cookie fallback is exhausted it now probes `/api/user/self` with the same cookie candidates. If that probe shows a real session-auth failure, the adapter returns the auth failure message instead of the misleading `Invalid URL` result.

## User impact

Before this change, expired AnyRouter sessions could be logged as `Invalid URL (POST /api/user/checkin)` and appear like a site capability regression. After this change, the runtime reports the real session failure, which lets auto-relogin flows trigger where configured and gives operators a correct reason when a manual rebind is needed.

## Validation

- `npm test -- --run src/server/services/platforms/newApi.test.ts src/server/services/checkinService.autoRelogin.test.ts`
- `npm run repo:drift-check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests covering expired and forbidden session-token scenarios and their authentication outcomes.

* **Bug Fixes**
  * Improved detection and handling of cookie/session authentication failures across sign-in, self-probe, and check-in flows.
  * Check-in now reports cookie-session failure messages (when present) instead of falling back to an invalid-endpoint error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->