### PR TITLE
[codex] fix codex responses continuation across channel drift

### DIFF
--- a/src/server/proxy-core/runtime/codexSessionResponseStore.test.ts
+++ b/src/server/proxy-core/runtime/codexSessionResponseStore.test.ts
@@ -71,6 +71,37 @@ describe('codexSessionResponseStore', () => {
     resetCodexSessionResponseStore();
   });
 
+  it('does not collapse distinct downstream sessions when scoped session ids contain delimiters', () => {
+    resetCodexSessionResponseStore();
+
+    const delimitedScopedKey = buildCodexSessionResponseStoreKey({
+      sessionId: 'session-delimited|tail',
+      siteId: 10,
+      accountId: 20,
+      channelId: 30,
+    });
+    const delimitedDriftedScopedKey = buildCodexSessionResponseStoreKey({
+      sessionId: 'session-delimited|tail',
+      siteId: 10,
+      accountId: 21,
+      channelId: 31,
+    });
+    const plainScopedKey = buildCodexSessionResponseStoreKey({
+      sessionId: 'session-delimited',
+      siteId: 10,
+      accountId: 22,
+      channelId: 32,
+    });
+
+    setCodexSessionResponseId(delimitedScopedKey, 'resp-delimited');
+    setCodexSessionResponseId(plainScopedKey, 'resp-plain');
+
+    expect(getCodexSessionResponseId(delimitedDriftedScopedKey)).toBe('resp-delimited');
+    expect(getCodexSessionResponseId(plainScopedKey)).toBe('resp-plain');
+
+    resetCodexSessionResponseStore();
+  });
+
   it('clears the bare downstream session fallback when removing a scoped continuation id', () => {
     resetCodexSessionResponseStore();
 

--- a/src/server/proxy-core/runtime/codexSessionResponseStore.ts
+++ b/src/server/proxy-core/runtime/codexSessionResponseStore.ts
@@ -3,6 +3,11 @@ const MAX_CODEX_SESSION_RESPONSE_IDS = 10_000;
 const codexSessionResponseIds = new Map<string, string>();
 
 const SCOPED_SESSION_SEGMENT_PREFIX = 'session:';
+const SCOPED_STORE_KEY_SEGMENT_PATTERN = /^(site|account|channel):\d+$/;
+
+function buildScopedSessionSegment(sessionId: string): string {
+  return `${SCOPED_SESSION_SEGMENT_PREFIX}${encodeURIComponent(sessionId)}`;
+}
 
 function extractScopedSessionSegment(sessionId: string): string {
   const normalizedSessionId = normalizeSessionId(sessionId);
@@ -16,8 +21,17 @@ function extractScopedSessionSegment(sessionId: string): string {
     .split('|')
     .map((segment) => segment.trim())
     .filter(Boolean);
-  const sessionSegment = scopedSegments.find((segment) => segment.startsWith(SCOPED_SESSION_SEGMENT_PREFIX));
-  return sessionSegment || '';
+  if (scopedSegments.length <= 1) return '';
+
+  const sessionSegment = scopedSegments[scopedSegments.length - 1];
+  if (!sessionSegment.startsWith(SCOPED_SESSION_SEGMENT_PREFIX)) {
+    return '';
+  }
+  const scopeSegments = scopedSegments.slice(0, -1);
+  if (!scopeSegments.every((segment) => SCOPED_STORE_KEY_SEGMENT_PATTERN.test(segment))) {
+    return '';
+  }
+  return sessionSegment;
 }
 
 function getBareSessionStoreKey(sessionId: string): string {
@@ -59,7 +73,7 @@ export function buildCodexSessionResponseStoreKey(input: {
     Number.isFinite(input.siteId as number) && Number(input.siteId) > 0 ? `site:${Math.trunc(Number(input.siteId))}` : '',
     Number.isFinite(input.accountId as number) && Number(input.accountId) > 0 ? `account:${Math.trunc(Number(input.accountId))}` : '',
     Number.isFinite(input.channelId as number) && Number(input.channelId) > 0 ? `channel:${Math.trunc(Number(input.channelId))}` : '',
-    `session:${normalizedSessionId}`,
+    buildScopedSessionSegment(normalizedSessionId),
   ].filter(Boolean);
   return parts.join('|');
 }

--- a/src/server/routes/proxy/responses.codex-oauth.test.ts
+++ b/src/server/routes/proxy/responses.codex-oauth.test.ts
@@ -681,9 +681,14 @@ describe('responses proxy codex oauth refresh', () => {
 
     expect(secondResponse.statusCode).toBe(200);
     expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(selectChannelMock).toHaveBeenCalledTimes(2);
+    expect(selectPreferredChannelMock).toHaveBeenCalledTimes(2);
 
+    const [, firstOptions] = fetchMock.mock.calls[0] as [string, any];
     const [, secondOptions] = fetchMock.mock.calls[1] as [string, any];
     const secondBody = JSON.parse(secondOptions.body);
+    expect(firstOptions.headers['Chatgpt-Account-Id'] || firstOptions.headers['chatgpt-account-id']).toBe('chatgpt-account-123');
+    expect(secondOptions.headers['Chatgpt-Account-Id'] || secondOptions.headers['chatgpt-account-id']).toBe('chatgpt-account-456');
     expect(secondBody.previous_response_id).toBe('resp_codex_prev_drift_1');
     expect(secondBody.input).toEqual([
       {


### PR DESCRIPTION
## Summary

Fix Codex native `/responses` continuation when the same downstream session drifts to a different internal channel or account between turns.

The user-facing failure was `Upstream returned HTTP 400: No tool call found for function call output with call_id ...` on follow-up tool-output turns. This happened when the second request still used native Responses input with `function_call_output`, but Metapi failed to reattach the previous Responses continuation id after routing drift.

## Root Cause

Metapi remembered Codex response ids under a fully scoped key that included `site`, `account`, `channel`, and `session`. That works only if the next turn lands on the same internal route. When the same downstream `session_id` was re-routed to a different account or channel, the scoped lookup missed, `previous_response_id` was omitted, and the upstream treated the tool output as orphaned.

## Fix

The response-id store now preserves the exact scoped key while also maintaining a fallback record keyed by the bare `session:<id>` segment extracted from scoped keys. Reads still prefer the exact scoped key first, then fall back to the bare session key only for scoped session entries. This preserves existing namespace behavior while allowing native Responses continuation to survive channel/account drift within the same downstream session.

The patch also adds:
- a focused store-level regression test for scoped-session fallback across drift
- an end-to-end Codex OAuth regression test proving that a follow-up `function_call_output` turn still carries `previous_response_id` after routing drift

## Validation

- `npm test -- src/server/proxy-core/runtime/codexSessionResponseStore.test.ts`
- `npm test -- src/server/routes/proxy/responses.codex-oauth.test.ts`
- `npm run repo:drift-check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session continuity so prior responses are correctly reused when downstream channel/account scope drifts while the upstream session is unchanged.
  * Clearing a session’s continuation now removes fallback keys so stale previous-response references aren’t reused.

* **Tests**
  * Added tests for scoped-session fallback behavior, preservation of prior response IDs across follow-up tool-output requests, and removal of fallbacks after clearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->