### PR TITLE
[codex] fix codex compact non-stream accept header

### DIFF
--- a/src/server/proxy-core/providers/codexProviderProfile.ts
+++ b/src/server/proxy-core/providers/codexProviderProfile.ts
@@ -20,6 +20,7 @@ export const codexProviderProfile: ProviderProfile = {
     const headers = buildCodexRuntimeHeaders({
       baseHeaders: input.baseHeaders,
       providerHeaders: input.providerHeaders,
+      stream: input.stream,
       explicitSessionId: asTrimmedString(input.codexExplicitSessionId) || null,
       continuityKey: asTrimmedString(input.codexSessionCacheKey) || null,
       userAgentOverride: configuredUserAgent || null,

--- a/src/server/proxy-core/providers/headerUtils.test.ts
+++ b/src/server/proxy-core/providers/headerUtils.test.ts
@@ -61,6 +61,7 @@ describe('provider header utils', () => {
         originator: 'codex_cli_rs',
         'chatgpt-account-id': 'acct-1',
       },
+      stream: false,
       continuityKey: 'cache-key-1',
       explicitSessionId: null,
     });
@@ -70,7 +71,7 @@ describe('provider header utils', () => {
     expect(headers['Chatgpt-Account-Id']).toBe('acct-1');
     expect(headers.Session_id).toMatch(/^[0-9a-f-]{36}$/);
     expect(headers.Conversation_id).toBe(headers.Session_id);
-    expect(headers.Accept).toBe('text/event-stream');
+    expect(headers.Accept).toBe('application/json');
   });
 
   it('builds claude runtime headers with merged betas and oauth bearer auth', async () => {

--- a/src/server/proxy-core/providers/headerUtils.ts
+++ b/src/server/proxy-core/providers/headerUtils.ts
@@ -114,6 +114,7 @@ function asTrimmedString(value: unknown): string {
 export function buildCodexRuntimeHeaders(input: {
   baseHeaders: Record<string, string>;
   providerHeaders?: Record<string, string>;
+  stream?: boolean;
   explicitSessionId?: string | null;
   continuityKey?: string | null;
   versionDefault?: string;
@@ -177,7 +178,7 @@ export function buildCodexRuntimeHeaders(input: {
     Session_id: sessionId,
     ...(conversationId ? { Conversation_id: conversationId } : {}),
     'User-Agent': userAgent,
-    Accept: 'text/event-stream',
+    Accept: input.stream === false ? 'application/json' : 'text/event-stream',
     Connection: 'Keep-Alive',
   };
 }

--- a/src/server/routes/proxy/responses.compact-upstream.test.ts
+++ b/src/server/routes/proxy/responses.compact-upstream.test.ts
@@ -362,6 +362,7 @@ describe('responses proxy compact upstream routing', () => {
     expect(forwardedBody.stream_options).toBeUndefined();
     expect(forwardedBody.instructions).toBe('');
     expect(forwardedBody.store).toBe(false);
+    expect(options.headers.Accept || options.headers.accept).toBe('application/json');
   });
 
   it('preserves native response.compaction payloads instead of coercing them into object=response', async () => {

--- a/src/server/routes/proxy/upstreamEndpoint.test.ts
+++ b/src/server/routes/proxy/upstreamEndpoint.test.ts
@@ -815,7 +815,7 @@ describe('buildUpstreamEndpointRequest', () => {
     expect(request.headers.Session_id).toMatch(/^[0-9a-f-]{36}$/i);
     expect(request.headers.Conversation_id).toBe(request.headers.Session_id);
     expect(request.headers['User-Agent']).toBe('codex_cli_rs/0.101.0 (Mac OS 26.0.1; arm64) Apple_Terminal/464');
-    expect(request.headers.Accept).toBe('text/event-stream');
+    expect(request.headers.Accept).toBe('application/json');
     expect(request.headers.Connection).toBe('Keep-Alive');
     expect(request.body.instructions).toBe('');
     expect(request.body.prompt_cache_key).toBeUndefined();


### PR DESCRIPTION
## What happened

Codex Desktop compact requests to `/v1/responses/compact` could still fail against ChatGPT Codex OAuth with `Upstream returned HTTP 400: Unknown parameter: 'stream'.` even after the runtime compact fallback setting had been enabled in production.

From live investigation on `cita`, the failure was real and reproducible on the Codex OAuth site/path family: the runtime setting `responses_compact_fallback_to_responses_enabled` was already persisted, but compact requests on the native Codex path were still being rejected before any ordinary `/responses` fallback could help.

## Root cause

The compact request body normalization was only half-complete. We already stripped `stream` and `stream_options` from the compact request body before proxying to Codex, but the Codex provider header builder still hard-coded `Accept: text/event-stream` for every responses request, including non-stream compact calls.

That meant `/responses/compact` was still being shaped like a streaming request at the header layer even when the body had been normalized to a non-stream payload. The visible user effect was a 400 on the compact endpoint instead of a valid non-stream compact response.

## Fix

This patch makes the Codex header builder respect the actual stream mode and emit `Accept: application/json` when `stream === false`, while preserving the existing SSE header behavior for true streaming requests.

The change is intentionally narrow:

- thread the resolved `stream` flag through the Codex provider profile into `buildCodexRuntimeHeaders(...)`
- switch Codex Accept negotiation to `application/json` for non-stream requests and keep `text/event-stream` for streaming requests
- add coverage at the compact route level and lower-level provider/upstream request tests so the regression is pinned at both the proxy path and provider-header boundary

## Validation

`npm exec vitest -- run --root . src/server/proxy-core/providers/headerUtils.test.ts src/server/routes/proxy/upstreamEndpoint.test.ts src/server/routes/proxy/responses.compact-upstream.test.ts`

`npm run repo:drift-check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable streaming mode, allowing responses to be returned as either streaming (event-stream) or JSON format based on request parameters.

* **Tests**
  * Updated test suite assertions to validate the new streaming mode behavior and corresponding header changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->