### PR TITLE
[daily] preserve both site-created next steps

### DIFF
--- a/src/web/components/SiteCreatedModal.test.tsx
+++ b/src/web/components/SiteCreatedModal.test.tsx
@@ -1,6 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
-import { act, create } from 'react-test-renderer';
+import { act, create, type ReactTestInstance } from 'react-test-renderer';
 import SiteCreatedModal from './SiteCreatedModal.js';
+
+function collectText(node: ReactTestInstance): string {
+  return (node.children || []).map((child) => {
+    if (typeof child === 'string') return child;
+    return collectText(child);
+  }).join('');
+}
 
 describe('SiteCreatedModal', () => {
   it('routes native dialog cancel events through onClose cleanup', async () => {
@@ -25,5 +32,36 @@ describe('SiteCreatedModal', () => {
     expect(preventDefault).toHaveBeenCalledTimes(1);
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(onChoice).not.toHaveBeenCalled();
+  });
+
+  it('keeps both next-step actions visible while promoting API key flow for api-key-first presets', async () => {
+    const onChoice = vi.fn();
+    const onClose = vi.fn();
+    const root = create(
+      <SiteCreatedModal
+        siteName="CodingPlan"
+        initializationPresetId="codingplan-openai"
+        initialSegment="apikey"
+        onChoice={onChoice}
+        onClose={onClose}
+      />,
+    );
+
+    const choiceButtons = root.root.findAll((node) => (
+      node.type === 'button'
+      && typeof node.props.onClick === 'function'
+      && collectText(node) !== '稍后配置'
+    ));
+
+    expect(choiceButtons.map((button) => collectText(button))).toEqual([
+      '添加 API Key（推荐）',
+      '添加账号（用户名密码登录）',
+    ]);
+
+    await act(async () => {
+      choiceButtons[1]!.props.onClick();
+    });
+
+    expect(onChoice).toHaveBeenCalledWith('session');
   });
 });

--- a/src/web/components/SiteCreatedModal.tsx
+++ b/src/web/components/SiteCreatedModal.tsx
@@ -25,6 +25,31 @@ export default function SiteCreatedModal({
     || (apiKeyFirst
       ? '该平台更适合直接通过 Base URL + API Key 接入，后续再补模型初始化。'
       : '接下来您可以继续补充登录连接或 API Key。');
+  const actionButtons = apiKeyFirst
+    ? [
+      {
+        choice: 'apikey' as const,
+        className: 'btn btn-primary btn-block',
+        label: '添加 API Key（推荐）',
+      },
+      {
+        choice: 'session' as const,
+        className: 'btn btn-outline btn-block',
+        label: '添加账号（用户名密码登录）',
+      },
+    ]
+    : [
+      {
+        choice: 'session' as const,
+        className: 'btn btn-primary btn-block',
+        label: '添加账号（用户名密码登录）',
+      },
+      {
+        choice: 'apikey' as const,
+        className: 'btn btn-outline btn-block',
+        label: '添加 API Key',
+      },
+    ];
 
   useEffect(() => {
     const dialog = dialogRef.current;
@@ -85,29 +110,15 @@ export default function SiteCreatedModal({
         )}
 
         <div className="modal-action" style={{ flexDirection: 'column', gap: 12 }}>
-          {apiKeyFirst ? (
+          {actionButtons.map((action) => (
             <button
-              className="btn btn-primary btn-block"
-              onClick={() => onChoice('apikey')}
+              key={action.choice}
+              className={action.className}
+              onClick={() => onChoice(action.choice)}
             >
-              添加 API Key（推荐）
+              {action.label}
             </button>
-          ) : (
-            <button
-              className="btn btn-primary btn-block"
-              onClick={() => onChoice('session')}
-            >
-              添加账号（用户名密码登录）
-            </button>
-          )}
-          {!apiKeyFirst && (
-            <button
-              className="btn btn-outline btn-block"
-              onClick={() => onChoice('apikey')}
-            >
-              添加 API Key
-            </button>
-          )}
+          ))}
           <button
             className="btn btn-ghost btn-block"
             onClick={() => onChoice('later')}


### PR DESCRIPTION
## Source Delta Reviewed
- `6e04db61ddd09b16ac47e8ffb85237465e276c26..0de9c5e3f142728659794216e43626ac25bc59c9`

## Problem
- The site-initialization flow added in `#351` treats API-key-first presets as exclusive in `SiteCreatedModal`, so users lose the session/account path immediately after creating those sites.

## Root Cause
- `initialSegment` is a guidance signal, but the modal rendered it as a hard mode switch and dropped the secondary action.

## Fix
- Always render both next-step buttons in the success modal.
- Keep API key first and marked as recommended for API-key-first presets, while retaining the session option as the secondary action.

## Verification
- `NODE_PATH=/Users/apple/code/metapi/node_modules /Users/apple/code/metapi/node_modules/.bin/vitest run src/web/components/SiteCreatedModal.test.tsx`

## Residual Risk
- This change only restores the missing modal action; it does not alter preset detection, redirects, or account creation APIs.

## Why This Is Safe To Merge
- The patch is limited to one web component and one focused regression test, with no schema, server, or routing changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization in the site creation modal for enhanced maintainability. Functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->