### PR TITLE
fix: send X-User-Id for New API session accounts

### DIFF
--- a/src/server/services/platforms/newApi.test.ts
+++ b/src/server/services/platforms/newApi.test.ts
@@ -14,6 +14,7 @@ interface RequestSnapshot {
 
 const COOKIE_SESSION_TOKEN = 'cookie-session-token';
 const COOKIE_REQUIRES_USER_TOKEN = 'cookie-requires-user';
+const COOKIE_REQUIRES_X_USER_ID_TOKEN = 'cookie-requires-x-user-id';
 const CHECKIN_ALREADY_TOKEN = 'checkin-already-token';
 const CHECKIN_INVALID_URL_TOKEN = 'checkin-invalid-url-token';
 const CHECKIN_INVALID_URL_EXPIRED_SESSION_TOKEN = 'checkin-invalid-url-expired-session-token';
@@ -222,6 +223,11 @@ describe('NewApiAdapter', () => {
           res.end(JSON.stringify({ success: false, message: 'unauthorized' }));
           return;
         }
+        if (typeof req.headers.authorization === 'string' && req.headers.authorization === `Bearer ${COOKIE_REQUIRES_X_USER_ID_TOKEN}`) {
+          res.writeHead(401, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ success: false, message: 'unauthorized' }));
+          return;
+        }
 
         if (typeof req.headers.cookie === 'string' && req.headers.cookie.includes(`session=${COOKIE_SESSION_TOKEN}`)) {
           res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -243,6 +249,21 @@ describe('NewApiAdapter', () => {
           res.end(JSON.stringify({
             data: {
               items: [{ key: 'cookie-user-key' }],
+            },
+          }));
+          return;
+        }
+
+        if (typeof req.headers.cookie === 'string' && req.headers.cookie.includes(`session=${COOKIE_REQUIRES_X_USER_ID_TOKEN}`)) {
+          if (req.headers['x-user-id'] !== '448') {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ success: false, message: 'missing X-User-Id' }));
+            return;
+          }
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({
+            data: {
+              items: [{ key: 'cookie-x-user-id-key' }],
             },
           }));
           return;
@@ -340,6 +361,11 @@ describe('NewApiAdapter', () => {
           res.end(JSON.stringify({ success: false, message: 'invalid token' }));
           return;
         }
+        if (typeof req.headers.authorization === 'string' && req.headers.authorization === `Bearer ${COOKIE_REQUIRES_X_USER_ID_TOKEN}`) {
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ success: false, message: 'invalid token' }));
+          return;
+        }
         if (typeof req.headers.authorization === 'string') {
           res.writeHead(200, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ success: false, message: 'invalid token' }));
@@ -365,6 +391,20 @@ describe('NewApiAdapter', () => {
           res.end(JSON.stringify({
             success: true,
             data: { id: 8899, username: 'cookie-user-id-required', quota: 1500000, used_quota: 100000 },
+          }));
+          return;
+        }
+
+        if (typeof req.headers.cookie === 'string' && req.headers.cookie.includes(`session=${COOKIE_REQUIRES_X_USER_ID_TOKEN}`)) {
+          if (req.headers['x-user-id'] !== '448') {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ success: false, message: 'missing X-User-Id' }));
+            return;
+          }
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({
+            success: true,
+            data: { id: 448, username: 'x-user-id-cookie-user', quota: 1500000, used_quota: 100000 },
           }));
           return;
         }
@@ -622,6 +662,21 @@ describe('NewApiAdapter', () => {
     expect(result.apiToken).toBe('cookie-user-key');
     expect(
       requests.some((r) => r.url === '/api/user/self' && r.headers['new-api-user'] === '8899'),
+    ).toBe(true);
+  });
+
+  it('sends X-User-Id for cookie sessions when the site requires that New API variant', async () => {
+    const adapter = new NewApiAdapter();
+    const result = await adapter.verifyToken(baseUrl, COOKIE_REQUIRES_X_USER_ID_TOKEN, 448);
+
+    expect(result.tokenType).toBe('session');
+    expect(result.userInfo?.username).toBe('x-user-id-cookie-user');
+    expect(result.apiToken).toBe('cookie-x-user-id-key');
+    expect(
+      requests.some((r) => r.url === '/api/user/self' && r.headers['x-user-id'] === '448'),
+    ).toBe(true);
+    expect(
+      requests.some((r) => r.url?.startsWith('/api/token/') && r.headers['x-user-id'] === '448'),
     ).toBe(true);
   });
 

