### PR TITLE
fix(settings): persist model allowlist as JSON array

### DIFF
--- a/src/server/routes/api/settings.events.test.ts
+++ b/src/server/routes/api/settings.events.test.ts
@@ -81,6 +81,8 @@ describe('settings and auth events', () => {
     (config as any).telegramChatId = '';
     (config as any).telegramUseSystemProxy = false;
     (config as any).telegramMessageThreadId = '';
+    config.globalBlockedBrands = [];
+    config.globalAllowedModels = [];
   });
 
   afterAll(async () => {
@@ -743,6 +745,32 @@ describe('settings and auth events', () => {
       'too many requests',
     ]);
     expect(runtime.proxyEmptyContentFailEnabled).toBe(true);
+  });
+
+  it('persists global model and brand filters as JSON arrays', async () => {
+    const updateResponse = await app.inject({
+      method: 'PUT',
+      url: '/api/settings/runtime',
+      payload: {
+        globalAllowedModels: ['model-alpha', ' model-beta ', 'model-alpha', 'model-gamma'],
+        globalBlockedBrands: ['Codex', ' Codex ', 'Gemini'],
+      },
+    });
+
+    expect(updateResponse.statusCode).toBe(200);
+    const updated = updateResponse.json() as {
+      globalAllowedModels?: string[];
+      globalBlockedBrands?: string[];
+    };
+    expect(updated.globalAllowedModels).toEqual(['model-alpha', 'model-beta', 'model-gamma']);
+    expect(updated.globalBlockedBrands).toEqual(['Codex', 'Gemini']);
+
+    const rows = await db.select().from(schema.settings).all();
+    const settingsMap = new Map(rows.map((row) => [row.key, row.value]));
+    expect(settingsMap.get('global_allowed_models')).toBe(JSON.stringify(['model-alpha', 'model-beta', 'model-gamma']));
+    expect(JSON.parse(settingsMap.get('global_allowed_models') || 'null')).toEqual(['model-alpha', 'model-beta', 'model-gamma']);
+    expect(settingsMap.get('global_blocked_brands')).toBe(JSON.stringify(['Codex', 'Gemini']));
+    expect(JSON.parse(settingsMap.get('global_blocked_brands') || 'null')).toEqual(['Codex', 'Gemini']);
   });
 
   it('persists and returns log cleanup settings from runtime settings', async () => {

--- a/src/server/routes/api/settings.ts
+++ b/src/server/routes/api/settings.ts
@@ -1425,7 +1425,7 @@ export async function settingsRoutes(app: FastifyInstance) {
         changedLabels.push('全局品牌屏蔽');
       }
       config.globalBlockedBrands = uniqueBrands;
-      upsertSetting('global_blocked_brands', JSON.stringify(uniqueBrands));
+      upsertSetting('global_blocked_brands', uniqueBrands);
       if (prev !== next) {
         startBackgroundTask(
           {
@@ -1450,7 +1450,7 @@ export async function settingsRoutes(app: FastifyInstance) {
         changedLabels.push('全局模型白名单');
       }
       config.globalAllowedModels = uniqueModels;
-      upsertSetting('global_allowed_models', JSON.stringify(uniqueModels));
+      upsertSetting('global_allowed_models', uniqueModels);
       if (prev !== next) {
         startBackgroundTask(
           {

--- a/src/server/runtimeSettingsHydration.test.ts
+++ b/src/server/runtimeSettingsHydration.test.ts
@@ -44,4 +44,14 @@ describe('applyRuntimeSettings', () => {
 
     expect(config.smtpPort).toBe(587);
   });
+
+  it('hydrates legacy double-encoded global model allowlist values', () => {
+    config.globalAllowedModels = [];
+
+    applyRuntimeSettings(new Map([
+      ['global_allowed_models', JSON.stringify(JSON.stringify(['model-alpha', ' model-beta ', 'model-gamma']))],
+    ]));
+
+    expect(config.globalAllowedModels).toEqual(['model-alpha', 'model-beta', 'model-gamma']);
+  });
 });

--- a/src/server/runtimeSettingsHydration.ts
+++ b/src/server/runtimeSettingsHydration.ts
@@ -22,6 +22,14 @@ function toStringList(value: unknown): string[] {
       .filter((item) => item.length > 0);
   }
   if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      if (Array.isArray(parsed)) {
+        return toStringList(parsed);
+      }
+    } catch {
+      // Fall back to comma splitting for legacy plain-string lists.
+    }
     return value
       .split(',')
       .map((item) => item.trim())


### PR DESCRIPTION
## Summary

- Fix double JSON encoding when persisting `global_allowed_models`.
- Apply the same fix to `global_blocked_brands`, which uses the same settings persistence path.
- Add hydration compatibility for legacy double-encoded list settings so existing bad values are parsed back into arrays on restart.
- Add regression coverage for both persistence and restart hydration behavior.

## Problem

Related to #301, which introduced the global model allowlist feature. This PR fixes a persistence encoding issue in that feature's runtime settings save path.

Runtime settings are persisted through `upsertSetting`, which already serializes values with `JSON.stringify`.

The model allowlist save path pre-serialized arrays before passing them to `upsertSetting`, so the stored value became a JSON string containing an array instead of a JSON array. After export/import or restart hydration, this could be interpreted as a malformed model name list.

Example bad persisted value:

```json
"[\"model-alpha\",\"model-beta\"]"
```

Expected persisted value:

```json
["model-alpha","model-beta"]
```

## Changes

- Pass normalized arrays directly to `upsertSetting` for:
  - `global_allowed_models`
  - `global_blocked_brands`
- Extend runtime settings hydration so legacy double-encoded array strings are parsed as arrays before falling back to comma-separated string handling.
- Add focused tests that verify:
  - runtime settings persistence stores JSON arrays, not double-encoded strings
  - legacy double-encoded model allowlist values hydrate back into normalized arrays

## Validation

```bash
npm test -- src/server/routes/api/settings.events.test.ts src/server/runtimeSettingsHydration.test.ts
```

Result:

```text
Test Files  2 passed
Tests       39 passed
```

Also verified with a local Docker deployment:

- rebuilt the image from this commit
- saved and reloaded runtime settings through the API
- confirmed the container SQLite `settings.value` stores `global_allowed_models` as a JSON array
- restarted the container and confirmed `/api/settings/runtime` still returns an array

## Risk

Low. The change is limited to runtime settings persistence and hydration for list values. Existing valid JSON arrays continue to work, and legacy double-encoded arrays are now accepted for compatibility.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved normalization of global blocked brands and allowed models settings by removing duplicates and trimming whitespace entries.
  * Enhanced support for legacy runtime settings formats.

* **Tests**
  * Added test coverage for runtime settings normalization and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->