### PR TITLE
Fix proxy-debug undici response header capture

### DIFF
--- a/src/server/services/proxyDebugTraceStore.test.ts
+++ b/src/server/services/proxyDebugTraceStore.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { Response } from 'undici';
 
 type DbModule = typeof import('../db/index.js');
 type StoreModule = typeof import('./proxyDebugTraceStore.js');
@@ -182,5 +183,19 @@ describe('proxyDebugTraceStore', () => {
     });
     expect(typeof bodyPayload.preview).toBe('string');
     expect(bodyPayload.preview).toContain('"model": "gpt-5.4"');
+  });
+
+  it('normalizes undici response headers for proxy debug capture', () => {
+    const response = new Response('ok', {
+      headers: {
+        'content-type': 'application/json',
+        'x-trace-id': 'trace-123',
+      },
+    });
+
+    expect(store.normalizeProxyDebugResponseHeaders(response.headers)).toEqual({
+      'content-type': 'application/json',
+      'x-trace-id': 'trace-123',
+    });
   });
 });

--- a/src/server/services/proxyDebugTraceStore.ts
+++ b/src/server/services/proxyDebugTraceStore.ts
@@ -70,8 +70,12 @@ function stringifyDebugValue(value: unknown, maxBytes: number): string | null {
 function normalizeHeadersValue(value: HeadersLike): Record<string, unknown> | null {
   if (!value) return null;
 
-  if (typeof Headers !== 'undefined' && value instanceof Headers) {
-    return Object.fromEntries([...value.entries()].sort((left, right) => left[0].localeCompare(right[0])));
+  const headerEntries = value as { entries?: unknown; get?: unknown };
+  if (typeof headerEntries.get === 'function' && typeof headerEntries.entries === 'function') {
+    return Object.fromEntries(
+      [...headerEntries.entries.call(value) as Iterable<[string, string]>]
+        .sort((left, right) => left[0].localeCompare(right[0])),
+    );
   }
 
   if (typeof value !== 'object' || Array.isArray(value)) {


### PR DESCRIPTION
## Summary
- normalize proxy-debug headers from undici response header objects via the headers interface instead of a global Headers instanceof check
- add a regression test covering undici Response.headers so upstream response headers no longer collapse to an empty object

## Testing
- npm test -- src/server/services/proxyDebugTraceStore.test.ts src/server/routes/api/stats.proxy-debug.test.ts src/server/services/proxyDebugTraceRuntime.test.ts
- npm run repo:drift-check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test case validating that proxy debug trace capture properly normalizes and preserves response headers including content-type and trace identifier fields

* **Bug Fixes**
  * Improved header normalization logic in proxy debug trace capture to correctly process and handle Headers-like objects from various HTTP response libraries, expanding platform compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->