### PR TITLE
[codex] align site created modal with shared actions

### DIFF
--- a/src/web/components/SiteCreatedModal.test.tsx
+++ b/src/web/components/SiteCreatedModal.test.tsx
@@ -82,4 +82,24 @@ describe('SiteCreatedModal', () => {
 
     expect(onChoice).toHaveBeenCalledWith('session');
   });
+
+  it('uses the supplied session label for OAuth-style session actions', () => {
+    const root = create(
+      <SiteCreatedModal
+        siteName="Codex Site"
+        initialSegment="session"
+        sessionLabel="添加 OAuth 连接"
+        onChoice={() => {}}
+        onClose={() => {}}
+      />,
+    );
+
+    const buttons = root.root.findAll((node) => (
+      node.type === 'button'
+      && typeof node.props.onClick === 'function'
+      && node.props['aria-label'] !== '关闭弹框'
+    ));
+
+    expect(buttons.some((button) => collectText(button) === '添加 OAuth 连接')).toBe(true);
+  });
 });

--- a/src/web/components/SiteCreatedModal.tsx
+++ b/src/web/components/SiteCreatedModal.tsx
@@ -7,6 +7,7 @@ type Props = {
   siteName: string;
   initializationPresetId?: string | null;
   initialSegment?: 'session' | 'apikey';
+  sessionLabel?: string;
   onChoice: (choice: NextStepChoice) => void;
   onClose: () => void;
 };
@@ -15,6 +16,7 @@ export default function SiteCreatedModal({
   siteName,
   initializationPresetId,
   initialSegment = 'session',
+  sessionLabel = '添加账号（用户名密码登录）',
   onChoice,
   onClose,
 }: Props) {
@@ -31,12 +33,12 @@ export default function SiteCreatedModal({
     }
     : {
       choice: 'session' as const,
-      label: '添加账号（用户名密码登录）',
+      label: sessionLabel,
     };
   const secondaryAction = apiKeyFirst
     ? {
       choice: 'session' as const,
-      label: '添加账号（用户名密码登录）',
+      label: sessionLabel,
     }
     : {
       choice: 'apikey' as const,

--- a/src/web/index.css
+++ b/src/web/index.css
@@ -3457,6 +3457,7 @@ textarea {
 
 .site-created-summary,
 .site-created-helper-text {
+  margin: 0;
   font-size: 12px;
   line-height: 1.7;
 }

--- a/src/web/pages/Sites.tsx
+++ b/src/web/pages/Sites.tsx
@@ -93,6 +93,12 @@ function formatUsd(value?: number | null): string {
   return `$${(value || 0).toFixed(2)}`;
 }
 
+function resolveSiteCreatedSessionLabel(platform?: string | null): string {
+  const normalized = String(platform || '').trim().toLowerCase();
+  if (normalized === 'codex') return '添加 OAuth 连接';
+  return '添加账号（用户名密码登录）';
+}
+
 function formatSubscriptionDate(value?: string | null): string {
   if (!value) return '';
   const parsed = Date.parse(value);
@@ -977,6 +983,7 @@ export default function Sites() {
             getSiteInitializationPreset(createdSiteForChoice.initializationPresetId)?.initialSegment
             || resolveInitialConnectionSegment(createdSiteForChoice.platform)
           }
+          sessionLabel={resolveSiteCreatedSessionLabel(createdSiteForChoice.platform)}
           onChoice={handleSiteCreatedChoice}
           onClose={() => {
             setCreatedSiteForChoice(null);

--- a/src/web/pages/sites.create-redirect.test.tsx
+++ b/src/web/pages/sites.create-redirect.test.tsx
@@ -121,19 +121,21 @@ async function createSiteAndClickModalChoice(
     // Find the button based on choice
     let targetButton;
     if (choice === 'session') {
-      targetButton = modalButtons.find((btn) => collectText(btn).includes('添加账号（用户名密码登录）'));
+      const expectedSessionLabel = createdSite.platform === 'codex'
+        ? '添加 OAuth 连接'
+        : '添加账号（用户名密码登录）';
+      targetButton = modalButtons.find((btn) => collectText(btn).includes(expectedSessionLabel));
     } else if (choice === 'apikey') {
       targetButton = modalButtons.find((btn) => collectText(btn).includes('添加 API Key'));
     } else {
       targetButton = modalButtons.find((btn) => collectText(btn).includes('稍后配置'));
     }
 
-    if (targetButton) {
-      await act(async () => {
-        targetButton.props.onClick();
-      });
-      await flushMicrotasks();
-    }
+    expect(targetButton).toBeTruthy();
+    await act(async () => {
+      targetButton!.props.onClick();
+    });
+    await flushMicrotasks();
 
     return JSON.stringify(root.toJSON());
   } finally {


### PR DESCRIPTION
## Summary
The site-created completion modal did not match the rest of the Metapi admin UI. It mixed a separate native `dialog` skin, full-width oversized action buttons, and an undefined `btn-outline` variant, so the completion state looked visually disconnected from the shared modal system used elsewhere in the web app.

For operators, the effect was immediate after creating a site: the follow-up prompt felt like a different product surface, and the secondary action button styling was inconsistent enough to read as broken rather than intentional.

## Root Cause
`SiteCreatedModal` owned its own native-dialog structure instead of reusing the shared `CenteredModal` shell. That split introduced a second layout and action pattern for the same modal family. On top of that, the completion actions relied on `btn-block` stacking and a `btn-outline` class that is not part of the current Metapi button set.

## Fix
The modal now uses the shared `CenteredModal` shell, including the standard header, close button, backdrop behavior, and footer action area. The content was reduced to the compact success and helper copy used elsewhere in Metapi, and the actions were moved into the footer as the existing `ghost / bordered ghost / primary` button hierarchy instead of large body-stacked buttons.

The tests were updated to lock in the shared modal structure and to follow the new footer-based button lookup path in the site-creation redirect flow. The redirect assertions themselves stay the same: session, API key, and later choices still route exactly as before.

## Validation
- `npm test -- src/web/components/SiteCreatedModal.test.tsx`
- `npx vitest run --root . src/web/pages/sites.create-redirect.test.tsx -t "shows modal after creating a site and navigates to session account when user chooses it|shows modal after creating a site and navigates to API key when user chooses it|shows modal after creating a codex site and allows choosing later|shows modal with all three choices after creating a site"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session button label can vary by platform; added customizable session label and extra note in the modal.

* **Refactor**
  * Replaced native dialog with a centered modal component and simplified action rendering into a fixed footer.

* **Style**
  * Added/standardized typography and helper/note styles for the modal.

* **Tests**
  * Updated modal tests to match the new structure and button selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->