### PR TITLE
[codex] preserve route bindings when expired api-key recovery fails

### DIFF
--- a/src/server/routes/api/accounts.apikey-recovery.test.ts
+++ b/src/server/routes/api/accounts.apikey-recovery.test.ts
@@ -175,6 +175,21 @@ describe('accounts api key recovery', { timeout: 15_000 }, () => {
       checkedAt: '2026-04-01T10:00:00.000Z',
     }).run();
 
+    const route = await db.insert(schema.tokenRoutes).values({
+      modelPattern: 'gpt-4.1',
+      enabled: true,
+    }).returning().get();
+
+    const seededChannel = await db.insert(schema.routeChannels).values({
+      routeId: route.id,
+      accountId: account.id,
+      tokenId: null,
+      priority: 0,
+      weight: 10,
+      enabled: true,
+      manualOverride: false,
+    }).returning().get();
+
     const response = await app.inject({
       method: 'PUT',
       url: `/api/accounts/${account.id}`,
@@ -211,6 +226,11 @@ describe('accounts api key recovery', { timeout: 15_000 }, () => {
     });
 
     const routeChannels = await db.select().from(schema.routeChannels).all();
-    expect(routeChannels.some((channel) => channel.accountId === account.id)).toBe(false);
+    expect(routeChannels).toContainEqual(expect.objectContaining({
+      id: seededChannel.id,
+      routeId: route.id,
+      accountId: account.id,
+      tokenId: null,
+    }));
   });
 });

--- a/src/server/services/accountUpdateWorkflow.ts
+++ b/src/server/services/accountUpdateWorkflow.ts
@@ -17,6 +17,11 @@ type AccountUpdateWorkflowInput = {
 };
 
 export async function applyAccountUpdateWorkflow(input: AccountUpdateWorkflowInput) {
+  const isExpiredApiKeyRecoveryFlow = Boolean(
+    input.preserveExpiredStatus
+    && input.allowInactiveModelRefresh
+    && input.reactivateAfterSuccessfulModelRefresh,
+  );
   const persistedUpdates: Partial<typeof schema.accounts.$inferInsert> = {
     ...input.updates,
     ...(input.preserveExpiredStatus ? { status: 'expired' } : {}),
@@ -51,7 +56,11 @@ export async function applyAccountUpdateWorkflow(input: AccountUpdateWorkflowInp
       .run();
   }
 
-  await rebuildRoutesBestEffort();
+  const shouldRebuildRoutes = !isExpiredApiKeyRecoveryFlow
+    || convergence.modelRefreshResult?.status === 'success';
+  if (shouldRebuildRoutes) {
+    await rebuildRoutesBestEffort();
+  }
 
   const account = await db.select()
     .from(schema.accounts)


### PR DESCRIPTION
## Summary
This fixes the still-open half of issue #409 for expired API-key recovery.

Before this change, editing an expired API-key account with a replacement key would persist the new key and preserve the old model availability when discovery failed, but the update workflow still ran a full route rebuild afterward. From a user perspective, that meant a failed recovery attempt could silently remove the account's existing route binding even though the user had only tried to repair the key.

## Root Cause
The expired API-key recovery path correctly kept the account in `expired` state and restored the previous `modelAvailability` rows on discovery failure, but `applyAccountUpdateWorkflow()` always called `rebuildRoutesBestEffort()` afterward.

That rebuild only considers `accounts.status = 'active'` as route candidates. As a result, the expired account no longer participated in the candidate set, and its existing auto-managed `route_channels` were treated as stale and deleted.

## Fix
The workflow now treats the expired API-key recovery flow specially:

- persist the edited key while preserving `expired`
- run the inactive-allowed model refresh
- reactivate and rebuild routes only if the refresh succeeds
- skip the destructive route rebuild when that recovery refresh fails or does not produce a successful result

This keeps the user-visible failure semantics narrow: the recovery still fails, the account still shows `expired`, but the previous route binding remains intact instead of being removed as collateral damage.

## Tests
I added a regression to the failed recovery case so it seeds a real exact route plus `route_channel` before editing the key, then verifies that after the failed recovery:

- the account still returns `expired`
- the new API key is persisted
- the previous `modelAvailability` row remains
- the seeded `route_channel` still exists

Validation run:

- `npx vitest run --root . src/server/routes/api/accounts.apikey-recovery.test.ts`
- `npx vitest run --root . src/server/services/modelService.discovery.test.ts`
- `npm run repo:drift-check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved API key recovery process to correctly handle route management during expired key recovery flows
* Routes are now selectively rebuilt based on recovery status and model refresh outcomes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->