### PR TITLE
[codex] fix sqlite migration journal recovery

### DIFF
--- a/src/server/db/migrate.test.ts
+++ b/src/server/db/migrate.test.ts
@@ -50,6 +50,8 @@ function recordAppliedMigrations(
   }
 }
 
+const STALE_JOURNAL_TIMESTAMP_DRIFT_MS = 4_196_930;
+
 describe('sqlite migrate bootstrap', () => {
   afterEach(() => {
     delete process.env.DATA_DIR;
@@ -204,6 +206,43 @@ describe('sqlite migrate bootstrap', () => {
 
     expect(applied).toHaveLength(1);
     expect(Number(applied[0].created_at)).toBe(1772500000001);
+
+    sqlite.close();
+  });
+
+  it('updates only the latest matching migration record when reconciling stale timestamps', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'metapi-migrate-rowid-reconcile-'));
+    process.env.DATA_DIR = dataDir;
+    vi.resetModules();
+
+    const migrateModule = await import('./migrate.js');
+    const { __migrateTestUtils } = migrateModule;
+
+    const sqlite = new Database(':memory:');
+    sqlite.exec(`
+      CREATE TABLE "__drizzle_migrations" (
+        id SERIAL PRIMARY KEY,
+        hash text NOT NULL,
+        created_at numeric
+      );
+    `);
+    sqlite.prepare('INSERT INTO "__drizzle_migrations" ("hash", "created_at") VALUES (?, ?)').run('same-hash', 10);
+    sqlite.prepare('INSERT INTO "__drizzle_migrations" ("hash", "created_at") VALUES (?, ?)').run('same-hash', 20);
+
+    const changed = __migrateTestUtils.markMigrationRecordIfMissing(sqlite, {
+      hash: 'same-hash',
+      createdAt: 30,
+    });
+
+    const records = sqlite
+      .prepare('SELECT rowid, hash, created_at FROM "__drizzle_migrations" ORDER BY rowid ASC')
+      .all() as Array<{ rowid: number; hash: string; created_at: number }>;
+
+    expect(changed).toBe(true);
+    expect(records).toEqual([
+      { rowid: 1, hash: 'same-hash', created_at: 10 },
+      { rowid: 2, hash: 'same-hash', created_at: 30 },
+    ]);
 
     sqlite.close();
   });
@@ -443,9 +482,10 @@ describe('sqlite migrate bootstrap', () => {
       ? readFileSync(join(migrationsDir, `${latestEntry.tag}.sql`), 'utf8')
       : '';
     const latestHash = createHash('sha256').update(latestSqlText).digest('hex');
+    // Introduce about 70 minutes of timestamp drift so journal reconciliation has work to do.
     sqlite
       .prepare('UPDATE __drizzle_migrations SET created_at = ? WHERE hash = ?')
-      .run((latestEntry?.when ?? 0) - 4_196_930, latestHash);
+      .run((latestEntry?.when ?? 0) - STALE_JOURNAL_TIMESTAMP_DRIFT_MS, latestHash);
     sqlite.close();
 
     process.env.DATA_DIR = dataDir;

--- a/src/server/db/migrate.ts
+++ b/src/server/db/migrate.ts
@@ -264,16 +264,16 @@ function ensureDrizzleMigrationsTable(sqlite: Database.Database): void {
 function markMigrationRecordIfMissing(sqlite: Database.Database, record: MigrationRecord): boolean {
   ensureDrizzleMigrationsTable(sqlite);
   const existing = sqlite
-    .prepare('SELECT "created_at" FROM "__drizzle_migrations" WHERE "hash" = ? ORDER BY "created_at" DESC LIMIT 1')
-    .get(record.hash) as { created_at?: number } | undefined;
+    .prepare('SELECT rowid, "created_at" FROM "__drizzle_migrations" WHERE "hash" = ? ORDER BY "created_at" DESC LIMIT 1')
+    .get(record.hash) as { rowid?: number; created_at?: number } | undefined;
   if (existing) {
     if (Number(existing.created_at) === record.createdAt) {
       return false;
     }
 
     sqlite
-      .prepare('UPDATE "__drizzle_migrations" SET "created_at" = ? WHERE "hash" = ?')
-      .run(record.createdAt, record.hash);
+      .prepare('UPDATE "__drizzle_migrations" SET "created_at" = ? WHERE rowid = ?')
+      .run(record.createdAt, existing.rowid);
     return true;
   }
 


### PR DESCRIPTION
This fixes a SQLite startup regression where Metapi could fail during runtime database bootstrap with duplicate-column errors such as `ALTER TABLE proxy_logs ADD is_stream integer` even though the target columns already existed. For an operator, the visible effect was that `npm run dev:server` or any SQLite-backed startup path aborted before the server came up.

The root cause was in the drizzle journal recovery path rather than in the `proxy_logs` schema itself. We had two bad states that the current logic did not reconcile correctly. First, some legacy SQLite databases already had newer schema columns because compatibility code had added them before drizzle recorded the matching migration sequence, and the recovery flow only retried once instead of continuing while progress was still being made. Second, a database could already contain the latest migration hash in `__drizzle_migrations` while keeping an older `created_at` value than the current journal timestamp, which caused Drizzle to treat the migration as still pending and replay the same `ALTER TABLE` again.

The fix makes migration journal reconciliation authoritative. Existing migration records are now updated when their hash matches but their recorded `created_at` is stale, so Drizzle no longer replays an already-applied migration just because the timestamp drifted. The duplicate-column recovery path was also tightened to keep replaying and recording migrations while each pass makes forward progress, instead of stopping after a single recovery cycle. This preserves the existing narrow recovery behavior but makes it robust for partially bootstrapped legacy SQLite schemas.

The test coverage adds two regression cases in `src/server/db/migrate.test.ts`: one for sequential duplicate-column recovery on a legacy SQLite schema that predates the drizzle journal, and one for the stale-timestamp case where the latest migration hash already exists but its `created_at` is older than the current drizzle journal entry.

Validation:
- `npx vitest run --root . src/server/db/migrate.test.ts`
- `npx vitest run --root . src/server/runtimeDatabaseBootstrap.test.ts`
- `npm run repo:drift-check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration recovery to handle stale migration timestamps, duplicate-column conflicts, and inconsistent migration records more reliably.
  * Ensures migration timestamps are reconciled so database initialization and upgrades complete consistently.

* **Tests**
  * Added end-to-end tests covering legacy schema bootstrapping, duplicate/duplicate-hash migration scenarios, and stale-timestamp recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->