### PR TITLE
[daily] keep codex continuation current across scope roundtrips

### DIFF
--- a/src/server/proxy-core/runtime/codexSessionResponseStore.test.ts
+++ b/src/server/proxy-core/runtime/codexSessionResponseStore.test.ts
@@ -126,4 +126,32 @@ describe('codexSessionResponseStore', () => {
 
     resetCodexSessionResponseStore();
   });
+
+  it('keeps the latest continuation id when the same downstream session drifts back to an earlier scope', () => {
+    resetCodexSessionResponseStore();
+
+    const originalScopedKey = buildCodexSessionResponseStoreKey({
+      sessionId: 'session-roundtrip',
+      siteId: 10,
+      accountId: 20,
+      channelId: 30,
+    });
+    const driftedScopedKey = buildCodexSessionResponseStoreKey({
+      sessionId: 'session-roundtrip',
+      siteId: 10,
+      accountId: 21,
+      channelId: 31,
+    });
+
+    setCodexSessionResponseId(originalScopedKey, 'resp-roundtrip-1');
+
+    expect(getCodexSessionResponseId(driftedScopedKey)).toBe('resp-roundtrip-1');
+
+    setCodexSessionResponseId(driftedScopedKey, 'resp-roundtrip-2');
+
+    expect(getCodexSessionResponseId(driftedScopedKey)).toBe('resp-roundtrip-2');
+    expect(getCodexSessionResponseId(originalScopedKey)).toBe('resp-roundtrip-2');
+
+    resetCodexSessionResponseStore();
+  });
 });

--- a/src/server/proxy-core/runtime/codexSessionResponseStore.ts
+++ b/src/server/proxy-core/runtime/codexSessionResponseStore.ts
@@ -57,6 +57,16 @@ function getSessionStoreKeys(sessionId: string): string[] {
   ];
 }
 
+function reconcileScopedSessionFallback(bareSessionKey: string): void {
+  if (!bareSessionKey) return;
+
+  for (const key of codexSessionResponseIds.keys()) {
+    if (key === bareSessionKey) continue;
+    if (getBareSessionStoreKey(key) !== bareSessionKey) continue;
+    codexSessionResponseIds.delete(key);
+  }
+}
+
 function normalizeSessionId(sessionId: string): string {
   return sessionId.trim();
 }
@@ -87,7 +97,10 @@ export function getCodexSessionResponseId(sessionId: string): string | null {
 
   for (const fallbackKey of getFallbackSessionStoreKeys(normalized)) {
     const fallback = codexSessionResponseIds.get(fallbackKey);
-    if (fallback) return fallback;
+    if (fallback) {
+      reconcileScopedSessionFallback(fallbackKey);
+      return fallback;
+    }
   }
 
   return null;


### PR DESCRIPTION
## Source delta reviewed
- Reviewed bounded mainline delta `b9b553d7726d2b71ea0b662df36b44f31edb1434..63f6b0784206d27284f0a940d5e19e851d517d12` from the harness memory anchor to latest `origin/main`.
- Focused on `#404` (`[codex] fix codex responses continuation across channel drift`), because it introduced the new scoped Codex continuation store used by the responses proxy.

## Problem
- Codex `previous_response_id` reuse can go stale when the same downstream `session_id` drifts from scope A to scope B and then back to scope A.
- After the first fallback-based drift, the store keeps the old scoped A entry alive, so a later return to A revives the outdated response id instead of the newest continuation id.

## Root cause
- `getCodexSessionResponseId()` only used the bare-session fallback when the requested scoped key was missing.
- Once a drifted lookup succeeded through that fallback, the older sibling scoped entries were left intact, so later lookups on the original scope hit stale direct entries before the updated bare-session value.

## Fix
- Reconcile sibling scoped entries when a bare-session fallback is actually used.
- This keeps the most recent continuation id authoritative after real scope drift, while preserving the existing scoped namespacing behavior until fallback is needed.
- Added a focused regression test for the A -> B -> A roundtrip drift sequence.

## Verification
- `NODE_PATH=/Users/apple/code/metapi/node_modules /Users/apple/code/metapi/node_modules/.bin/vitest run src/server/proxy-core/runtime/codexSessionResponseStore.test.ts`
- `NODE_PATH=/Users/apple/code/metapi/node_modules /Users/apple/code/metapi/node_modules/.bin/vitest run src/server/routes/proxy/responses.codex-oauth.test.ts`
- `npm run repo:drift-check`

## Residual risk
- The store still treats a fallback hit as evidence that the scoped session ids represent the same downstream conversation. If two genuinely unrelated conversations reuse the same downstream `session_id` and trigger fallback, they will still converge by design. This PR only fixes the stale roundtrip case inside that existing model.

## Why this is safe to merge
- One production file plus one test file changed, both inside the new continuation-store family introduced by `#404`.
- The fix only affects the fallback path after a real scoped miss, so unchanged direct lookups and the broader routing stack keep their current behavior.
- Focused unit and surface verification stayed green, and `repo:drift-check` reported no new violations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for session response management across scope changes.

* **Bug Fixes**
  * Improved session response storage and retrieval to better handle multiple scope contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->