### PR TITLE
[codex] follow up route priority left rail drag preview

### DIFF
--- a/src/web/pages/token-routes/RouteCard.test.tsx
+++ b/src/web/pages/token-routes/RouteCard.test.tsx
@@ -213,5 +213,20 @@ describe('RouteCard', () => {
     expect(text).toContain('P1 · 1');
     expect(text).toContain('user_a');
     expect(text).toContain('user_b');
+
+    const p0RailNode = root.root.find((node) => (
+      node.type === 'div'
+      && collectText(node) === 'P0 · 1'
+      && node.props?.style?.borderRadius === 999
+    ));
+    const p1RailNode = root.root.find((node) => (
+      node.type === 'div'
+      && collectText(node) === 'P1 · 1'
+      && node.props?.style?.borderRadius === 999
+    ));
+
+    expect(p0RailNode.props.style.background).not.toBe('var(--color-bg)');
+    expect(p1RailNode.props.style.background).not.toBe('var(--color-bg)');
+    expect(p0RailNode.props.style.color).not.toBe(p1RailNode.props.style.color);
   });
 });

--- a/src/web/pages/token-routes/RouteCard.tsx
+++ b/src/web/pages/token-routes/RouteCard.tsx
@@ -42,11 +42,13 @@ import {
   isExplicitGroupRoute,
   resolveRouteTitle,
   resolveRouteIcon,
+  getPriorityTagStyle,
 } from './utils.js';
 import {
   buildPriorityBuckets,
 } from './priorityBuckets.js';
 import {
+  buildPriorityDragPreviewStyle,
   buildPriorityRailSections,
   createPriorityRailNewLayerId,
   isPriorityRailNewLayerId,
@@ -160,15 +162,18 @@ function PriorityRailNewLayerRow({
 function PriorityDragPreview({
   channel,
   displayPriority,
+  activeRowWidth,
 }: {
   channel: RouteChannel;
   displayPriority: number;
+  activeRowWidth?: number | null;
 }) {
   return (
     <div
       style={{
         display: 'inline-flex',
         alignItems: 'center',
+        justifyContent: 'space-between',
         gap: 8,
         padding: '8px 12px',
         borderRadius: 'var(--radius-md)',
@@ -177,6 +182,7 @@ function PriorityDragPreview({
         boxShadow: 'var(--shadow-sm)',
         color: 'var(--color-text-primary)',
         fontSize: 12,
+        ...buildPriorityDragPreviewStyle(activeRowWidth),
       }}
     >
       <span
@@ -275,6 +281,7 @@ function RouteCardInner({
   const priorityBuckets = buildPriorityBuckets(channels || []);
   const priorityRailSections = buildPriorityRailSections(channels || []);
   const [activeDragChannelId, setActiveDragChannelId] = useState<number | null>(null);
+  const [activeDragRowWidth, setActiveDragRowWidth] = useState<number | null>(null);
   const [dragOverId, setDragOverId] = useState<string | number | null>(null);
   const activeDragChannel = activeDragChannelId == null
     ? null
@@ -291,12 +298,14 @@ function RouteCardInner({
 
   const clearDragState = () => {
     setActiveDragChannelId(null);
+    setActiveDragRowWidth(null);
     setDragOverId(null);
   };
 
   const handleDragStart = (event: DragStartEvent) => {
     const nextId = Number(event.active.id);
     setActiveDragChannelId(Number.isFinite(nextId) ? nextId : null);
+    setActiveDragRowWidth(event.active.rect.current.initial?.width ?? null);
     setDragOverId(event.active.id);
   };
 
@@ -670,6 +679,7 @@ function RouteCardInner({
                   const hoveredExistingLayer = activeDragChannelId != null && hoveredBucketIndex === bucketIndex;
                   const hoveredCrossLayer = hoveredExistingLayer && activeDragBucketIndex !== bucketIndex;
                   const hoveredNewLayer = activeDragChannelId != null && hoveredNewLayerBucketIndex === bucketIndex;
+                  const railTone = getPriorityTagStyle(bucketIndex);
 
                   return (
                     <div
@@ -729,11 +739,11 @@ function RouteCardInner({
                                 minWidth: 72,
                                 padding: '6px 10px',
                                 borderRadius: 999,
-                                border: `1px solid ${hoveredExistingLayer ? 'var(--color-primary)' : 'var(--color-border)'}`,
+                                border: `1px solid ${hoveredExistingLayer ? 'var(--color-primary)' : 'color-mix(in srgb, currentColor 24%, transparent)'}`,
                                 background: hoveredExistingLayer
                                   ? 'color-mix(in srgb, var(--color-primary) 10%, var(--color-bg))'
-                                  : 'var(--color-bg)',
-                                color: hoveredExistingLayer ? 'var(--color-primary)' : 'var(--color-text-secondary)',
+                                  : railTone.background,
+                                color: hoveredExistingLayer ? 'var(--color-primary)' : railTone.color,
                                 fontSize: 11,
                                 fontWeight: 600,
                                 textAlign: 'center',
@@ -801,6 +811,7 @@ function RouteCardInner({
                 <PriorityDragPreview
                   channel={activeDragChannel}
                   displayPriority={Math.max(0, activeDragBucketIndex)}
+                  activeRowWidth={activeDragRowWidth}
                 />
               ) : null}
             </DragOverlay>

--- a/src/web/pages/token-routes/SortableChannelRow.tsx
+++ b/src/web/pages/token-routes/SortableChannelRow.tsx
@@ -50,7 +50,7 @@ export function SortableChannelRow({
   const rowStyle: CSSProperties = {
     transform: CSS.Transform.toString(transform),
     transition,
-    opacity: isDragging ? 0.72 : channel.enabled === false ? 0.5 : 1,
+    opacity: isDragging ? (mobile ? 0.72 : 0) : channel.enabled === false ? 0.5 : 1,
     zIndex: isDragging ? 10 : 1,
     display: 'grid',
     gridTemplateColumns: managementLocked || mobile ? 'minmax(0, 1fr)' : 'minmax(0, 1fr) auto auto auto',

--- a/src/web/pages/token-routes/priorityRail.test.ts
+++ b/src/web/pages/token-routes/priorityRail.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   applyPriorityRailDrop,
+  buildPriorityDragPreviewStyle,
   buildPriorityRailDragTargets,
   buildPriorityRailSections,
   createPriorityRailNewLayerId,
@@ -73,5 +74,12 @@ describe('priorityRail helpers', () => {
       { id: 12, priority: 1 },
       { id: 21, priority: 2 },
     ]);
+  });
+
+  it('uses the active row width for drag preview alignment when available', () => {
+    expect(buildPriorityDragPreviewStyle(640)).toMatchObject({
+      width: 640,
+      maxWidth: 'calc(100vw - 32px)',
+    });
   });
 });

--- a/src/web/pages/token-routes/priorityRail.ts
+++ b/src/web/pages/token-routes/priorityRail.ts
@@ -1,3 +1,4 @@
+import type { CSSProperties } from 'react';
 import type { PriorityRailDragTarget, PriorityRailSection } from './types.js';
 
 type PriorityRailChannelLike = {
@@ -116,4 +117,12 @@ export function applyPriorityRailDrop<T extends PriorityRailChannelLike>(
         : channel
     )),
   );
+}
+
+export function buildPriorityDragPreviewStyle(activeRowWidth?: number | null): CSSProperties {
+  const resolvedWidth = Number.isFinite(activeRowWidth ?? Number.NaN) ? activeRowWidth ?? undefined : undefined;
+  return {
+    width: resolvedWidth,
+    maxWidth: 'calc(100vw - 32px)',
+  };
 }


### PR DESCRIPTION
## Summary

This is a follow-up to #371.

The left priority rail itself is already merged, but two interaction details still felt wrong in use:

- the drag preview could appear offset from the cursor, which made the drag feel like it was not attached to the mouse
- the rail nodes for `P0 / P1 / P2` had become too neutral, so the priority hierarchy lost its quick visual scan value

## What Changed

- use the active row width when rendering the drag preview overlay so the preview stays visually anchored to the dragged row
- hide the live desktop row while dragging to avoid a double-image effect
- restore priority color hierarchy to the desktop rail nodes using the same priority tone logic already used elsewhere in the route UI
- add focused regression coverage for the drag preview style helper and rail node color treatment

## Validation

```bash
npm test -- src/web/pages/token-routes/RouteCard.test.tsx src/web/pages/token-routes/priorityRail.test.ts src/web/pages/tokenRoutes.mobile-layout.test.tsx src/web/pages/tokenRoutes.group-collapse.test.tsx src/web/pages/tokenRoutes.mobile.test.tsx
npm run typecheck:web && npm run typecheck:web:test
```

Both checks passed locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined priority rail styling with context-aware color schemes based on priority levels.
  * Enhanced drag-and-drop visual feedback with differentiated row opacity behavior between mobile and desktop devices.
  * Improved drag preview sizing to align with the active row width for better visual consistency during drag operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->