### PR TITLE
[codex] Fix desktop default-browser external links

### DIFF
--- a/src/desktop/main.ts
+++ b/src/desktop/main.ts
@@ -22,7 +22,7 @@ import {
   waitForServerReady,
 } from './runtime.js';
 import { getDesktopRuntimeIconPath, getDesktopTrayIconPath } from './iconAssets.js';
-import { attachDesktopNavigationGuard } from './navigationGuard.js';
+import { attachDesktopNavigationGuard, createSafeOpenExternal } from './navigationGuard.js';
 
 const { autoUpdater } = electronUpdater;
 
@@ -157,7 +157,12 @@ async function createMainWindow() {
 
   attachDesktopNavigationGuard({
     appUrl: frontendUrl,
-    openExternal: (url) => shell.openExternal(url),
+    openExternal: createSafeOpenExternal({
+      openExternal: (url) => shell.openExternal(url),
+      onError: (url, error) => {
+        log.error('Failed to open external URL', { url, error });
+      },
+    }),
     webContents: mainWindow.webContents,
   });
 

--- a/src/desktop/navigationGuard.test.ts
+++ b/src/desktop/navigationGuard.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   attachDesktopNavigationGuard,
+  createSafeOpenExternal,
   resolveDesktopNavigationAction,
   type DesktopWebContentsLike,
   type DesktopWillNavigateEvent,
@@ -45,6 +46,11 @@ describe('desktop navigation guard', () => {
   it('keeps same-origin popup links inside the desktop app', () => {
     expect(resolveDesktopNavigationAction('/monitor-proxy/ldoh/', appUrl)).toBe('allow');
     expect(resolveDesktopNavigationAction('about:blank', appUrl)).toBe('allow');
+  });
+
+  it('denies malformed navigation targets by default', () => {
+    expect(resolveDesktopNavigationAction('https://example.com', 'not a valid app url')).toBe('deny');
+    expect(resolveDesktopNavigationAction('http://[::1', appUrl)).toBe('deny');
   });
 
   it('opens cross-origin window.open targets externally and denies the popup', () => {
@@ -97,5 +103,19 @@ describe('desktop navigation guard', () => {
 
     expect(preventDefault).not.toHaveBeenCalled();
     expect(openExternal).not.toHaveBeenCalled();
+  });
+
+  it('reports external-open failures instead of leaving a rejected promise behind', async () => {
+    const error = new Error('failed to open');
+    const onError = vi.fn();
+    const safeOpenExternal = createSafeOpenExternal({
+      openExternal: vi.fn().mockRejectedValue(error),
+      onError,
+    });
+
+    safeOpenExternal('https://example.com/docs');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(onError).toHaveBeenCalledWith('https://example.com/docs', error);
   });
 });

--- a/src/desktop/navigationGuard.ts
+++ b/src/desktop/navigationGuard.ts
@@ -20,8 +20,13 @@ export type DesktopWebContentsLike = {
 
 export type AttachDesktopNavigationGuardInput = {
   appUrl: string;
-  openExternal: (url: string) => void | Promise<void>;
+  openExternal: (url: string) => void;
   webContents: DesktopWebContentsLike;
+};
+
+export type CreateSafeOpenExternalInput = {
+  openExternal: (url: string) => Promise<void>;
+  onError: (url: string, error: unknown) => void;
 };
 
 export function resolveDesktopNavigationAction(
@@ -35,7 +40,7 @@ export function resolveDesktopNavigationAction(
     appLocation = new URL(appUrl);
     targetLocation = new URL(targetUrl, appLocation);
   } catch {
-    return 'allow';
+    return 'deny';
   }
 
   if (targetLocation.protocol === 'about:') {
@@ -43,6 +48,16 @@ export function resolveDesktopNavigationAction(
   }
 
   return targetLocation.origin === appLocation.origin ? 'allow' : 'deny';
+}
+
+export function createSafeOpenExternal(
+  input: CreateSafeOpenExternalInput,
+): (url: string) => void {
+  return (url: string) => {
+    void input.openExternal(url).catch((error) => {
+      input.onError(url, error);
+    });
+  };
 }
 
 export function attachDesktopNavigationGuard(


### PR DESCRIPTION
## Summary
Closes #412.

Desktop external links were opening inside the Electron shell instead of handing off to the user's default browser. That made docs, GitHub, OAuth entry points, and other `target="_blank"` links feel broken in the desktop app.

The root cause was isolated to `src/desktop/main.ts`: the main `BrowserWindow` had no `setWindowOpenHandler` or `will-navigate` guard, so Electron kept both popup and same-window cross-origin navigations inside the app window.

This patch adds a narrow desktop navigation guard that:

- keeps same-origin routes inside Electron
- sends cross-origin popup and top-level navigations to `shell.openExternal()`
- preserves existing same-origin desktop flows such as `/monitor-proxy/ldoh/`

I kept the change in the desktop main-process layer only, with no web routing or server-side behavior changes.

## Validation
- `npm test -- src/desktop/navigationGuard.test.ts src/desktop/runtime.test.ts src/desktop/iconAssets.test.ts`
- `npm run typecheck:desktop`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a desktop navigation guard that blocks cross-origin navigations, allows same-origin (and about:blank), and routes external targets to the system browser, with safe handling of external-open failures.

* **Tests**
  * Added tests covering window-open and navigation behavior: cross-origin deny, same-origin allow, popup handling, and error reporting for external opens.

* **Refactor**
  * Ensured navigation guard is attached when the main window is created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->