### PR TITLE
[codex] keep codex auth store false

### DIFF
--- a/src/server/proxy-core/surfaces/openAiResponsesSurface.ts
+++ b/src/server/proxy-core/surfaces/openAiResponsesSurface.ts
@@ -538,6 +538,7 @@ export async function handleOpenAiResponsesSurfaceRequest(
         const endpointStrategy = openAiResponsesTransformer.compatibility.createEndpointStrategy({
           isStream: isStream || forceCodexUpstreamStream,
           requiresNativeResponsesFileUrl,
+          sitePlatform: selected.site.platform,
           dispatchRequest,
         });
         const tryRecover = async (ctx: Parameters<NonNullable<typeof endpointStrategy.tryRecover>>[0]) => {

--- a/src/server/routes/proxy/responses.codex-oauth.test.ts
+++ b/src/server/routes/proxy/responses.codex-oauth.test.ts
@@ -1123,7 +1123,7 @@ describe('responses proxy codex oauth refresh', () => {
     expect(response.body).toContain('data: [DONE]');
   });
 
-  it('preserves codex-required instructions and store fields across responses compatibility retries', async () => {
+  it('keeps store false across codex responses compatibility retries', async () => {
     fetchMock.mockResolvedValue(new Response(JSON.stringify({
       error: { message: 'upstream_error', type: 'upstream_error' },
     }), {
@@ -1137,7 +1137,7 @@ describe('responses proxy codex oauth refresh', () => {
       payload: {
         model: 'gpt-5.2-codex',
         input: 'hello codex',
-        metadata: { trace: 'compatibility-retry' },
+        store: true,
       },
     });
 
@@ -1149,14 +1149,8 @@ describe('responses proxy codex oauth refresh', () => {
     const firstBody = JSON.parse(firstOptions.body);
     const secondBody = JSON.parse(secondOptions.body);
 
-    expect(firstBody.instructions).toBe('');
     expect(firstBody.store).toBe(false);
-    expect(firstBody.stream).toBe(true);
-    expect(firstBody.max_output_tokens).toBeUndefined();
-    expect(secondBody.instructions).toBe('');
     expect(secondBody.store).toBe(false);
-    expect(secondBody.stream).toBe(true);
-    expect(secondBody.max_output_tokens).toBeUndefined();
   });
 
   it('does not record success when a streaming responses request ends with response.failed', async () => {

--- a/src/server/transformers/openai/responses/compatibility.ts
+++ b/src/server/transformers/openai/responses/compatibility.ts
@@ -230,6 +230,9 @@ function buildStrictResponsesBody(
     model,
     input: body.input,
     stream: body.stream === true,
+    ...(body.previous_response_id !== undefined
+      ? { previous_response_id: cloneJsonValue(body.previous_response_id) }
+      : {}),
     ...(body.tools !== undefined ? { tools: cloneJsonValue(body.tools) } : {}),
     ...(body.tool_choice !== undefined ? { tool_choice: cloneJsonValue(body.tool_choice) } : {}),
     ...(explicitInstructions !== null

--- a/src/server/transformers/openai/responses/conversion.test.ts
+++ b/src/server/transformers/openai/responses/conversion.test.ts
@@ -1618,6 +1618,29 @@ describe('convertResponsesBodyToOpenAiBody', () => {
     }
   });
 
+  it('preserves previous_response_id in strict compatibility bodies for tool-output turns', () => {
+    const input = [{
+      type: 'function_call_output',
+      call_id: 'call_3',
+      output: '{"ok":true}',
+    }];
+
+    const candidates = buildResponsesCompatibilityBodies({
+      model: 'gpt-5.4',
+      input,
+      stream: true,
+      previous_response_id: 'resp_prev_tool_3',
+      temperature: 0.7,
+    });
+
+    expect(candidates).toContainEqual({
+      model: 'gpt-5.4',
+      input,
+      stream: true,
+      previous_response_id: 'resp_prev_tool_3',
+    });
+  });
+
   it('maps native tool choices and strict function tools into OpenAI-compatible fallback bodies', () => {
     const result = convertResponsesBodyToOpenAiBody(
       {

--- a/src/server/transformers/openai/responses/routeCompatibility.ts
+++ b/src/server/transformers/openai/responses/routeCompatibility.ts
@@ -11,6 +11,7 @@ import {
   shouldDowngradeResponsesChatToMessages,
   shouldRetryResponsesCompatibility,
 } from './compatibility.js';
+import { normalizeCodexResponsesBodyForProxy } from './codexCompatibility.js';
 
 type CompatibilityRequest = {
   endpoint: CompatibilityEndpoint;
@@ -38,6 +39,7 @@ type UpstreamResponse = Exclude<EndpointRecoverResult, null>['upstream'];
 type CreateResponsesEndpointStrategyInput = {
   isStream: boolean;
   requiresNativeResponsesFileUrl: boolean;
+  sitePlatform: string;
   dispatchRequest: (
     request: CompatibilityRequest,
     targetUrl?: string,
@@ -45,6 +47,10 @@ type CreateResponsesEndpointStrategyInput = {
 };
 
 export function createResponsesEndpointStrategy(input: CreateResponsesEndpointStrategyInput) {
+  const normalizeRetryBody = (body: Record<string, unknown>) => (
+    normalizeCodexResponsesBodyForProxy(body, input.sitePlatform)
+  );
+
   return {
     async tryRecover(ctx: EndpointAttemptContext): Promise<EndpointRecoverResult> {
       if (shouldRetryResponsesCompatibility({
@@ -63,7 +69,7 @@ export function createResponsesEndpointStrategy(input: CreateResponsesEndpointSt
             const compatibilityRequest = {
               ...ctx.request,
               headers: compatibilityHeadersCandidate,
-              body: compatibilityBody,
+              body: normalizeRetryBody(compatibilityBody),
             };
             const compatibilityResponse = await input.dispatchRequest(
               compatibilityRequest,
@@ -94,6 +100,7 @@ export function createResponsesEndpointStrategy(input: CreateResponsesEndpointSt
           endpoint: ctx.request.endpoint,
           stream: input.isStream,
         }),
+        body: normalizeRetryBody(ctx.request.body),
       };
       const minimalResponse = await input.dispatchRequest(minimalRequest, ctx.targetUrl);
       if (minimalResponse.ok) {


### PR DESCRIPTION
Codex upstream rejects responses requests unless store remains false. Re-run Codex payload normalization before compatibility retries so fallback attempts cannot resurrect an invalid store value.

#455 #446

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved OpenAI Responses compatibility to respect the selected site platform and normalize request bodies for retry and fallback flows.

* **Tests**
  * Updated compatibility-retry tests to focus on store behavior across retry attempts and added coverage for previous_response_id propagation in compatibility candidates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->