### PR TITLE
[codex] add oauth pre-refresh resilience

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -274,7 +274,7 @@ app.addHook('onClose', async () => {
   stopProxyLogRetentionService();
   stopModelAvailabilityProbeScheduler();
   stopChannelRecoveryProbeScheduler();
-  stopOauthTokenRefreshScheduler();
+  await stopOauthTokenRefreshScheduler();
   await stopOAuthLoopbackCallbackServers();
 });
 

--- a/src/server/services/modelService.discovery.test.ts
+++ b/src/server/services/modelService.discovery.test.ts
@@ -1187,6 +1187,108 @@ describe('refreshModelsForAccount credential discovery', () => {
     expect(parsed.oauth).not.toHaveProperty('provider');
   });
 
+  it('preserves refreshed codex oauth metadata when the retry after refresh still fails', async () => {
+    getApiTokenMock.mockResolvedValue(null);
+    getModelsMock.mockRejectedValue(new Error('codex oauth discovery should not call adapter.getModels'));
+    refreshOauthAccessTokenSingleflightMock.mockImplementation(async (accountId: number) => {
+      const refreshedExtraConfig = JSON.stringify({
+        credentialMode: 'session',
+        oauth: {
+          provider: 'codex',
+          email: 'codex-refreshed-user@example.com',
+          accountId: 'chatgpt-account-refreshed',
+          planType: 'plus',
+          refreshToken: 'codex-refresh-token-next',
+          tokenExpiresAt: 1770000000000,
+        },
+      });
+
+      await db.update(schema.accounts).set({
+        accessToken: 'codex-access-token-refreshed',
+        oauthProvider: 'codex',
+        oauthAccountKey: 'chatgpt-account-refreshed',
+        extraConfig: refreshedExtraConfig,
+        status: 'active',
+        updatedAt: '2026-03-21T00:00:00.000Z',
+      }).where(eq(schema.accounts.id, accountId)).run();
+
+      return {
+        accountId,
+        accessToken: 'codex-access-token-refreshed',
+        accountKey: 'chatgpt-account-refreshed',
+        extraConfig: refreshedExtraConfig,
+      };
+    });
+    undiciFetchMock
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        json: async () => ({ error: 'expired' }),
+        text: async () => 'expired',
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: async () => ({ error: 'still unavailable' }),
+        text: async () => 'still unavailable',
+      });
+
+    const site = await db.insert(schema.sites).values({
+      name: 'codex-refresh-failure-site',
+      url: 'https://chatgpt.com/backend-api/codex',
+      platform: 'codex',
+      status: 'active',
+    }).returning().get();
+
+    const account = await db.insert(schema.accounts).values({
+      siteId: site.id,
+      username: 'codex-user@example.com',
+      accessToken: 'codex-access-token-expired',
+      apiToken: null,
+      status: 'active',
+      oauthProvider: 'codex',
+      oauthAccountKey: 'chatgpt-account-original',
+      extraConfig: JSON.stringify({
+        credentialMode: 'session',
+        oauth: {
+          provider: 'codex',
+          email: 'codex-user@example.com',
+          accountId: 'chatgpt-account-original',
+          planType: 'plus',
+          refreshToken: 'codex-refresh-token-old',
+          tokenExpiresAt: 1760000000000,
+        },
+      }),
+    }).returning().get();
+
+    const result = await refreshModelsForAccount(account.id);
+
+    expect(result).toMatchObject({
+      accountId: account.id,
+      refreshed: true,
+      status: 'failed',
+      errorCode: 'unknown',
+      discoveredByCredential: false,
+    });
+    expect(refreshOauthAccessTokenSingleflightMock).toHaveBeenCalledWith(account.id);
+
+    const latest = await db.select().from(schema.accounts)
+      .where(eq(schema.accounts.id, account.id))
+      .get();
+    expect(latest).toMatchObject({
+      accessToken: 'codex-access-token-refreshed',
+      oauthProvider: 'codex',
+      oauthAccountKey: 'chatgpt-account-refreshed',
+    });
+    const parsed = JSON.parse(latest!.extraConfig || '{}');
+    expect(parsed.oauth).toMatchObject({
+      email: 'codex-refreshed-user@example.com',
+      refreshToken: 'codex-refresh-token-next',
+      tokenExpiresAt: 1770000000000,
+      modelDiscoveryStatus: 'abnormal',
+    });
+  });
+
   it('marks codex oauth account abnormal when upstream cloud discovery fails', async () => {
     getApiTokenMock.mockResolvedValue(null);
     getModelsMock.mockRejectedValue(new Error('codex plan discovery should not call adapter.getModels'));

--- a/src/server/services/modelService.ts
+++ b/src/server/services/modelService.ts
@@ -109,6 +109,9 @@ export type ModelRefreshResult =
   | ModelRefreshSuccessResult;
 
 type ModelDiscoveryAccountRow = typeof schema.accounts.$inferSelect;
+type ModelDiscoveryRetryError = {
+  refreshedAccount?: ModelDiscoveryAccountRow;
+};
 
 function looksLikeHtmlJsonParseError(message: string): boolean {
   const lowered = String(message || '').trim().toLowerCase();
@@ -330,11 +333,27 @@ async function retryOauthModelDiscoveryWithRefresh<T>(input: {
     }
 
     discoveryAccount = refreshedAccount;
-    return {
-      result: await input.attempt(discoveryAccount),
-      account: discoveryAccount,
-    };
+    try {
+      return {
+        result: await input.attempt(discoveryAccount),
+        account: discoveryAccount,
+      };
+    } catch (retryError) {
+      if (retryError && typeof retryError === 'object') {
+        (retryError as ModelDiscoveryRetryError).refreshedAccount = discoveryAccount;
+        throw retryError;
+      }
+      const wrappedError = new Error(String(retryError || 'model discovery retry failed')) as Error & ModelDiscoveryRetryError;
+      wrappedError.refreshedAccount = discoveryAccount;
+      throw wrappedError;
+    }
   }
+}
+
+function extractRefreshedDiscoveryAccount(error: unknown): ModelDiscoveryAccountRow | null {
+  if (!error || typeof error !== 'object') return null;
+  const refreshedAccount = (error as ModelDiscoveryRetryError).refreshedAccount;
+  return refreshedAccount ?? null;
 }
 
 export async function refreshModelsForAccount(
@@ -488,6 +507,7 @@ export async function refreshModelsForAccount(
         discoveredApiToken: false,
       });
     } catch (err) {
+      discoveryAccount = extractRefreshedDiscoveryAccount(err) ?? discoveryAccount;
       const rawMessage = (err as { message?: string })?.message || 'codex model discovery failed';
       const errorCode = classifyModelDiscoveryError(rawMessage);
       const errorMessage = `Codex 模型获取失败（${rawMessage}）`;
@@ -567,6 +587,7 @@ export async function refreshModelsForAccount(
         discoveredApiToken: false,
       });
     } catch (err) {
+      discoveryAccount = extractRefreshedDiscoveryAccount(err) ?? discoveryAccount;
       const rawMessage = (err as { message?: string })?.message || 'claude oauth model discovery failed';
       const errorCode = classifyModelDiscoveryError(rawMessage);
       const errorMessage = `Claude OAuth 模型获取失败（${rawMessage}）`;
@@ -740,6 +761,7 @@ export async function refreshModelsForAccount(
         discoveredApiToken: false,
       });
     } catch (err) {
+      discoveryAccount = extractRefreshedDiscoveryAccount(err) ?? discoveryAccount;
       const rawMessage = (err as { message?: string })?.message || 'antigravity model discovery failed';
       const errorCode = classifyModelDiscoveryError(rawMessage);
       const errorMessage = `Antigravity 模型获取失败（${rawMessage}）`;

--- a/src/server/services/oauth/oauthRefreshScheduler.test.ts
+++ b/src/server/services/oauth/oauthRefreshScheduler.test.ts
@@ -59,17 +59,19 @@ describe('oauthRefreshScheduler', () => {
   beforeEach(async () => {
     vi.useFakeTimers();
     refreshOauthAccessTokenSingleflightMock.mockReset();
-    stopOauthTokenRefreshScheduler();
-    resetOauthTokenRefreshSchedulerForTests();
+    await stopOauthTokenRefreshScheduler();
+    await resetOauthTokenRefreshSchedulerForTests();
 
     await db.delete(schema.accounts).run();
     await db.delete(schema.sites).run();
   });
 
   afterEach(() => {
-    stopOauthTokenRefreshScheduler();
-    resetOauthTokenRefreshSchedulerForTests();
-    vi.useRealTimers();
+    return (async () => {
+      await stopOauthTokenRefreshScheduler();
+      await resetOauthTokenRefreshSchedulerForTests();
+      vi.useRealTimers();
+    })();
   });
 
   afterAll(() => {
@@ -275,8 +277,55 @@ describe('oauthRefreshScheduler', () => {
     await vi.advanceTimersByTimeAsync(60_000);
     expect(refreshOauthAccessTokenSingleflightMock).toHaveBeenCalledTimes(2);
 
-    stopOauthTokenRefreshScheduler();
+    await stopOauthTokenRefreshScheduler();
     await vi.advanceTimersByTimeAsync(60_000);
     expect(refreshOauthAccessTokenSingleflightMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('waits for an in-flight refresh pass before stop resolves', async () => {
+    const nowMs = Date.parse('2026-04-05T12:00:00.000Z');
+    vi.setSystemTime(nowMs);
+
+    let releaseRefresh: (() => void) | null = null;
+    refreshOauthAccessTokenSingleflightMock.mockImplementation(() => new Promise<void>((resolve) => {
+      releaseRefresh = resolve;
+    }));
+
+    const site = await db.insert(schema.sites).values({
+      name: 'oauth-refresh-site',
+      url: 'https://oauth-refresh.example.com',
+      platform: 'antigravity',
+      status: 'active',
+    }).returning().get();
+
+    await db.insert(schema.accounts).values({
+      siteId: site.id,
+      username: 'scheduler-user@example.com',
+      accessToken: 'scheduler-access-token',
+      apiToken: null,
+      status: 'active',
+      oauthProvider: 'antigravity',
+      oauthAccountKey: 'scheduler-user@example.com',
+      extraConfig: buildOauthExtraConfig({
+        provider: 'antigravity',
+        refreshToken: 'scheduler-refresh-token',
+        tokenExpiresAt: nowMs + (4 * 60 * 1000),
+      }),
+    }).run();
+
+    startOauthTokenRefreshScheduler(60_000);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(refreshOauthAccessTokenSingleflightMock).toHaveBeenCalledTimes(1);
+
+    let stopResolved = false;
+    const stopPromise = Promise.resolve(stopOauthTokenRefreshScheduler()).then(() => {
+      stopResolved = true;
+    });
+    await Promise.resolve();
+    expect(stopResolved).toBe(false);
+
+    releaseRefresh?.();
+    await stopPromise;
+    expect(stopResolved).toBe(true);
   });
 });

--- a/src/server/services/oauth/oauthRefreshScheduler.ts
+++ b/src/server/services/oauth/oauthRefreshScheduler.ts
@@ -15,6 +15,12 @@ const OAUTH_REFRESH_LEAD_BY_PROVIDER: Record<string, number> = {
 let oauthRefreshSchedulerTimer: ReturnType<typeof setInterval> | null = null;
 let oauthRefreshPassInFlight: Promise<void> | null = null;
 
+function clearOauthRefreshSchedulerTimer(): void {
+  if (!oauthRefreshSchedulerTimer) return;
+  clearInterval(oauthRefreshSchedulerTimer);
+  oauthRefreshSchedulerTimer = null;
+}
+
 function normalizeProvider(provider?: string | null): string {
   return String(provider || '').trim().toLowerCase();
 }
@@ -106,7 +112,7 @@ async function runScheduledOauthRefreshPass(): Promise<void> {
 }
 
 export function startOauthTokenRefreshScheduler(intervalMs = OAUTH_REFRESH_SCHEDULER_INTERVAL_MS) {
-  stopOauthTokenRefreshScheduler();
+  clearOauthRefreshSchedulerTimer();
 
   const safeIntervalMs = Math.max(OAUTH_REFRESH_SCHEDULER_INTERVAL_MS, Math.trunc(intervalMs || 0));
   void runScheduledOauthRefreshPass();
@@ -121,14 +127,14 @@ export function startOauthTokenRefreshScheduler(intervalMs = OAUTH_REFRESH_SCHED
   };
 }
 
-export function stopOauthTokenRefreshScheduler() {
-  if (oauthRefreshSchedulerTimer) {
-    clearInterval(oauthRefreshSchedulerTimer);
-    oauthRefreshSchedulerTimer = null;
+export async function stopOauthTokenRefreshScheduler() {
+  clearOauthRefreshSchedulerTimer();
+  if (oauthRefreshPassInFlight) {
+    await oauthRefreshPassInFlight;
   }
 }
 
-export function __resetOauthTokenRefreshSchedulerForTests() {
-  stopOauthTokenRefreshScheduler();
+export async function __resetOauthTokenRefreshSchedulerForTests() {
+  await stopOauthTokenRefreshScheduler();
   oauthRefreshPassInFlight = null;
 }


### PR DESCRIPTION
## Summary

This PR fixes a gap in Metapi's OAuth token lifecycle for managed cloud-backed accounts.

Users could authorize an OAuth account, sync models successfully, and then hit cloud discovery failures a few hours later once the upstream access token expired. The visible symptom was that accounts such as Antigravity would start returning `HTTP 401` / `UNAUTHENTICATED` during model discovery until the operator manually re-authorized the account. Runtime request paths already had partial on-demand refresh behavior, but the model discovery path did not consistently recover across providers, and there was no background pre-refresh loop to reduce the chance of hitting expiry during normal operation.

The root cause was twofold:

1. OAuth-backed model discovery only retried token refresh for `gemini-cli`, while the `codex`, `claude`, and `antigravity` cloud discovery branches still failed hard on expired credentials.
2. Metapi had no background service that proactively refreshed managed OAuth accounts before `tokenExpiresAt`, so the first operation after expiry still had to discover and recover from stale credentials in-band.

This PR addresses both pieces.

`refreshModelsForAccount()` now shares one OAuth refresh retry helper for cloud-backed discovery. When `codex`, `claude`, or `antigravity` model discovery receives an auth-style failure (`401`, `unauthorized`, or `unauthenticated`), Metapi refreshes the OAuth token through `refreshOauthAccessTokenSingleflight`, reloads the persisted account state, and retries discovery with the new token. That makes the cloud discovery path consistent with the existing `gemini-cli` recovery behavior and prevents the account from being marked abnormal just because the access token rolled over.

On top of that, Metapi now starts a dedicated background OAuth refresh service at server startup. The service scans managed OAuth accounts on a short interval, looks for accounts with both `refreshToken` and `tokenExpiresAt`, and proactively refreshes credentials before they expire. The lead window is provider-aware: `codex` uses a long lead like CLIProxyAPI, `claude` uses an hours-scale window, and the Google-backed providers (`gemini-cli` and `antigravity`) use a short pre-expiry window. This means `gemini-cli` is now also covered by proactive refresh, not just by 401 retry during validation.

The scheduler is best-effort and isolated in its own service so it does not entangle the existing check-in or balance cron logic. Startup triggers an immediate pass, later passes are interval-based, and shutdown cleanly stops the timer.

## Test Plan

- `npx vitest run src/server/services/oauth/oauthRefreshScheduler.test.ts src/server/services/modelService.discovery.test.ts`
- `npm run typecheck:server`
- `npm run repo:drift-check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic OAuth token refresh scheduling added and integrated with server lifecycle
  * Model discovery now retries using refreshed OAuth tokens when initial requests fail

* **Tests**
  * Comprehensive tests for the OAuth token refresh scheduler behavior and lifecycle
  * New test coverage for model discovery retry scenarios with OAuth token refresh
<!-- end of auto-generated comment: release notes by coderabbit.ai -->