--- a/src/server/services/platforms/newApi.ts
+++ b/src/server/services/platforms/newApi.ts
@@ -51,13 +51,21 @@ export class NewApiAdapter extends BasePlatformAdapter {
   }
 
   private authHeaders(accessToken: string, userId?: number): Record<string, string> {
-    const headers: Record<string, string> = { Authorization: `Bearer ${accessToken}` };
+    return {
+      Authorization: `Bearer ${accessToken}`,
+      ...this.userIdHeaders(userId),
+    };
+  }
+
+  private userIdHeaders(userId?: number | null): Record<string, string> {
+    const headers: Record<string, string> = {};
     if (userId) {
       const value = String(userId);
       headers['New-API-User'] = value;
       headers['Veloera-User'] = value;
       headers['voapi-user'] = value;
       headers['User-id'] = value;
+      headers['X-User-Id'] = value;
       headers['Rix-Api-User'] = value;
       headers['neo-api-user'] = value;
     }
@@ -769,7 +777,7 @@ export class NewApiAdapter extends BasePlatformAdapter {
     for (const cookie of this.buildCookieCandidates(token)) {
       try {
         const headers: Record<string, string> = { Cookie: cookie };
-        if (platformUserId) headers['New-Api-User'] = String(platformUserId);
+        Object.assign(headers, this.userIdHeaders(platformUserId));
         const res = await this.fetchJsonRaw<any>(`${baseUrl}/api/user/self`, { headers });
         if (res?.success && res?.data) return res;
         if (typeof res?.message === 'string' && res.message.trim()) {
@@ -786,7 +794,7 @@ export class NewApiAdapter extends BasePlatformAdapter {
       for (const id of candidates) {
         try {
           const res = await this.fetchJsonRaw<any>(`${baseUrl}/api/user/self`, {
-            headers: { Cookie: cookie, 'New-Api-User': String(id) },
+            headers: { Cookie: cookie, ...this.userIdHeaders(id) },
           });
           if (res?.success && res?.data) return id;
         } catch {}
@@ -812,7 +820,7 @@ export class NewApiAdapter extends BasePlatformAdapter {
     for (const cookie of this.buildCookieCandidates(token)) {
       try {
         const headers: Record<string, string> = { Cookie: cookie };
-        if (userId) headers['New-Api-User'] = String(userId);
+        Object.assign(headers, this.userIdHeaders(userId));
         const res = await this.fetchJsonRaw<any>(`${baseUrl}/api/token/?p=0&size=100`, { headers });
         const normalized = this.normalizeTokenItems(this.parseTokenItems(res));
         if (normalized.length > 0) return normalized;
@@ -825,7 +833,7 @@ export class NewApiAdapter extends BasePlatformAdapter {
     for (const cookie of this.buildCookieCandidates(token)) {
       try {
         const headers: Record<string, string> = { Cookie: cookie };
-        if (userId) headers['New-Api-User'] = String(userId);
+        Object.assign(headers, this.userIdHeaders(userId));
         const res = await this.fetchJsonRaw<any>(`${baseUrl}/api/user/models`, { headers });
         if (Array.isArray(res?.data) && res.data.length > 0) return res.data.filter(Boolean);
         if (res?.data && typeof res.data === 'object') {
@@ -1125,7 +1133,7 @@ export class NewApiAdapter extends BasePlatformAdapter {
 
         try {
           const headers: Record<string, string> = { Cookie: cookie };
-          if (cookieUserId) headers['New-Api-User'] = String(cookieUserId);
+          Object.assign(headers, this.userIdHeaders(cookieUserId));
           const res = await this.fetchJsonRaw<any>(`${baseUrl}/api/user/checkin`, {
             method: 'POST',
             headers,
@@ -1284,7 +1292,7 @@ export class NewApiAdapter extends BasePlatformAdapter {
     for (const cookie of this.buildCookieCandidates(accessToken)) {
       try {
         const headers: Record<string, string> = { Cookie: cookie };
-        if (cookieUserId) headers['New-Api-User'] = String(cookieUserId);
+        Object.assign(headers, this.userIdHeaders(cookieUserId));
         const res = await this.fetchJsonRaw<any>(`${baseUrl}/api/token/`, {
           method: 'POST',
           headers,
@@ -1327,7 +1335,7 @@ export class NewApiAdapter extends BasePlatformAdapter {
     const cookieUserId = resolvedUserId || await this.probeUserIdByCookie(baseUrl, accessToken);
     for (const cookie of this.buildCookieCandidates(accessToken)) {
       const headers: Record<string, string> = { Cookie: cookie };
-      if (cookieUserId) headers['New-Api-User'] = String(cookieUserId);
+      Object.assign(headers, this.userIdHeaders(cookieUserId));
 
       try {
         const res = await this.fetchJsonRaw<any>(`${baseUrl}/api/user/self/groups`, { headers });
@@ -1395,7 +1403,7 @@ export class NewApiAdapter extends BasePlatformAdapter {
     const cookieUserId = resolvedUserId || await this.probeUserIdByCookie(baseUrl, accessToken);
     for (const cookie of this.buildCookieCandidates(accessToken)) {
       const headers: Record<string, string> = { Cookie: cookie };
-      if (cookieUserId) headers['New-Api-User'] = String(cookieUserId);
+      Object.assign(headers, this.userIdHeaders(cookieUserId));
 
       try {
         if (!tokenId) {


### PR DESCRIPTION
## Summary

- add a shared New API user-id header helper that also sends `X-User-Id`
- use the helper across session-cookie verification, user-id probing, token sync, check-in, group fetch, and token deletion paths
- cover New API deployments that require `X-User-Id` for session-cookie accounts

## Why

Some New API-compatible deployments require the browser/session request header to be `X-User-Id` instead of only accepting `New-Api-User` / related variants. In that case, session-cookie verification can fail even when the cookie and platform user id are correct, which also prevents balance refresh, check-in, and API token sync from working.

The fix keeps the existing compatibility headers and adds `X-User-Id` anywhere Metapi already has a resolved platform user id.

## Validation

- `npx vitest run --root . src/server/services/platforms/newApi.test.ts`
- `npm run typecheck:server`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved authentication header handling by centralizing user-id header construction to support multiple platform-specific header variants for cookie-based sessions.
  * Enhanced consistency across all authentication flows.

* **Tests**
  * Added test coverage for cookie-session variants with header validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cita-777/metapi/pull/567?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->