### PR TITLE
[codex] fix expired connection health recovery

### DIFF
--- a/src/server/routes/api/accounts.apikey-recovery.test.ts
+++ b/src/server/routes/api/accounts.apikey-recovery.test.ts
@@ -109,4 +109,108 @@ describe('accounts api key recovery', { timeout: 15_000 }, () => {
     const routeChannels = await db.select().from(schema.routeChannels).all();
     expect(routeChannels.some((channel) => channel.accountId === account.id)).toBe(true);
   });
+
+  it('keeps an expired API key connection pinned when only status is edited', async () => {
+    const site = await db.insert(schema.sites).values({
+      name: 'Pinned Site',
+      url: 'https://pinned.example.com',
+      platform: 'new-api',
+      status: 'active',
+    }).returning().get();
+
+    const account = await db.insert(schema.accounts).values({
+      siteId: site.id,
+      username: 'status-only-user',
+      accessToken: '',
+      apiToken: 'sk-still-expired',
+      status: 'expired',
+      checkinEnabled: false,
+      extraConfig: JSON.stringify({ credentialMode: 'apikey' }),
+    }).returning().get();
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: `/api/accounts/${account.id}`,
+      payload: {
+        username: 'status-only-user-edited',
+        status: 'active',
+        checkinEnabled: false,
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      id: account.id,
+      username: 'status-only-user-edited',
+      status: 'expired',
+    });
+    expect(getModelsMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps the new api key but preserves expired status and previous availability when recovery fails', async () => {
+    getModelsMock.mockRejectedValueOnce(new Error('upstream unavailable'));
+
+    const site = await db.insert(schema.sites).values({
+      name: 'Recovery Failure Site',
+      url: 'https://recovery-failure.example.com',
+      platform: 'new-api',
+      status: 'active',
+    }).returning().get();
+
+    const account = await db.insert(schema.accounts).values({
+      siteId: site.id,
+      username: 'expired-apikey-user',
+      accessToken: '',
+      apiToken: 'sk-old-expired-key',
+      status: 'expired',
+      checkinEnabled: false,
+      extraConfig: JSON.stringify({ credentialMode: 'apikey' }),
+    }).returning().get();
+
+    await db.insert(schema.modelAvailability).values({
+      accountId: account.id,
+      modelName: 'gpt-4.1',
+      available: true,
+      latencyMs: 100,
+      checkedAt: '2026-04-01T10:00:00.000Z',
+    }).run();
+
+    const response = await app.inject({
+      method: 'PUT',
+      url: `/api/accounts/${account.id}`,
+      payload: {
+        username: 'expired-apikey-user',
+        status: 'expired',
+        checkinEnabled: false,
+        accessToken: '',
+        apiToken: 'sk-new-invalid-key',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toMatchObject({
+      id: account.id,
+      status: 'expired',
+      apiToken: 'sk-new-invalid-key',
+    });
+
+    const latest = await db.select().from(schema.accounts).where(eq(schema.accounts.id, account.id)).get();
+    expect(latest).toMatchObject({
+      id: account.id,
+      status: 'expired',
+      apiToken: 'sk-new-invalid-key',
+    });
+
+    const availabilityRows = await db.select().from(schema.modelAvailability)
+      .where(eq(schema.modelAvailability.accountId, account.id))
+      .all();
+    expect(availabilityRows).toHaveLength(1);
+    expect(availabilityRows[0]).toMatchObject({
+      accountId: account.id,
+      modelName: 'gpt-4.1',
+    });
+
+    const routeChannels = await db.select().from(schema.routeChannels).all();
+    expect(routeChannels.some((channel) => channel.accountId === account.id)).toBe(false);
+  });
 });

--- a/src/server/routes/api/accounts.ts
+++ b/src/server/routes/api/accounts.ts
@@ -20,6 +20,7 @@ import {
   type AccountCredentialMode,
 } from '../../services/accountExtraConfig.js';
 import { encryptAccountPassword } from '../../services/accountCredentialService.js';
+import { applyAccountUpdateWorkflow } from '../../services/accountUpdateWorkflow.js';
 import { startBackgroundTask } from '../../services/backgroundTaskService.js';
 import { parseCheckinRewardAmount } from '../../services/checkinRewardParser.js';
 import { estimateRewardWithTodayIncomeFallback } from '../../services/todayIncomeRewardService.js';
@@ -1405,49 +1406,32 @@ export async function accountsRoutes(app: FastifyInstance) {
     const nextStatus = typeof updates.status === 'string' && updates.status.trim()
       ? updates.status.trim()
       : (account.status || 'active');
-    const credentialFieldsTouched =
-      Object.prototype.hasOwnProperty.call(body, 'accessToken')
-      || Object.prototype.hasOwnProperty.call(body, 'apiToken')
-      || wantsManagedSub2ApiAuthPatch;
     const needsModelRefresh =
       Object.prototype.hasOwnProperty.call(body, 'accessToken')
       || Object.prototype.hasOwnProperty.call(body, 'apiToken')
       || Object.prototype.hasOwnProperty.call(body, 'extraConfig')
       || Object.prototype.hasOwnProperty.call(body, 'proxyUrl')
       || wantsManagedSub2ApiAuthPatch;
-    const shouldAttemptExpiredApiKeyRecovery =
+    const isExpiredApiKeyAccount =
       account.status === 'expired'
       && nextCredentialMode === 'apikey'
-      && credentialFieldsTouched
       && nextStatus !== 'disabled';
+    const shouldAttemptExpiredApiKeyRecovery =
+      isExpiredApiKeyAccount
+      && needsModelRefresh;
 
-    if (shouldAttemptExpiredApiKeyRecovery) {
-      updates.status = 'expired';
-    }
-
-    updates.updatedAt = new Date().toISOString();
-    await db.update(schema.accounts).set(updates).where(eq(schema.accounts.id, id)).run();
-
-    const convergence = await convergeAccountMutation({
+    const { account: updatedAccount } = await applyAccountUpdateWorkflow({
       accountId: id,
+      updates,
       preferredApiToken: nextCredentialMode !== 'apikey' ? nextApiToken : null,
-      defaultTokenSource: 'manual',
       refreshModels: needsModelRefresh,
+      preserveExpiredStatus: isExpiredApiKeyAccount,
       allowInactiveModelRefresh: shouldAttemptExpiredApiKeyRecovery,
-      rebuildRoutes: false,
+      reactivateAfterSuccessfulModelRefresh: shouldAttemptExpiredApiKeyRecovery,
       continueOnError: true,
     });
 
-    if (shouldAttemptExpiredApiKeyRecovery && convergence.modelRefreshResult?.status === 'success') {
-      await db.update(schema.accounts).set({
-        status: 'active',
-        updatedAt: new Date().toISOString(),
-      }).where(eq(schema.accounts.id, id)).run();
-    }
-
-    await rebuildRoutesBestEffort();
-
-    return await db.select().from(schema.accounts).where(eq(schema.accounts.id, id)).get();
+    return updatedAccount;
   });
 
   // Delete an account

--- a/src/server/services/accountHealthService.test.ts
+++ b/src/server/services/accountHealthService.test.ts
@@ -24,7 +24,7 @@ describe('accountHealthService', () => {
     const health = buildRuntimeHealthForAccount({
       accountStatus: 'expired',
       siteStatus: 'active',
-      extraConfig: null,
+      extraConfig: JSON.stringify({ credentialMode: 'apikey' }),
       sessionCapable: false,
     });
 
@@ -41,6 +41,7 @@ describe('accountHealthService', () => {
       accountStatus: 'expired',
       siteStatus: 'active',
       extraConfig: JSON.stringify({
+        credentialMode: 'apikey',
         runtimeHealth: {
           state: 'healthy',
           reason: '模型探测成功',
@@ -57,6 +58,25 @@ describe('accountHealthService', () => {
       source: 'auth',
     });
     expect(health.reason).toContain('连接已过期');
+  });
+
+  it('uses a generic expired-credential message for oauth-backed accounts', () => {
+    const health = buildRuntimeHealthForAccount({
+      accountStatus: 'expired',
+      siteStatus: 'active',
+      extraConfig: JSON.stringify({
+        oauth: {
+          provider: 'codex',
+        },
+      }),
+      sessionCapable: false,
+    });
+
+    expect(health).toMatchObject({
+      state: 'unhealthy',
+      source: 'auth',
+      reason: '连接凭证已过期，请更新凭证',
+    });
   });
 
   it('ignores stored auth failures for proxy-only accounts', () => {

--- a/src/server/services/accountHealthService.ts
+++ b/src/server/services/accountHealthService.ts
@@ -1,6 +1,10 @@
 import { eq } from 'drizzle-orm';
 import { db, schema } from '../db/index.js';
-import { mergeAccountExtraConfig } from './accountExtraConfig.js';
+import {
+  getCredentialModeFromExtraConfig,
+  hasOauthProvider,
+  mergeAccountExtraConfig,
+} from './accountExtraConfig.js';
 
 export type RuntimeHealthState = 'healthy' | 'unhealthy' | 'degraded' | 'unknown' | 'disabled';
 
@@ -116,11 +120,17 @@ export function buildRuntimeHealthForAccount(input: {
   }
 
   if (accountStatus === 'expired') {
+    const credentialMode = getCredentialModeFromExtraConfig(input.extraConfig);
+    const usesOauthCredential = hasOauthProvider({ extraConfig: input.extraConfig });
     return {
       state: 'unhealthy',
-      reason: input.sessionCapable === false
-        ? '连接已过期，请更新 API Key'
-        : '访问令牌已过期',
+      reason: usesOauthCredential
+        ? '连接凭证已过期，请更新凭证'
+        : credentialMode === 'apikey'
+          ? '连接已过期，请更新 API Key'
+          : (credentialMode === 'session'
+            ? '访问令牌已过期'
+            : '连接凭证已过期，请更新凭证'),
       source: 'auth',
       checkedAt: null,
     };

--- a/src/server/services/accountMutationWorkflow.test.ts
+++ b/src/server/services/accountMutationWorkflow.test.ts
@@ -120,6 +120,19 @@ describe('accountMutationWorkflow', () => {
     expect(result.refreshedModels).toBe(false);
   });
 
+  it('passes allowInactive to model refresh when recovery explicitly requests it', async () => {
+    refreshModelsForAccountMock.mockResolvedValue({ accountId: 5, refreshed: true, status: 'success' });
+
+    const { convergeAccountMutation } = await import('./accountMutationWorkflow.js');
+    await convergeAccountMutation({
+      accountId: 5,
+      refreshModels: true,
+      allowInactiveModelRefresh: true,
+    });
+
+    expect(refreshModelsForAccountMock).toHaveBeenCalledWith(5, { allowInactive: true });
+  });
+
   it('refreshes model coverage in batches and maps failures', async () => {
     refreshModelsForAccountMock
       .mockResolvedValueOnce({ accountId: 1, refreshed: true, status: 'success' })

--- a/src/server/services/accountMutationWorkflow.ts
+++ b/src/server/services/accountMutationWorkflow.ts
@@ -112,9 +112,10 @@ export async function convergeAccountMutation(input: {
   }
 
   if (input.refreshModels) {
-    const modelRefreshResult = await runStep(() => refreshModelsForAccount(
-      input.accountId,
-      input.allowInactiveModelRefresh ? { allowInactive: true } : undefined,
+    const modelRefreshResult = await runStep(() => (
+      input.allowInactiveModelRefresh
+        ? refreshModelsForAccount(input.accountId, { allowInactive: true })
+        : refreshModelsForAccount(input.accountId)
     ));
     if (modelRefreshResult) {
       result.modelRefreshResult = modelRefreshResult;

--- a/src/server/services/accountUpdateWorkflow.ts
+++ b/src/server/services/accountUpdateWorkflow.ts
@@ -1,0 +1,65 @@
+import { eq } from 'drizzle-orm';
+import { db, schema } from '../db/index.js';
+import {
+  convergeAccountMutation,
+  rebuildRoutesBestEffort,
+} from './accountMutationWorkflow.js';
+
+type AccountUpdateWorkflowInput = {
+  accountId: number;
+  updates: Partial<typeof schema.accounts.$inferInsert>;
+  preferredApiToken?: string | null;
+  refreshModels: boolean;
+  preserveExpiredStatus?: boolean;
+  allowInactiveModelRefresh?: boolean;
+  reactivateAfterSuccessfulModelRefresh?: boolean;
+  continueOnError?: boolean;
+};
+
+export async function applyAccountUpdateWorkflow(input: AccountUpdateWorkflowInput) {
+  const persistedUpdates: Partial<typeof schema.accounts.$inferInsert> = {
+    ...input.updates,
+    ...(input.preserveExpiredStatus ? { status: 'expired' } : {}),
+    updatedAt: new Date().toISOString(),
+  };
+
+  await db.update(schema.accounts)
+    .set(persistedUpdates)
+    .where(eq(schema.accounts.id, input.accountId))
+    .run();
+
+  const convergence = await convergeAccountMutation({
+    accountId: input.accountId,
+    preferredApiToken: input.preferredApiToken,
+    defaultTokenSource: 'manual',
+    refreshModels: input.refreshModels,
+    allowInactiveModelRefresh: input.allowInactiveModelRefresh,
+    rebuildRoutes: false,
+    continueOnError: input.continueOnError,
+  });
+
+  if (
+    input.reactivateAfterSuccessfulModelRefresh
+    && convergence.modelRefreshResult?.status === 'success'
+  ) {
+    await db.update(schema.accounts)
+      .set({
+        status: 'active',
+        updatedAt: new Date().toISOString(),
+      })
+      .where(eq(schema.accounts.id, input.accountId))
+      .run();
+  }
+
+  await rebuildRoutesBestEffort();
+
+  const account = await db.select()
+    .from(schema.accounts)
+    .where(eq(schema.accounts.id, input.accountId))
+    .get();
+
+  return {
+    account,
+    convergence,
+  };
+}

--- a/src/web/pages/Accounts.tsx
+++ b/src/web/pages/Accounts.tsx
@@ -597,16 +597,14 @@ export default function Accounts() {
   };
 
   const resolveRuntimeHealth = (account: any) => {
-    const capabilities = resolveAccountCapabilities(account);
     if (account.status === 'expired') {
       return {
         ...runtimeHealthMap.unhealthy,
         label: '已过期',
-        reason: capabilities.proxyOnly
-          ? '连接已过期，请在编辑中更新 API Key'
-          : (account.runtimeHealth?.reason || '访问令牌已过期，请重新绑定 Session Token'),
+        reason: account.runtimeHealth?.reason || '连接凭证已过期，请更新凭证',
       };
     }
+    const capabilities = resolveAccountCapabilities(account);
     const fallbackState = account.status === 'disabled' || account.site?.status === 'disabled'
       ? 'disabled'
       : (!capabilities.proxyOnly && account.status === 'expired' ? 'unhealthy' : 'unknown');

--- a/src/web/pages/accounts.proxy-only-expired.test.tsx
+++ b/src/web/pages/accounts.proxy-only-expired.test.tsx
@@ -52,8 +52,8 @@ describe('Accounts proxy-only expired state', () => {
         status: 'expired',
         checkinEnabled: false,
         runtimeHealth: {
-          state: 'healthy',
-          reason: '模型探测成功',
+          state: 'unhealthy',
+          reason: '连接已过期，请更新 API Key',
         },
         capabilities: {
           canCheckin: false,
@@ -82,6 +82,7 @@ describe('Accounts proxy-only expired state', () => {
       const rendered = JSON.stringify(root.toJSON());
       expect(rendered).not.toContain('仅代理');
       expect(rendered).toContain('已过期');
+      expect(rendered).toContain('连接已过期，请更新 API Key');
       expect(rendered).not.toContain('访问令牌已过期');
 
       const badgeTexts = root.root.findAll((node) => (

--- a/src/web/pages/accounts.refresh-reload-on-error.test.tsx
+++ b/src/web/pages/accounts.refresh-reload-on-error.test.tsx
@@ -105,7 +105,7 @@ describe('Accounts refresh action', () => {
 
       expect(apiMock.getAccounts).toHaveBeenCalledTimes(2);
       const rendered = JSON.stringify(root.toJSON());
-      expect(rendered).toContain('异常');
+      expect(rendered).toContain('已过期');
     } finally {
       root?.unmount();
     }


### PR DESCRIPTION
## Summary

This PR fixes issue #359, where an expired connection could still appear healthy in the connections list, especially for API Key or other proxy-only connections on newapi-style sites.

From the user perspective, the confusing behavior was:
- the edit panel showed the account status as `expired`,
- token routes had already excluded that connection,
- but the list view still rendered the connection as green and healthy,
- and updating the API key in the edit panel did not bring the connection back into service.

## Root Cause

There were two adjacent causes:

1. Runtime health synthesis allowed proxy-only connections to fall back to stored or derived model-discovery health. That meant an account could stay green in the list because it had discovered models earlier, even after its persisted account status had already become `expired`.

2. Editing an expired API Key connection only wrote the new credential and then ran the normal convergence path. Model refresh for inactive accounts is normally skipped, so the replacement key never got a chance to rebuild availability and route state before the account remained expired.

## Fix

This patch makes the expired state authoritative in the shared account health path. If an account is `expired`, the account list now reports it as unhealthy instead of reusing a stale healthy model-discovery snapshot. Proxy-only connections get copy that tells the operator to update the API key, rather than session-token wording.

It also adds a narrow recovery flow when editing an expired API Key connection. If credentials were updated on an expired API Key account, Metapi now performs an allow-inactive model refresh first. If the replacement key successfully discovers models, the account is flipped back to `active` and routes are rebuilt. If discovery fails, the account stays expired instead of being reactivated prematurely.

On the frontend, the accounts list now surfaces these rows as `已过期` instead of a green `健康` badge, while still avoiding the session-only `重新绑定` action for proxy-only connections.

## Validation

I validated the change with focused regression coverage and adjacent account flows:

- `npm test -- src/server/services/accountHealthService.test.ts src/server/routes/api/accounts.apikey-recovery.test.ts src/server/routes/api/accounts.credentialMode.test.ts src/server/routes/api/accounts.rebind-session.test.ts src/web/pages/accounts.proxy-only-expired.test.tsx src/web/pages/accounts.rebind-panel-focus.test.tsx src/web/pages/accounts.edit-panel.test.tsx`
- `npm run repo:drift-check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API key recovery: expired API-key accounts can be reactivated when updated with a valid API token.

* **Bug Fixes**
  * Expired accounts now consistently show an "已过期" badge and a credential-specific reason in the UI.
  * Proxy-only and OAuth expired states report health correctly.

* **Tests**
  * Added comprehensive tests covering API-key recovery, account update workflows, and expired-account health behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->