### PR TITLE
[daily] restore oauth route channels on delete rollback

### DIFF
--- a/src/server/routes/api/oauth.test.ts
+++ b/src/server/routes/api/oauth.test.ts
@@ -3246,6 +3246,97 @@ describe('oauth routes', { timeout: 15_000 }, () => {
     }
   });
 
+  it('restores oauth route unit route channels when delete rebuild keeps failing', async () => {
+    const site = await db.insert(schema.sites).values({
+      name: 'ChatGPT Codex OAuth',
+      url: 'https://chatgpt.com/backend-api/codex',
+      platform: 'codex',
+      status: 'active',
+    }).returning().get();
+
+    const first = await db.insert(schema.accounts).values({
+      siteId: site.id,
+      username: 'rollback-delete-double-fail-a@example.com',
+      accessToken: 'rollback-delete-double-fail-access-a',
+      status: 'active',
+      oauthProvider: 'codex',
+      oauthAccountKey: 'rollback-delete-double-fail-a',
+      extraConfig: JSON.stringify({
+        oauth: {
+          provider: 'codex',
+          accountId: 'rollback-delete-double-fail-a',
+          accountKey: 'rollback-delete-double-fail-a',
+          email: 'rollback-delete-double-fail-a@example.com',
+          refreshToken: 'rollback-delete-double-fail-refresh-a',
+        },
+      }),
+    }).returning().get();
+    const second = await db.insert(schema.accounts).values({
+      siteId: site.id,
+      username: 'rollback-delete-double-fail-b@example.com',
+      accessToken: 'rollback-delete-double-fail-access-b',
+      status: 'active',
+      oauthProvider: 'codex',
+      oauthAccountKey: 'rollback-delete-double-fail-b',
+      extraConfig: JSON.stringify({
+        oauth: {
+          provider: 'codex',
+          accountId: 'rollback-delete-double-fail-b',
+          accountKey: 'rollback-delete-double-fail-b',
+          email: 'rollback-delete-double-fail-b@example.com',
+          refreshToken: 'rollback-delete-double-fail-refresh-b',
+        },
+      }),
+    }).returning().get();
+
+    await db.insert(schema.modelAvailability).values([
+      { accountId: first.id, modelName: 'gpt-5.4', available: true },
+      { accountId: second.id, modelName: 'gpt-5.4', available: true },
+    ]).run();
+
+    const routeRefreshWorkflow = await import('../../services/routeRefreshWorkflow.js');
+    await routeRefreshWorkflow.rebuildRoutesOnly();
+
+    const createResponse = await app.inject({
+      method: 'POST',
+      url: '/api/oauth/route-units',
+      payload: {
+        accountIds: [first.id, second.id],
+        name: 'Rollback Delete Double Fail Pool',
+        strategy: 'round_robin',
+      },
+    });
+    expect(createResponse.statusCode).toBe(200);
+    const routeUnitId = createResponse.json().routeUnit?.id as number;
+
+    const rebuildSpy = vi.spyOn(routeRefreshWorkflow, 'rebuildRoutesOnly');
+    rebuildSpy.mockImplementation(async () => {
+      throw new Error('route rebuild failed');
+    });
+
+    try {
+      const response = await app.inject({
+        method: 'DELETE',
+        url: `/api/oauth/route-units/${routeUnitId}`,
+      });
+
+      expect(response.statusCode).toBe(500);
+      expect(response.json()).toMatchObject({
+        message: 'route rebuild failed',
+      });
+
+      const routeUnits = await db.select().from(schema.oauthRouteUnits).all();
+      expect(routeUnits).toHaveLength(1);
+      const members = await db.select().from(schema.oauthRouteUnitMembers).all();
+      expect(members).toHaveLength(2);
+      const routeChannels = await db.select().from(schema.routeChannels).all();
+      expect(routeChannels).toHaveLength(1);
+      expect(routeChannels[0]?.oauthRouteUnitId).toBe(routeUnitId);
+    } finally {
+      rebuildSpy.mockRestore();
+    }
+  });
+
   it('accepts normalized route unit strategy values from the HTTP payload', async () => {
     const site = await db.insert(schema.sites).values({
       name: 'ChatGPT Codex OAuth',

--- a/src/server/services/oauth/routeUnitService.ts
+++ b/src/server/services/oauth/routeUnitService.ts
@@ -153,6 +153,7 @@ async function rollbackCreatedOauthRouteUnit(routeUnitId: number): Promise<void>
 async function restoreDeletedOauthRouteUnit(snapshot: {
   unit: typeof schema.oauthRouteUnits.$inferSelect;
   members: Array<typeof schema.oauthRouteUnitMembers.$inferSelect>;
+  channels: Array<typeof schema.routeChannels.$inferSelect>;
 }): Promise<void> {
   await db.transaction(async (tx) => {
     await tx.insert(schema.oauthRouteUnits).values({
@@ -174,6 +175,31 @@ async function restoreDeletedOauthRouteUnit(snapshot: {
         sortOrder: member.sortOrder,
         createdAt: member.createdAt,
         updatedAt: member.updatedAt,
+      }))).run();
+    }
+
+    if (snapshot.channels.length > 0) {
+      await tx.insert(schema.routeChannels).values(snapshot.channels.map((channel) => ({
+        id: channel.id,
+        routeId: channel.routeId,
+        accountId: channel.accountId,
+        tokenId: channel.tokenId,
+        oauthRouteUnitId: channel.oauthRouteUnitId,
+        sourceModel: channel.sourceModel,
+        priority: channel.priority,
+        weight: channel.weight,
+        enabled: channel.enabled,
+        manualOverride: channel.manualOverride,
+        successCount: channel.successCount,
+        failCount: channel.failCount,
+        totalLatencyMs: channel.totalLatencyMs,
+        totalCost: channel.totalCost,
+        lastUsedAt: channel.lastUsedAt,
+        lastSelectedAt: channel.lastSelectedAt,
+        lastFailAt: channel.lastFailAt,
+        consecutiveFailCount: channel.consecutiveFailCount,
+        cooldownLevel: channel.cooldownLevel,
+        cooldownUntil: channel.cooldownUntil,
       }))).run();
     }
   });
@@ -373,6 +399,9 @@ export async function deleteOauthRouteUnit(routeUnitId: number) {
   const existingMembers = await db.select().from(schema.oauthRouteUnitMembers)
     .where(eq(schema.oauthRouteUnitMembers.unitId, routeUnitId))
     .all();
+  const existingChannels = await db.select().from(schema.routeChannels)
+    .where(eq(schema.routeChannels.oauthRouteUnitId, routeUnitId))
+    .all();
 
   await db.delete(schema.routeChannels)
     .where(eq(schema.routeChannels.oauthRouteUnitId, routeUnitId))
@@ -390,6 +419,7 @@ export async function deleteOauthRouteUnit(routeUnitId: number) {
     await restoreDeletedOauthRouteUnit({
       unit: existing,
       members: existingMembers,
+      channels: existingChannels,
     });
     try {
       await routeRefreshWorkflow.rebuildRoutesOnly();


### PR DESCRIPTION
## Source Delta Reviewed
- `3edeb6e24532819943d23802cdf8fb58271bbfd5..63c435c90189d175ccdb533bbdc1cf52e3996b41` on `origin/main`
- regression family introduced by `#440` (`[codex] add oauth route pools and proxy save flow`)

## Problem
Deleting an OAuth route unit removes its collapsed `route_channels` before route rebuild. If the rebuild fails and the best-effort retry also fails, the request returns an error after those route rows have already been lost.

## Root Cause
The delete rollback restored `oauth_route_units` and `oauth_route_unit_members`, but it relied on a second `rebuildRoutesOnly()` call to recreate the deleted `route_channels`. Persistent rebuild failure left the original routing shape partially deleted.

## Fix
- snapshot the deleted route-unit `route_channels` before removal
- restore those rows inside the rollback transaction together with the route unit and members
- add a regression test that keeps both rebuild attempts failing and asserts the collapsed route row is preserved

## Verification
- `npx vitest run src/server/routes/api/oauth.test.ts`

## Residual Risk
This only hardens the rollback path for route-unit deletion. It does not change the happy-path rebuild logic or broader route rebuild behavior.

## Why This Is Safe To Merge
The patch is limited to one server rollback helper plus one focused regression test. There are no API contract, schema, or happy-path routing changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for OAuth route unit deletion. When deletion operations fail, the system now automatically restores the previous routing configuration and associated channels, maintaining data consistency and preventing incomplete state changes.

* **Tests**
  * Added test coverage for OAuth route unit deletion failure recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->