### PR TITLE
修复 Claude /anthropic 模型发现回退

### DIFF
--- a/src/server/services/platforms/claude.test.ts
+++ b/src/server/services/platforms/claude.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { AddressInfo } from 'node:net';
+import { ClaudeAdapter } from './claude.js';
+
+vi.mock('../siteProxy.js', () => ({
+  withSiteProxyRequestInit: (_url: string, options: unknown) => options,
+}));
+
+describe('ClaudeAdapter', () => {
+  let server: ReturnType<typeof createServer> | undefined;
+  let baseUrl: string;
+  const requests: Array<{ url: string | undefined; headers: IncomingMessage['headers'] }> = [];
+
+  afterEach(async () => {
+    requests.length = 0;
+    if (server) {
+      const s = server;
+      server = undefined;
+      await new Promise<void>((resolve, reject) => {
+        s.close((err?: Error) => (err ? reject(err) : resolve()));
+      });
+    }
+  });
+
+  function startServer(handler: (req: IncomingMessage, res: ServerResponse) => void) {
+    return new Promise<void>((resolve) => {
+      server = createServer((req, res) => {
+        requests.push({ url: req.url, headers: req.headers });
+        handler(req, res);
+      });
+      server.listen(0, '127.0.0.1', () => {
+        const addr = server!.address() as AddressInfo;
+        baseUrl = `http://127.0.0.1:${addr.port}`;
+        resolve();
+      });
+    });
+  }
+
+  it('reads models from the configured Claude models endpoint', async () => {
+    await startServer((req, res) => {
+      if (req.url === '/anthropic/v1/models') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ data: [{ id: 'claude-sonnet-test' }] }));
+        return;
+      }
+      res.writeHead(404).end();
+    });
+
+    const adapter = new ClaudeAdapter();
+    const models = await adapter.getModels(`${baseUrl}/anthropic`, 'tp-test');
+
+    expect(models).toEqual(['claude-sonnet-test']);
+    expect(requests).toHaveLength(1);
+    expect(requests[0].headers['x-api-key']).toBe('tp-test');
+    expect(requests[0].headers.authorization).toBeUndefined();
+  });
+
+  it('falls back from /anthropic to the parent OpenAI-compatible models endpoint', async () => {
+    await startServer((req, res) => {
+      if (req.url === '/anthropic/v1/models') {
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'not found' }));
+        return;
+      }
+      if (req.url === '/v1/models') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ data: [{ id: 'mimo-v2.5' }, { id: 'mimo-v2.5-pro' }] }));
+        return;
+      }
+      res.writeHead(404).end();
+    });
+
+    const adapter = new ClaudeAdapter();
+    const models = await adapter.getModels(`${baseUrl}/anthropic`, 'tp-test');
+
+    expect(models).toEqual(['mimo-v2.5', 'mimo-v2.5-pro']);
+    expect(requests.map((request) => request.url)).toEqual(['/anthropic/v1/models', '/v1/models']);
+    expect(requests[0].headers['x-api-key']).toBe('tp-test');
+    expect(requests[1].headers.authorization).toBe('Bearer tp-test');
+    expect(requests[1].headers['x-api-key']).toBeUndefined();
+  });
+
+  it('does not fall back for non-anthropic base urls', async () => {
+    await startServer((_req, res) => {
+      res.writeHead(404, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'not found' }));
+    });
+
+    const adapter = new ClaudeAdapter();
+    const models = await adapter.getModels(baseUrl, 'tp-test');
+
+    expect(models).toEqual([]);
+    expect(requests.map((request) => request.url)).toEqual(['/v1/models']);
+  });
+});

--- a/src/server/services/platforms/claude.ts
+++ b/src/server/services/platforms/claude.ts
@@ -1,5 +1,12 @@
 import { StandardApiProviderAdapterBase } from './standardApiProvider.js';
-import { CLAUDE_DEFAULT_ANTHROPIC_VERSION } from '../oauth/claudeProvider.js';
+
+const CLAUDE_DEFAULT_ANTHROPIC_VERSION = '2023-06-01';
+
+function resolveOpenAiCompatibleBaseUrl(baseUrl: string): string | null {
+  const normalized = (baseUrl || '').trim().replace(/\/+$/, '');
+  const match = normalized.match(/^(.*)\/anthropic$/i);
+  return match?.[1] || null;
+}
 
 export class ClaudeAdapter extends StandardApiProviderAdapterBase {
   readonly platformName = 'claude';
@@ -10,12 +17,25 @@ export class ClaudeAdapter extends StandardApiProviderAdapterBase {
   }
 
   async getModels(baseUrl: string, apiToken: string): Promise<string[]> {
+    const openAiCompatibleBaseUrl = resolveOpenAiCompatibleBaseUrl(baseUrl);
+    try {
+      const claudeModels = await this.fetchModelsFromStandardEndpoint({
+        baseUrl,
+        headers: {
+          'x-api-key': apiToken,
+          'anthropic-version': CLAUDE_DEFAULT_ANTHROPIC_VERSION,
+        },
+      });
+      if (claudeModels.length > 0) return claudeModels;
+    } catch (error) {
+      if (!openAiCompatibleBaseUrl) throw error;
+    }
+
+    if (!openAiCompatibleBaseUrl) return [];
+
     return this.fetchModelsFromStandardEndpoint({
-      baseUrl,
-      headers: {
-        'x-api-key': apiToken,
-        'anthropic-version': CLAUDE_DEFAULT_ANTHROPIC_VERSION,
-      },
+      baseUrl: openAiCompatibleBaseUrl,
+      headers: { Authorization: `Bearer ${apiToken}` },
     });
   }
 }


### PR DESCRIPTION
## 摘要

- 为 Claude 站点增加模型发现回退：当配置的 `/anthropic/v1/models` 没有返回模型时，改查父级 OpenAI 兼容的 `/v1/models`。
- 保持 Claude 聊天路由不变，仍然走配置的 `/anthropic/v1/messages`。
- 新增 Claude 适配器测试，覆盖正常 Claude 模型接口、OpenAI 兼容回退接口，以及非 `/anthropic` 地址不回退的场景。

## 测试
- [x] `npm test -- src/server/services/platforms/claude.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced Claude platform integration with improved model discovery. The adapter now automatically falls back to alternative endpoint configurations when the primary endpoint is unavailable, ensuring better compatibility across different setups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cita-777/metapi/pull/554)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->