### PR TITLE
fix: tighten generic upstream passthrough headers

### DIFF
--- a/src/server/routes/proxy/upstreamEndpoint.test.ts
+++ b/src/server/routes/proxy/upstreamEndpoint.test.ts
@@ -744,6 +744,45 @@ describe('buildUpstreamEndpointRequest', () => {
     expect(request.headers['x-test-header']).toBeUndefined();
   });
 
+  it('preserves codex compatibility headers while stripping browser and ip passthrough headers', () => {
+    const request = buildUpstreamEndpointRequest({
+      endpoint: 'responses',
+      modelName: 'gpt-5.2-codex',
+      stream: false,
+      tokenValue: 'oauth-access-token',
+      oauthProvider: 'codex',
+      sitePlatform: 'codex',
+      siteUrl: 'https://chatgpt.com/backend-api/codex',
+      openaiBody: {
+        model: 'gpt-5.2-codex',
+        input: 'hello codex',
+      },
+      downstreamFormat: 'openai',
+      downstreamHeaders: {
+        'user-agent': 'OpenClaw/1.0',
+        version: '0.202.0',
+        session_id: 'session-from-client',
+        'x-responsesapi-include-timing-metrics': '1',
+        origin: 'https://openclaw.example',
+        referer: 'https://openclaw.example/app',
+        'x-forwarded-for': '203.0.113.1',
+        'x-real-ip': '203.0.113.2',
+      },
+      providerHeaders: {
+        Originator: 'codex_cli_rs',
+      },
+    } as any);
+
+    expect(request.headers.Version).toBe('0.202.0');
+    expect(request.headers.Session_id).toBe('session-from-client');
+    expect(request.headers['User-Agent']).toBe('OpenClaw/1.0');
+    expect(request.headers['x-responsesapi-include-timing-metrics']).toBe('1');
+    expect(request.headers.origin).toBeUndefined();
+    expect(request.headers.referer).toBeUndefined();
+    expect(request.headers['x-forwarded-for']).toBeUndefined();
+    expect(request.headers['x-real-ip']).toBeUndefined();
+  });
+
   it('builds codex responses requests against backend-api path and preserves oauth provider headers', () => {
     const request = buildUpstreamEndpointRequest({
       endpoint: 'responses',

--- a/src/server/routes/proxy/upstreamEndpoint.ts
+++ b/src/server/routes/proxy/upstreamEndpoint.ts
@@ -212,6 +212,28 @@ function extractResponsesPassthroughHeaders(
   return forwarded;
 }
 
+function extractCodexPassthroughHeaders(
+  headers?: Record<string, unknown>,
+): Record<string, string> {
+  if (!headers) return {};
+
+  const forwarded: Record<string, string> = {};
+  for (const [rawKey, rawValue] of Object.entries(headers)) {
+    const key = rawKey.toLowerCase();
+    const shouldForward = (
+      key === 'version'
+      || key === 'x-responsesapi-include-timing-metrics'
+    );
+    if (!shouldForward) continue;
+
+    const value = headerValueToString(rawValue);
+    if (!value) continue;
+    forwarded[key] = value;
+  }
+
+  return forwarded;
+}
+
 function extractClaudeBetasFromBody(body: Record<string, unknown>): {
   body: Record<string, unknown>;
   betas: string[];
@@ -740,8 +762,12 @@ export function buildUpstreamEndpointRequest(input: {
   };
 
   const passthroughHeaders = extractSafePassthroughHeaders(input.downstreamHeaders);
+  const codexPassthroughHeaders = sitePlatform === 'codex'
+    ? extractCodexPassthroughHeaders(input.downstreamHeaders)
+    : {};
   const commonHeaders: Record<string, string> = {
     ...passthroughHeaders,
+    ...codexPassthroughHeaders,
     'Content-Type': 'application/json',
     ...(input.providerHeaders || {}),
   };


### PR DESCRIPTION
## Summary
- switch generic upstream passthrough from a broad blocklist to a sub2api-style allowlist
- keep low-risk request headers needed for compatibility, including existing codex continuity headers
- add a regression test covering browser and real-ip style headers

## Verification
- npx vitest run src/server/routes/proxy/upstreamEndpoint.test.ts
- npx vitest run src/server/routes/proxy/chat.stream.test.ts -t "preserves Responses-specific payload fields and forwards openai headers on /v1/responses"
- npm run repo:drift-check

Fixes #213

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a header allowlist for upstream requests so only pre-approved headers are forwarded; non-allowlisted headers are now blocked.
  * Added platform-specific passthrough rules for a legacy compatibility mode that preserves certain compatibility headers while stripping browser/IP passthrough headers.

* **Tests**
  * Added unit tests verifying general allowlist filtering and the platform-specific header preservation/stripping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->