### PR TITLE
[codex] strip codex responses max_output_tokens

### DIFF
--- a/src/server/routes/proxy/architecture-boundaries.test.ts
+++ b/src/server/routes/proxy/architecture-boundaries.test.ts
@@ -98,6 +98,15 @@ describe('proxy route architecture boundaries', () => {
     expect(source).not.toContain('shouldInjectDerivedPromptCacheKey');
   });
 
+  it('keeps codex responses normalization behind transformer helpers', () => {
+    const source = readSource('./upstreamEndpoint.ts');
+    expect(source).toContain("from '../../transformers/openai/responses/codexCompatibility.js'");
+    expect(source).not.toContain('function ensureCodexResponsesInstructions(');
+    expect(source).not.toContain('function ensureCodexResponsesStoreFalse(');
+    expect(source).not.toContain('function stripCodexUnsupportedResponsesFields(');
+    expect(source).not.toContain('function applyCodexResponsesCompatibility(');
+  });
+
   it('keeps endpoint runtime snapshot helper out of the route layer', () => {
     const source = readSource('./upstreamEndpoint.ts');
     expect(source).not.toContain('function getUpstreamEndpointRuntimeStateSnapshot(');

--- a/src/server/routes/proxy/chat.codex-oauth.test.ts
+++ b/src/server/routes/proxy/chat.codex-oauth.test.ts
@@ -211,6 +211,7 @@ describe('chat proxy codex oauth compatibility', () => {
     expect(forwardedBody.parallel_tool_calls).toBeUndefined();
     expect(forwardedBody.include).toBeUndefined();
     expect(forwardedBody.max_output_tokens).toBeUndefined();
+    expect(forwardedBody.max_tokens).toBeUndefined();
     expect(forwardedBody.max_completion_tokens).toBeUndefined();
 
     const body = response.json();

--- a/src/server/routes/proxy/upstreamEndpoint.test.ts
+++ b/src/server/routes/proxy/upstreamEndpoint.test.ts
@@ -737,6 +737,8 @@ describe('buildUpstreamEndpointRequest', () => {
     expect(request.body.parallel_tool_calls).toBeUndefined();
     expect(request.body.include).toBeUndefined();
     expect(request.body.max_output_tokens).toBeUndefined();
+    expect(request.body.max_tokens).toBeUndefined();
+    expect(request.body.max_completion_tokens).toBeUndefined();
     expect(request.body.temperature).toBe(0.2);
     expect(request.body.top_p).toBe(0.9);
     expect(request.body.user).toBe('drop-me');
@@ -854,6 +856,8 @@ describe('buildUpstreamEndpointRequest', () => {
         previous_response_id: 'resp_prev_123',
         temperature: 0.3,
         top_p: 0.8,
+        max_completion_tokens: 256,
+        max_tokens: 128,
         max_output_tokens: 512,
       },
       providerHeaders: {
@@ -873,6 +877,8 @@ describe('buildUpstreamEndpointRequest', () => {
     expect(request.body.previous_response_id).toBe('resp_prev_123');
     expect(request.body.temperature).toBe(0.3);
     expect(request.body.top_p).toBe(0.8);
+    expect(request.body.max_completion_tokens).toBeUndefined();
+    expect(request.body.max_tokens).toBeUndefined();
     expect(request.body.max_output_tokens).toBeUndefined();
   });
 
@@ -1002,6 +1008,8 @@ describe('buildUpstreamEndpointRequest', () => {
           models: [{ name: 'gpt-5.4', protocol: 'codex' }],
           params: {
             'text.verbosity': 'low',
+            max_completion_tokens: 48,
+            max_tokens: 32,
             max_output_tokens: 64,
             store: true,
           },
@@ -1039,6 +1047,8 @@ describe('buildUpstreamEndpointRequest', () => {
     expect(request.body.reasoning).toEqual({ effort: 'high' });
     expect(request.body.text).toEqual({ verbosity: 'low' });
     expect(request.body.safety_identifier).toBeUndefined();
+    expect(request.body.max_completion_tokens).toBeUndefined();
+    expect(request.body.max_tokens).toBeUndefined();
     expect(request.body.max_output_tokens).toBeUndefined();
     expect(request.body.store).toBe(false);
   });

--- a/src/server/routes/proxy/upstreamEndpoint.ts
+++ b/src/server/routes/proxy/upstreamEndpoint.ts
@@ -17,6 +17,7 @@ import {
   convertOpenAiBodyToResponsesBody as convertOpenAiBodyToResponsesBodyViaTransformer,
   sanitizeResponsesBodyForProxy as sanitizeResponsesBodyForProxyViaTransformer,
 } from '../../transformers/openai/responses/conversion.js';
+import { normalizeCodexResponsesBodyForProxy } from '../../transformers/openai/responses/codexCompatibility.js';
 import {
   convertOpenAiBodyToAnthropicMessagesBody,
   sanitizeAnthropicMessagesBody,
@@ -369,73 +370,6 @@ function sanitizeResponsesFallbackChatBody(
 function toFiniteNumber(value: unknown): number | null {
   return typeof value === 'number' && Number.isFinite(value) ? value : null;
 }
-
-function ensureCodexResponsesInstructions(
-  body: Record<string, unknown>,
-  sitePlatform: string,
-): Record<string, unknown> {
-  if (sitePlatform !== 'codex') return body;
-  if (typeof body.instructions === 'string') return body;
-  return {
-    ...body,
-    instructions: '',
-  };
-}
-
-function ensureCodexResponsesStoreFalse(
-  body: Record<string, unknown>,
-  sitePlatform: string,
-): Record<string, unknown> {
-  if (sitePlatform !== 'codex') return body;
-  return {
-    ...body,
-    store: false,
-  };
-}
-
-function stripCodexUnsupportedResponsesFields(
-  body: Record<string, unknown>,
-  sitePlatform: string,
-): Record<string, unknown> {
-  if (sitePlatform !== 'codex') return body;
-  const next = { ...body };
-  delete next.max_output_tokens;
-  delete next.max_completion_tokens;
-  delete next.max_tokens;
-  return next;
-}
-
-function convertCodexSystemRoleToDeveloper(input: unknown): unknown {
-  if (!Array.isArray(input)) return input;
-  return input.map((item) => {
-    if (!isRecord(item)) return item;
-    if (asTrimmedString(item.type).toLowerCase() !== 'message') return item;
-    if (asTrimmedString(item.role).toLowerCase() !== 'system') return item;
-    return {
-      ...item,
-      role: 'developer',
-    };
-  });
-}
-
-function applyCodexResponsesCompatibility(
-  body: Record<string, unknown>,
-  sitePlatform: string,
-): Record<string, unknown> {
-  if (sitePlatform !== 'codex') return body;
-
-  const next: Record<string, unknown> = {
-    ...body,
-    input: convertCodexSystemRoleToDeveloper(body.input),
-  };
-
-  if (typeof next.instructions !== 'string') {
-    next.instructions = '';
-  }
-
-  return next;
-}
-
 
 function normalizeEndpointTypes(value: unknown): UpstreamEndpoint[] {
   const raw = asTrimmedString(value).toLowerCase();
@@ -969,24 +903,12 @@ export function buildUpstreamEndpointRequest(input: {
     if (preserveWebsocketIncrementalMode && rawBody.generate === false) {
       sanitizedResponsesBody.generate = false;
     }
-    const body = ensureCodexResponsesStoreFalse(
-      stripCodexUnsupportedResponsesFields(
-        ensureCodexResponsesInstructions(
-          applyCodexResponsesCompatibility(
-            sanitizedResponsesBody,
-            sitePlatform,
-          ),
-          sitePlatform,
-        ),
-        sitePlatform,
-      ),
+    const body = normalizeCodexResponsesBodyForProxy(
+      sanitizedResponsesBody,
       sitePlatform,
     );
-    const configuredResponsesBody = ensureCodexResponsesStoreFalse(
-      stripCodexUnsupportedResponsesFields(
-        applyConfiguredPayloadRules(body),
-        sitePlatform,
-      ),
+    const configuredResponsesBody = normalizeCodexResponsesBodyForProxy(
+      applyConfiguredPayloadRules(body),
       sitePlatform,
     );
 

--- a/src/server/transformers/openai/responses/codexCompatibility.test.ts
+++ b/src/server/transformers/openai/responses/codexCompatibility.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeCodexResponsesBodyForProxy } from './codexCompatibility.js';
+
+describe('normalizeCodexResponsesBodyForProxy', () => {
+  it('normalizes codex responses bodies before proxying upstream', () => {
+    const body = normalizeCodexResponsesBodyForProxy({
+      input: [
+        {
+          type: 'message',
+          role: 'system',
+          content: [{ type: 'input_text', text: 'be precise' }],
+        },
+      ],
+      max_output_tokens: 512,
+      max_completion_tokens: 256,
+      max_tokens: 128,
+      temperature: 0.3,
+      store: true,
+    }, 'codex');
+
+    expect(body).toEqual({
+      input: [
+        {
+          type: 'message',
+          role: 'developer',
+          content: [{ type: 'input_text', text: 'be precise' }],
+        },
+      ],
+      instructions: '',
+      store: false,
+      temperature: 0.3,
+    });
+  });
+
+  it('leaves non-codex bodies untouched', () => {
+    const source = {
+      input: 'hello',
+      max_output_tokens: 512,
+    };
+
+    const body = normalizeCodexResponsesBodyForProxy(source, 'openai');
+
+    expect(body).toBe(source);
+  });
+});

--- a/src/server/transformers/openai/responses/codexCompatibility.ts
+++ b/src/server/transformers/openai/responses/codexCompatibility.ts
@@ -1,0 +1,90 @@
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object';
+}
+
+function asTrimmedString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function ensureCodexResponsesInstructions(
+  body: Record<string, unknown>,
+  sitePlatform: string,
+): Record<string, unknown> {
+  if (sitePlatform !== 'codex') return body;
+  if (typeof body.instructions === 'string') return body;
+  return {
+    ...body,
+    instructions: '',
+  };
+}
+
+function ensureCodexResponsesStoreFalse(
+  body: Record<string, unknown>,
+  sitePlatform: string,
+): Record<string, unknown> {
+  if (sitePlatform !== 'codex') return body;
+  return {
+    ...body,
+    store: false,
+  };
+}
+
+function stripCodexUnsupportedResponsesFields(
+  body: Record<string, unknown>,
+  sitePlatform: string,
+): Record<string, unknown> {
+  if (sitePlatform !== 'codex') return body;
+  const next = { ...body };
+  delete next.max_output_tokens;
+  delete next.max_completion_tokens;
+  delete next.max_tokens;
+  return next;
+}
+
+function convertCodexSystemRoleToDeveloper(input: unknown): unknown {
+  if (!Array.isArray(input)) return input;
+  return input.map((item) => {
+    if (!isRecord(item)) return item;
+    if (asTrimmedString(item.type).toLowerCase() !== 'message') return item;
+    if (asTrimmedString(item.role).toLowerCase() !== 'system') return item;
+    return {
+      ...item,
+      role: 'developer',
+    };
+  });
+}
+
+function applyCodexResponsesCompatibility(
+  body: Record<string, unknown>,
+  sitePlatform: string,
+): Record<string, unknown> {
+  if (sitePlatform !== 'codex') return body;
+
+  const next: Record<string, unknown> = {
+    ...body,
+    input: convertCodexSystemRoleToDeveloper(body.input),
+  };
+
+  if (typeof next.instructions !== 'string') {
+    next.instructions = '';
+  }
+
+  return next;
+}
+
+export function normalizeCodexResponsesBodyForProxy(
+  body: Record<string, unknown>,
+  sitePlatform: string,
+): Record<string, unknown> {
+  if (sitePlatform !== 'codex') return body;
+  return ensureCodexResponsesStoreFalse(
+    stripCodexUnsupportedResponsesFields(
+      ensureCodexResponsesInstructions(
+        applyCodexResponsesCompatibility(body, sitePlatform),
+        sitePlatform,
+      ),
+      sitePlatform,
+    ),
+    sitePlatform,
+  );
+}


### PR DESCRIPTION
This PR fixes a Codex upstream contract mismatch in the `/v1/messages` and `/v1/responses` proxy paths.

When a downstream Claude-style `/v1/messages` request was bridged into the ChatGPT Codex OAuth upstream `/responses` endpoint, Metapi preserved or synthesized a `max_output_tokens` field in the outgoing Codex request body. The current Codex upstream rejects that field with `Unsupported parameter: max_output_tokens`, which surfaced to users as a fast 400 failure even though the downstream request itself was otherwise valid.

The root cause was that Codex-specific response shaping still assumed an older native `/responses` contract. We already force `store: false` and normalize a few Codex-only compatibility details in `buildUpstreamEndpointRequest(...)`, but token-limit fields were still allowed to pass through that final Codex request-shaping step. That meant the same incompatibility could leak in from OpenAI chat input, Claude `/v1/messages` input, native `/v1/responses` payloads, or even configured payload rules.

The fix adds a Codex-only cleanup step in the final `/responses` request builder so `max_output_tokens`, `max_completion_tokens`, and `max_tokens` are stripped before the request is sent upstream, and again after payload rules are applied so configuration cannot reintroduce the unsupported field. The associated tests were updated to lock the current contract for all affected entry paths, including `/v1/messages -> /responses`, OpenAI/chat-derived Codex requests, native Codex responses requests, and payload-rule overrides.

Validation was done with focused proxy tests plus the repo drift guardrail:

- `npm test -- src/server/routes/proxy/upstreamEndpoint.test.ts src/server/routes/proxy/chat.codex-oauth.test.ts src/server/routes/proxy/responses.codex-oauth.test.ts`
- `npm run repo:drift-check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unsupported token-limit fields from Codex-style requests so upstream requests no longer include them.

* **New Features**
  * Added a dedicated Codex responses normalizer to centralize compatibility handling for Codex vs. non-Codex requests.

* **Tests**
  * Updated and added tests to verify token-field stripping and Codex-specific response normalization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->