### PR TITLE
[codex] expose more payload-rule upstream types

### DIFF
--- a/src/web/pages/Settings.tsx
+++ b/src/web/pages/Settings.tsx
@@ -8,6 +8,7 @@ import ModernSelect from '../components/ModernSelect.js';
 import ResponsiveFormGrid from '../components/ResponsiveFormGrid.js';
 import FactoryResetModal from './settings/FactoryResetModal.js';
 import ModelAvailabilityProbeConfirmModal from './settings/ModelAvailabilityProbeConfirmModal.js';
+import { PAYLOAD_RULE_PROTOCOL_OPTIONS } from './settings/payloadRuleProtocolOptions.js';
 import {
   createCodexDefaultHighReasoningVisualPreset,
   createVisualPayloadRule,
@@ -207,15 +208,6 @@ const PAYLOAD_RULE_ACTION_OPTIONS: Array<{ value: PayloadRuleAction; label: stri
   { value: 'override', label: '强制覆盖' },
   { value: 'override-raw', label: '强制覆盖 JSON' },
   { value: 'filter', label: '删除字段' },
-];
-
-const PAYLOAD_RULE_PROTOCOL_OPTIONS = [
-  { value: '', label: '全部协议' },
-  { value: 'codex', label: 'Codex' },
-  { value: 'openai', label: 'OpenAI' },
-  { value: 'claude', label: 'Claude' },
-  { value: 'gemini', label: 'Gemini' },
-  { value: 'antigravity', label: 'Antigravity' },
 ];
 
 const PAYLOAD_RULE_VALUE_MODE_OPTIONS: Array<{ value: VisualPayloadRuleValueMode; label: string }> = [
@@ -1637,14 +1629,14 @@ export default function Settings() {
                       />
                     </div>
                     <div>
-                      <div style={{ fontSize: 12, color: 'var(--color-text-muted)', marginBottom: 6 }}>协议</div>
+                      <div style={{ fontSize: 12, color: 'var(--color-text-muted)', marginBottom: 6 }}>上游类型</div>
                       <ModernSelect
                         size="sm"
                         data-testid={`payload-rule-protocol-${index + 1}`}
                         value={rule.protocol}
                         onChange={(value) => updatePayloadVisualRule(rule.id, { protocol: String(value || '') })}
                         options={PAYLOAD_RULE_PROTOCOL_OPTIONS}
-                        placeholder="全部协议"
+                        placeholder="全部上游类型"
                       />
                     </div>
                     <div>

--- a/src/web/pages/settings.payload-rule-platform-options.test.ts
+++ b/src/web/pages/settings.payload-rule-platform-options.test.ts
@@ -10,6 +10,7 @@ describe('payload rule platform options', () => {
       'codex',
       'sub2api',
       'new-api',
+      'one-api',
       'cliproxyapi',
       'openai',
       'claude',

--- a/src/web/pages/settings.payload-rule-platform-options.test.ts
+++ b/src/web/pages/settings.payload-rule-platform-options.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { PAYLOAD_RULE_PROTOCOL_OPTIONS } from './settings/payloadRuleProtocolOptions.js';
+
+describe('payload rule platform options', () => {
+  it('includes non-codex upstream platforms that payload rules can match in production routing', () => {
+    const values = PAYLOAD_RULE_PROTOCOL_OPTIONS.map((option) => option.value);
+
+    expect(values).toEqual(expect.arrayContaining([
+      '',
+      'codex',
+      'sub2api',
+      'new-api',
+      'cliproxyapi',
+      'openai',
+      'claude',
+      'gemini',
+      'gemini-cli',
+      'antigravity',
+      'anyrouter',
+      'done-hub',
+      'one-hub',
+      'veloera',
+    ]));
+  });
+});

--- a/src/web/pages/settings/payloadRuleProtocolOptions.ts
+++ b/src/web/pages/settings/payloadRuleProtocolOptions.ts
@@ -3,6 +3,7 @@ export const PAYLOAD_RULE_PROTOCOL_OPTIONS: Array<{ value: string; label: string
   { value: 'codex', label: 'Codex' },
   { value: 'sub2api', label: 'Sub2API' },
   { value: 'new-api', label: 'New API' },
+  { value: 'one-api', label: 'One API' },
   { value: 'cliproxyapi', label: 'CLIProxyAPI' },
   { value: 'openai', label: 'OpenAI' },
   { value: 'claude', label: 'Claude' },

--- a/src/web/pages/settings/payloadRuleProtocolOptions.ts
+++ b/src/web/pages/settings/payloadRuleProtocolOptions.ts
@@ -1,0 +1,16 @@
+export const PAYLOAD_RULE_PROTOCOL_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: '', label: '全部平台' },
+  { value: 'codex', label: 'Codex' },
+  { value: 'sub2api', label: 'Sub2API' },
+  { value: 'new-api', label: 'New API' },
+  { value: 'cliproxyapi', label: 'CLIProxyAPI' },
+  { value: 'openai', label: 'OpenAI' },
+  { value: 'claude', label: 'Claude' },
+  { value: 'gemini', label: 'Gemini' },
+  { value: 'gemini-cli', label: 'Gemini CLI' },
+  { value: 'antigravity', label: 'Antigravity' },
+  { value: 'anyrouter', label: 'AnyRouter' },
+  { value: 'done-hub', label: 'Done Hub' },
+  { value: 'one-hub', label: 'One Hub' },
+  { value: 'veloera', label: 'Veloera' },
+];


### PR DESCRIPTION
## Summary

This follow-up PR expands the payload-rule visual editor to expose the upstream types that the runtime matcher actually supports, and renames the selector copy from “协议” to “上游类型”.

## Why

The first payload-rules PR made the feature configurable, but the visual dropdown still looked too narrow for real production routing. In live use, playground requests may land on upstream types such as `sub2api`, `new-api`, or `cliproxyapi` instead of `codex`, so a codex-only mental model makes rule debugging misleading.

## What changed

- extracted the payload-rule upstream-type options into `payloadRuleProtocolOptions.ts`
- expanded the selector options to include runtime-relevant upstream types:
  - `codex`
  - `sub2api`
  - `new-api`
  - `cliproxyapi`
  - `openai`
  - `claude`
  - `gemini`
  - `gemini-cli`
  - `antigravity`
  - `anyrouter`
  - `done-hub`
  - `one-hub`
  - `veloera`
- renamed the field label to `上游类型`
- added a focused test to lock the expanded option set

## Validation

- `npx vitest run --root . src/web/pages/settings.payload-rules.test.tsx src/web/pages/settings.payload-rule-platform-options.test.ts`
- `npm run typecheck:web`
- `npm run typecheck:web:test`
- `npm run repo:drift-check`

## Notes

This PR is intentionally narrow and only covers the selector vocabulary/UI alignment. It does not change the payload-rules schema key, which remains `protocol` for compatibility with the existing runtime matcher.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Renamed "Protocol" to "Upstream Type" in the Payload Rule settings and standardized the dropdown labels and placeholder.
  * Standardized the available upstream options shown in the Payload Rule selector.

* **Tests**
  * Added test coverage validating the upstream platform options presented in the settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->