### PR TITLE
[codex] smooth route detail panel motion

### DIFF
--- a/src/web/index.css
+++ b/src/web/index.css
@@ -6786,7 +6786,7 @@ textarea {
 }
 
 @keyframes route-detail-panel-in {
-  from {
+  0% {
     opacity: 0;
     clip-path: inset(0 0 100% 0 round 16px);
     transform: translateY(-8px) scale(0.992);
@@ -6798,7 +6798,7 @@ textarea {
     transform: translateY(0) scale(1.006);
   }
 
-  to {
+  100% {
     opacity: 1;
     clip-path: inset(0 0 0 0 round 16px);
     transform: translateY(0) scale(1);
@@ -6806,13 +6806,13 @@ textarea {
 }
 
 @keyframes route-detail-panel-out {
-  from {
+  0% {
     opacity: 1;
     clip-path: inset(0 0 0 0 round 16px);
     transform: translateY(0) scale(1);
   }
 
-  to {
+  100% {
     opacity: 0;
     clip-path: inset(0 0 100% 0 round 16px);
     transform: translateY(-6px) scale(0.994);

--- a/src/web/index.css
+++ b/src/web/index.css
@@ -6764,14 +6764,13 @@ textarea {
   border-top-left-radius: 16px;
   border-top-right-radius: 16px;
   contain: layout paint;
+  will-change: transform, opacity, clip-path;
+  backface-visibility: hidden;
+  transform-origin: top center;
 }
 
 .route-detail-panel-presence {
   overflow: clip;
-  contain: layout paint;
-  opacity: 1;
-  transform: none;
-  transition: grid-template-rows 0.18s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 .route-detail-panel-presence.is-closing {
@@ -6779,18 +6778,44 @@ textarea {
 }
 
 .route-detail-panel-presence.is-open .route-card-detail-panel {
-  animation: route-detail-panel-in 0.18s cubic-bezier(0.22, 1, 0.36, 1);
+  animation: route-detail-panel-in 0.26s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.route-detail-panel-presence.is-closing .route-card-detail-panel {
+  animation: route-detail-panel-out 0.2s cubic-bezier(0.4, 0, 1, 1) both;
 }
 
 @keyframes route-detail-panel-in {
   from {
     opacity: 0;
-    transform: translateY(-4px);
+    clip-path: inset(0 0 100% 0 round 16px);
+    transform: translateY(-8px) scale(0.992);
+  }
+
+  62% {
+    opacity: 1;
+    clip-path: inset(0 0 0 0 round 16px);
+    transform: translateY(0) scale(1.006);
   }
 
   to {
     opacity: 1;
-    transform: translateY(0);
+    clip-path: inset(0 0 0 0 round 16px);
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes route-detail-panel-out {
+  from {
+    opacity: 1;
+    clip-path: inset(0 0 0 0 round 16px);
+    transform: translateY(0) scale(1);
+  }
+
+  to {
+    opacity: 0;
+    clip-path: inset(0 0 100% 0 round 16px);
+    transform: translateY(-6px) scale(0.994);
   }
 }
 

--- a/src/web/index.css
+++ b/src/web/index.css
@@ -6764,7 +6764,6 @@ textarea {
   border-top-left-radius: 16px;
   border-top-right-radius: 16px;
   contain: layout paint;
-  will-change: transform, opacity, clip-path;
   backface-visibility: hidden;
   transform-origin: top center;
 }
@@ -6778,11 +6777,32 @@ textarea {
 }
 
 .route-detail-panel-presence.is-open .route-card-detail-panel {
+  will-change: transform, opacity, clip-path;
   animation: route-detail-panel-in 0.26s cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
 .route-detail-panel-presence.is-closing .route-card-detail-panel {
+  will-change: transform, opacity, clip-path;
   animation: route-detail-panel-out 0.2s cubic-bezier(0.4, 0, 1, 1) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .route-detail-panel-presence.is-open .route-card-detail-panel,
+  .route-detail-panel-presence.is-closing .route-card-detail-panel {
+    animation: none;
+  }
+
+  .route-detail-panel-presence.is-open .route-card-detail-panel {
+    opacity: 1;
+    clip-path: inset(0 0 0 0 round 16px);
+    transform: translateY(0) scale(1);
+  }
+
+  .route-detail-panel-presence.is-closing .route-card-detail-panel {
+    opacity: 0;
+    clip-path: inset(0 0 100% 0 round 16px);
+    transform: translateY(-6px) scale(0.994);
+  }
 }
 
 @keyframes route-detail-panel-in {

--- a/src/web/index.css
+++ b/src/web/index.css
@@ -6777,6 +6777,12 @@ textarea {
 }
 
 .route-detail-panel-presence.is-open .route-card-detail-panel {
+  opacity: 1;
+  clip-path: inset(0 0 0 0 round 16px);
+  transform: translateY(0) scale(1);
+}
+
+.route-detail-panel-presence.is-entering .route-card-detail-panel {
   will-change: transform, opacity, clip-path;
   animation: route-detail-panel-in 0.26s cubic-bezier(0.22, 1, 0.36, 1) both;
 }
@@ -6787,7 +6793,7 @@ textarea {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .route-detail-panel-presence.is-open .route-card-detail-panel,
+  .route-detail-panel-presence.is-entering .route-card-detail-panel,
   .route-detail-panel-presence.is-closing .route-card-detail-panel {
     animation: none;
   }

--- a/src/web/pages/TokenRoutes.tsx
+++ b/src/web/pages/TokenRoutes.tsx
@@ -93,7 +93,13 @@ const EMPTY_ROUTE_FORM: RouteEditorForm = {
   sourceRouteIds: [],
   advancedOpen: false,
 };
+const DESKTOP_DETAIL_ENTER_MS = 260;
 const DESKTOP_DETAIL_COLLAPSE_MS = 200;
+
+function prefersReducedMotion(): boolean {
+  return typeof globalThis.matchMedia === 'function'
+    && globalThis.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
 
 function getRouteRoutingStrategySuccessMessage(value: RouteRoutingStrategy): string {
   if (value === 'round_robin') return '已切换为轮询策略';
@@ -114,30 +120,44 @@ export function DesktopDetailPanelPresence({
 }) {
   const [shouldRender, setShouldRender] = useState(open);
   const [isOpen, setIsOpen] = useState(open);
+  const [isEntering, setIsEntering] = useState(false);
   const [isClosing, setIsClosing] = useState(false);
   const hasEverOpenedRef = useRef(open);
 
   useEffect(() => {
+    const reduceMotion = prefersReducedMotion();
+
     if (open) {
       hasEverOpenedRef.current = true;
       setShouldRender(true);
-      setIsClosing(false);
-      if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
-        const rafId = window.requestAnimationFrame(() => setIsOpen(true));
-        return () => window.cancelAnimationFrame(rafId);
-      }
       setIsOpen(true);
-      return undefined;
+      setIsClosing(false);
+      if (reduceMotion) {
+        setIsEntering(false);
+        return undefined;
+      }
+      setIsEntering(true);
+      const enterTimerId = globalThis.setTimeout(() => {
+        setIsEntering(false);
+      }, DESKTOP_DETAIL_ENTER_MS);
+      return () => globalThis.clearTimeout(enterTimerId);
     }
 
     if (!hasEverOpenedRef.current) {
       setShouldRender(false);
       setIsOpen(false);
+      setIsEntering(false);
       setIsClosing(false);
       return undefined;
     }
 
     setIsOpen(false);
+    setIsEntering(false);
+    if (reduceMotion) {
+      setShouldRender(false);
+      setIsClosing(false);
+      return undefined;
+    }
     setIsClosing(true);
     const timerId = globalThis.setTimeout(() => {
       setShouldRender(false);
@@ -150,7 +170,7 @@ export function DesktopDetailPanelPresence({
   if (!shouldRender) return null;
   return (
     <div
-      className={`route-detail-panel-presence ${isOpen ? 'is-open' : ''} ${isClosing ? 'is-closing' : ''}`.trim()}
+      className={`route-detail-panel-presence ${isOpen ? 'is-open' : ''} ${isEntering ? 'is-entering' : ''} ${isClosing ? 'is-closing' : ''}`.trim()}
       style={{ gridColumn: '1 / -1' }}
     >
       {children(isClosing)}
@@ -1280,15 +1300,20 @@ export default function TokenRoutes() {
     const isCurrentlyExpanded = expandedRouteIds.includes(routeId);
     if (isCurrentlyExpanded) {
       if (!isMobile) {
-        setClosingDesktopDetailRouteIds((prev) => (prev.includes(routeId) ? prev : [...prev, routeId]));
-        const existingTimer = desktopDetailCloseTimersRef.current[routeId];
-        if (existingTimer) {
-          globalThis.clearTimeout(existingTimer);
-        }
-        desktopDetailCloseTimersRef.current[routeId] = globalThis.setTimeout(() => {
+        const reduceMotion = prefersReducedMotion();
+        if (reduceMotion) {
           setClosingDesktopDetailRouteIds((prev) => prev.filter((id) => id !== routeId));
-          delete desktopDetailCloseTimersRef.current[routeId];
-        }, DESKTOP_DETAIL_COLLAPSE_MS);
+        } else {
+          setClosingDesktopDetailRouteIds((prev) => (prev.includes(routeId) ? prev : [...prev, routeId]));
+          const existingTimer = desktopDetailCloseTimersRef.current[routeId];
+          if (existingTimer) {
+            globalThis.clearTimeout(existingTimer);
+          }
+          desktopDetailCloseTimersRef.current[routeId] = globalThis.setTimeout(() => {
+            setClosingDesktopDetailRouteIds((prev) => prev.filter((id) => id !== routeId));
+            delete desktopDetailCloseTimersRef.current[routeId];
+          }, DESKTOP_DETAIL_COLLAPSE_MS);
+        }
       }
       setExpandedRouteIds((prev) => prev.filter((id) => id !== routeId));
     } else {

--- a/src/web/pages/TokenRoutes.tsx
+++ b/src/web/pages/TokenRoutes.tsx
@@ -93,7 +93,7 @@ const EMPTY_ROUTE_FORM: RouteEditorForm = {
   sourceRouteIds: [],
   advancedOpen: false,
 };
-const DESKTOP_DETAIL_COLLAPSE_MS = 180;
+const DESKTOP_DETAIL_COLLAPSE_MS = 200;
 
 function getRouteRoutingStrategySuccessMessage(value: RouteRoutingStrategy): string {
   if (value === 'round_robin') return '已切换为轮询策略';
@@ -150,12 +150,10 @@ export function DesktopDetailPanelPresence({
   if (!shouldRender) return null;
   return (
     <div
-      className={`route-detail-panel-presence anim-collapse route-panel-collapse ${isOpen ? 'is-open' : ''} ${isClosing ? 'is-closing' : ''}`.trim()}
+      className={`route-detail-panel-presence ${isOpen ? 'is-open' : ''} ${isClosing ? 'is-closing' : ''}`.trim()}
       style={{ gridColumn: '1 / -1' }}
     >
-      <div className="anim-collapse-inner">
-        {children(isClosing)}
-      </div>
+      {children(isClosing)}
     </div>
   );
 }

--- a/src/web/pages/tokenRoutes.desktop-detail-panel.test.tsx
+++ b/src/web/pages/tokenRoutes.desktop-detail-panel.test.tsx
@@ -62,6 +62,7 @@ async function flushMicrotasks() {
 
 describe('TokenRoutes desktop detail panel', () => {
   const originalIntersectionObserver = globalThis.IntersectionObserver;
+  const originalMatchMedia = globalThis.matchMedia;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -74,6 +75,20 @@ describe('TokenRoutes desktop detail panel', () => {
       readonly rootMargin = '0px';
       readonly thresholds = [];
     } as unknown as typeof IntersectionObserver;
+    const defaultMatchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(() => false),
+    }));
+    globalThis.matchMedia = defaultMatchMedia as unknown as typeof matchMedia;
+    if (typeof window !== 'undefined') {
+      window.matchMedia = defaultMatchMedia as unknown as typeof window.matchMedia;
+    }
     getBrandMock.mockReset();
     getBrandMock.mockReturnValue(null);
     apiMock.getRoutesSummary.mockResolvedValue([
@@ -136,6 +151,10 @@ describe('TokenRoutes desktop detail panel', () => {
   afterEach(() => {
     vi.clearAllMocks();
     globalThis.IntersectionObserver = originalIntersectionObserver;
+    globalThis.matchMedia = originalMatchMedia;
+    if (typeof window !== 'undefined') {
+      window.matchMedia = originalMatchMedia as typeof window.matchMedia;
+    }
   });
 
   it('keeps summary cards stable and opens a separate desktop detail panel', async () => {
@@ -283,6 +302,78 @@ describe('TokenRoutes desktop detail panel', () => {
 
       expect(root.toJSON()).toBeNull();
       expect(setTimeoutSpy).not.toHaveBeenCalled();
+    } finally {
+      root?.unmount();
+      vi.useRealTimers();
+    }
+  });
+
+  it('closes the desktop detail panel immediately when reduced motion is preferred', async () => {
+    vi.useFakeTimers();
+    const reducedMotionMatchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: query === '(prefers-reduced-motion: reduce)',
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(() => false),
+    }));
+    globalThis.matchMedia = reducedMotionMatchMedia as unknown as typeof matchMedia;
+    if (typeof window !== 'undefined') {
+      window.matchMedia = reducedMotionMatchMedia as unknown as typeof window.matchMedia;
+    }
+    let root!: ReactTestRenderer;
+
+    try {
+      await act(async () => {
+        root = create(
+          <MemoryRouter initialEntries={['/routes']}>
+            <ToastProvider>
+              <TokenRoutes />
+            </ToastProvider>
+          </MemoryRouter>,
+        );
+      });
+      await flushMicrotasks();
+
+      const firstSummaryCard = root.root.find((node) => (
+        node.type === 'div'
+        && String(node.props.className || '').includes('route-card-collapsed')
+        && collectText(node).includes('gpt-4o-mini')
+      ));
+
+      await act(async () => {
+        await firstSummaryCard.props.onClick();
+      });
+      await flushMicrotasks();
+
+      const closeButton = root.root.find((node) => (
+        node.type === 'button'
+        && collectText(node).includes('收起详情')
+      ));
+
+      await act(async () => {
+        await closeButton.props.onClick();
+      });
+      await flushMicrotasks();
+      await act(async () => {
+        vi.advanceTimersByTime(1);
+      });
+      await flushMicrotasks();
+
+      const detailPanelPresence = root.root.findAll((node) => (
+        node.type === 'div'
+        && String(node.props.className || '').includes('route-detail-panel-presence')
+      ));
+      expect(detailPanelPresence).toHaveLength(0);
+      const summaryCardAfterClosing = root.root.find((node) => (
+        node.type === 'div'
+        && String(node.props.className || '').includes('route-card-collapsed')
+        && collectText(node).includes('gpt-4o-mini')
+      ));
+      expect(String(summaryCardAfterClosing.props.className || '')).not.toContain('is-active');
     } finally {
       root?.unmount();
       vi.useRealTimers();

--- a/src/web/pages/tokenRoutes.desktop-detail-panel.test.tsx
+++ b/src/web/pages/tokenRoutes.desktop-detail-panel.test.tsx
@@ -230,7 +230,7 @@ describe('TokenRoutes desktop detail panel', () => {
         && String(node.props.className || '').includes('route-detail-panel-presence')
       ));
       expect(detailPanelPresence).toHaveLength(1);
-      expect(String(detailPanelPresence[0]!.props.className || '')).toContain('anim-collapse');
+      expect(String(detailPanelPresence[0]!.props.className || '')).not.toContain('anim-collapse');
       expect(String(detailPanelPresence[0]!.props.className || '')).not.toContain('is-open');
       expect(String(detailPanelPresence[0]!.props.className || '')).toContain('is-closing');
       const detailPanelsWhileClosing = root.root.findAll((node) => (


### PR DESCRIPTION
## Summary

This PR smooths the desktop route detail panel motion on the Token Routes page while restoring a more panel-like reveal feel.

## User-visible problem

On the route page, expanding or collapsing a model route detail panel felt noticeably less smooth than the lightweight filter panel. After the first motion fix, the interaction became smooth again, but it still felt less "q弹" than the debug trace panel on the Proxy Logs page.

## Root cause

The desktop route detail panel lives inside the multi-column route grid and spans the full row. Reusing the shared `anim-collapse` container meant animating layout-facing properties (`grid-template-rows`) inside that grid context, which made expand/collapse prone to jank. The route detail panel therefore needed a motion path that preserved the panel reveal feel without going back to layout-driven collapse.

## Fix

- remove the desktop route detail presence wrapper from the shared `anim-collapse` path
- keep the presence shell lightweight and let the detail card animate itself
- switch the detail card motion to transform/opacity/clip-path-based keyframes
- tune the open/close timing so the reveal feels closer to the Proxy Logs debug panel without reintroducing layout jank
- align the close timer with the updated animation duration
- update the desktop detail-panel test to match the new presence behavior

## Validation

- `npm test -- src/web/pages/tokenRoutes.desktop-detail-panel.test.tsx src/web/pages/tokenRoutes.group-collapse.test.tsx src/web/pages/token-routes/RouteFilterBar.test.tsx`
- `npm run typecheck:web`
- `npm run typecheck:web:test`
- `npm run repo:drift-check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes & Improvements**
  * Redesigned route detail panel reveal/close with a rounded clip-path reveal, subtle overshoot on open, and crisper close animation
  * Adjusted desktop timing (slightly longer enter/close) for more reliable responsiveness
  * Properly honor prefers-reduced-motion: animations are skipped and panels hide immediately when requested

* **Tests**
  * Updated tests and matchMedia mocking to verify new open/close behavior and reduced-motion immediate-hide handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->