### PR TITLE
[codex] normalize anyrouter balance refresh challenge errors

### DIFF
--- a/src/server/services/platforms/newApi.test.ts
+++ b/src/server/services/platforms/newApi.test.ts
@@ -20,6 +20,7 @@ const CHECKIN_INVALID_URL_EXPIRED_SESSION_TOKEN = 'checkin-invalid-url-expired-s
 const CHECKIN_INVALID_URL_FORBIDDEN_SESSION_TOKEN = 'checkin-invalid-url-forbidden-session-token';
 const CHECKIN_CLOUDFLARE_530_TOKEN = 'checkin-cloudflare-530-token';
 const BALANCE_FAIL_TOKEN = 'balance-fail-token';
+const BALANCE_SHIELD_FAILURE_TOKEN = 'balance-shield-failure-token';
 const GROUP_EXPIRED_TOKEN = 'group-expired-token';
 const SHIELD_LOGIN_USERNAME = 'shield-user';
 const SHIELD_LOGIN_PASSWORD = 'shield-pass';
@@ -257,9 +258,35 @@ describe('NewApiAdapter', () => {
       }
 
       if (req.url === '/api/user/self') {
+        if (typeof req.headers.authorization === 'string' && req.headers.authorization === `Bearer ${BALANCE_SHIELD_FAILURE_TOKEN}`) {
+          res.writeHead(200, {
+            'Content-Type': 'text/html; charset=utf-8',
+            'Set-Cookie': `cdn_sec_tc=${SHIELD_LOGIN_COOKIE}; Path=/; HttpOnly`,
+          });
+          res.end(ANYROUTER_CHALLENGE_HTML);
+          return;
+        }
+
         if (typeof req.headers.authorization === 'string' && req.headers.authorization === `Bearer ${BALANCE_FAIL_TOKEN}`) {
           res.writeHead(200, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ success: false, message: '无权进行此操作，access token 无效' }));
+          return;
+        }
+
+        if (
+          typeof req.headers.cookie === 'string' &&
+          (
+            req.headers.cookie.includes(`session=${BALANCE_SHIELD_FAILURE_TOKEN}`) ||
+            req.headers.cookie.includes(`token=${BALANCE_SHIELD_FAILURE_TOKEN}`)
+          )
+        ) {
+          if (!req.headers.cookie.includes(`acw_sc__v2=${ANYROUTER_CHALLENGE_ACW}`)) {
+            res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+            res.end(ANYROUTER_CHALLENGE_HTML);
+            return;
+          }
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ success: false, message: '无权进行此操作，未登录且未提供 access token' }));
           return;
         }
 
@@ -661,6 +688,13 @@ describe('NewApiAdapter', () => {
     const adapter = new NewApiAdapter();
 
     await expect(adapter.getBalance(baseUrl, BALANCE_FAIL_TOKEN)).rejects.toThrow('access token');
+  });
+
+  it('prefers post-challenge cookie failure over raw html parse error when reading balance', async () => {
+    const adapter = new AnyRouterAdapter();
+
+    await expect(adapter.getBalance(baseUrl, BALANCE_SHIELD_FAILURE_TOKEN)).rejects
+      .toThrow('无权进行此操作，未登录且未提供 access token');
   });
 
   it('preserves nested checkin error message instead of generic fallback', async () => {

--- a/src/server/services/platforms/newApi.ts
+++ b/src/server/services/platforms/newApi.ts
@@ -549,6 +549,15 @@ export class NewApiAdapter extends BasePlatformAdapter {
     return '';
   }
 
+  private isHtmlJsonParseErrorMessage(message?: string | null): boolean {
+    if (!message) return false;
+    const text = message.toLowerCase();
+    return (
+      text.includes("unexpected token '<'")
+      || (text.includes('not valid json') && (text.includes('<html') || text.includes('<script')))
+    );
+  }
+
   private isShieldChallenge(contentType: string, text: string): boolean {
     const ct = (contentType || '').toLowerCase();
     if (ct.includes('text/html') && /var\s+arg1\s*=|acw_sc__v2|cdn_sec_tc|<script/i.test(text)) {
@@ -1162,10 +1171,15 @@ export class NewApiAdapter extends BasePlatformAdapter {
     const resolvedUserId = platformUserId || await this.discoverUserId(baseUrl, accessToken);
     let failureMessage: string | null = null;
     const rememberFailure = (message?: string | null) => {
-      if (failureMessage) return;
       const text = typeof message === 'string' ? message.trim() : '';
       if (!text) return;
-      failureMessage = text;
+      if (!failureMessage) {
+        failureMessage = text;
+        return;
+      }
+      if (this.isHtmlJsonParseErrorMessage(failureMessage) && !this.isHtmlJsonParseErrorMessage(text)) {
+        failureMessage = text;
+      }
     };
 
     try {


### PR DESCRIPTION
## Summary

This PR fixes the AnyRouter account refresh error shown in Connection Management when clicking the row-level `刷新` action.

In the current UI that action hits the balance refresh path (`POST /api/accounts/:id/balance`), not model sync. On cita production, the AnyRouter upstream currently returns an anti-bot challenge HTML page from `/api/user/self`, which caused Metapi to surface the raw JSON parse failure:

`Unexpected token '<', "<html><scr"... is not valid JSON`

## User Impact

Before this change, users saw a low-level parser error when refreshing an AnyRouter account from Connection Management. The message looked like a frontend bug even though the real failure was upstream challenge handling followed by a more specific session/auth rejection.

After this change, balance refresh no longer gets stuck on the first HTML parse noise. If the cookie-based retry path reaches a clearer upstream failure, Metapi now returns that more actionable message instead of the raw `Unexpected token '<'` parse error.

## Root Cause

`NewApiAdapter.getBalance()` records the first failure message it sees.

For AnyRouter challenge flows, the first failure can be the raw HTML-to-JSON parse error from `/api/user/self`. The adapter then retries through the cookie challenge flow, but even if that later attempt reaches a more precise upstream response, the earlier parse error still wins and is thrown back to the API route.

## Fix

The balance refresh path now treats the challenge-page parse error as lower-priority noise.

If a later retry produces a more specific non-HTML failure message, that message replaces the original parse error and becomes the final error returned to the user.

A regression test was added to cover the exact sequence:

1. direct balance read returns AnyRouter challenge HTML
2. cookie retry solves the challenge and reaches the upstream
3. upstream returns a specific auth/session failure
4. Metapi returns that specific failure instead of `Unexpected token '<'`

## Validation

I ran:

- `npm test -- src/server/services/platforms/newApi.test.ts`
- `npm run repo:drift-check`

Both passed on the clean latest-main worktree used for this PR.
