### PR TITLE
Fix Gemini official tool history thought signatures

### DIFF
--- a/src/server/proxy-core/executors/types.ts
+++ b/src/server/proxy-core/executors/types.ts
@@ -23,7 +23,7 @@ export type ProxyRuntimeRequest = {
   headers: Record<string, string>;
   body: Record<string, unknown>;
   runtime?: {
-    executor: 'default' | 'codex' | 'gemini-cli' | 'antigravity' | 'claude';
+    executor: 'default' | 'codex' | 'gemini-native' | 'gemini-cli' | 'antigravity' | 'claude';
     modelName?: string;
     stream?: boolean;
     oauthProjectId?: string | null;

--- a/src/server/proxy-core/orchestration/endpointFlow.ts
+++ b/src/server/proxy-core/orchestration/endpointFlow.ts
@@ -14,7 +14,7 @@ export type BuiltEndpointRequest = {
   headers: Record<string, string>;
   body: Record<string, unknown>;
   runtime?: {
-    executor: 'default' | 'codex' | 'gemini-cli' | 'antigravity' | 'claude';
+    executor: 'default' | 'codex' | 'gemini-native' | 'gemini-cli' | 'antigravity' | 'claude';
     modelName?: string;
     stream?: boolean;
     oauthProjectId?: string | null;

--- a/src/server/proxy-core/orchestration/upstreamRequest.test.ts
+++ b/src/server/proxy-core/orchestration/upstreamRequest.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { buildUpstreamUrl } from './upstreamRequest.js';
+
+describe('buildUpstreamUrl', () => {
+  it('routes native Gemini fallbacks outside an OpenAI compatibility suffix', () => {
+    expect(buildUpstreamUrl(
+      'https://generativelanguage.googleapis.com/v1beta/openai',
+      '/v1beta/models/gemini-3-flash:generateContent?key=gemini-key',
+    )).toBe(
+      'https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash:generateContent?key=gemini-key',
+    );
+  });
+});

--- a/src/server/proxy-core/orchestration/upstreamRequest.test.ts
+++ b/src/server/proxy-core/orchestration/upstreamRequest.test.ts
@@ -10,4 +10,22 @@ describe('buildUpstreamUrl', () => {
       'https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash:generateContent?key=gemini-key',
     );
   });
+
+  it('normalizes a versioned OpenAI compatibility suffix before native fallback', () => {
+    expect(buildUpstreamUrl(
+      'https://generativelanguage.googleapis.com/v1/openai',
+      '/v1beta/models/gemini-3-flash:generateContent?key=gemini-key',
+    )).toBe(
+      'https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash:generateContent?key=gemini-key',
+    );
+  });
+
+  it('merges site and request query parameters once', () => {
+    expect(buildUpstreamUrl(
+      'https://generativelanguage.googleapis.com/v1beta/openai?quotaUser=test-user',
+      '/v1beta/models/gemini-3-flash:generateContent?key=gemini-key',
+    )).toBe(
+      'https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash:generateContent?quotaUser=test-user&key=gemini-key',
+    );
+  });
 });

--- a/src/server/proxy-core/orchestration/upstreamRequest.ts
+++ b/src/server/proxy-core/orchestration/upstreamRequest.ts
@@ -104,7 +104,13 @@ export function buildUpstreamUrl(siteUrl: string, requestPath: string): string {
   const baseRaw = typeof siteUrl === 'string' ? siteUrl.trim() : '';
   const pathRaw = typeof requestPath === 'string' ? requestPath.trim() : '';
   const fallbackBase = baseRaw.replace(/\/+$/, '');
-  let path = pathRaw.startsWith('/') ? pathRaw : `/${pathRaw}`;
+  const requestHashIndex = pathRaw.indexOf('#');
+  const requestHash = requestHashIndex >= 0 ? pathRaw.slice(requestHashIndex) : '';
+  const pathWithQuery = requestHashIndex >= 0 ? pathRaw.slice(0, requestHashIndex) : pathRaw;
+  const requestQueryIndex = pathWithQuery.indexOf('?');
+  const requestQuery = requestQueryIndex >= 0 ? pathWithQuery.slice(requestQueryIndex + 1) : '';
+  let path = (requestQueryIndex >= 0 ? pathWithQuery.slice(0, requestQueryIndex) : pathWithQuery);
+  path = path.startsWith('/') ? path : `/${path}`;
 
   if (!fallbackBase) return path || '/';
   if (!path || path === '/') return fallbackBase;
@@ -116,8 +122,13 @@ export function buildUpstreamUrl(siteUrl: string, requestPath: string): string {
     // compatibility base is /v1beta/openai. Remove only that known suffix so
     // the request is not sent to /v1beta/openai/v1beta/models.
     const nativeGeminiPath = /^\/(v\d+(?:beta)?)\/models(?:\/|$)/i.test(path);
-    if (nativeGeminiPath && /\/openai$/i.test(basePath)) {
-      basePath = basePath.slice(0, -'/openai'.length).replace(/\/+$/, '');
+    if (nativeGeminiPath) {
+      const compatibilitySuffix = basePath.match(/\/(?:api\/)?v\d+(?:beta)?\/openai$/i);
+      if (compatibilitySuffix?.index !== undefined) {
+        basePath = basePath.slice(0, compatibilitySuffix.index).replace(/\/+$/, '');
+      } else if (/\/openai$/i.test(basePath)) {
+        basePath = basePath.slice(0, -'/openai'.length).replace(/\/+$/, '');
+      }
     }
     const baseVersionMatch = basePath.match(/\/(?:api\/)?(v\d+(?:beta)?)$/i);
     const baseHasVersionSuffix = !!baseVersionMatch;
@@ -131,7 +142,12 @@ export function buildUpstreamUrl(siteUrl: string, requestPath: string): string {
     }
 
     const joinedPath = joinPath(basePath, path);
-    return `${formatUrlOrigin(parsed)}${joinedPath}${parsed.search}${parsed.hash}`;
+    const mergedQuery = new URLSearchParams(parsed.search);
+    for (const [key, value] of new URLSearchParams(requestQuery)) {
+      mergedQuery.set(key, value);
+    }
+    const query = mergedQuery.toString();
+    return `${formatUrlOrigin(parsed)}${joinedPath}${query ? `?${query}` : ''}${requestHash || parsed.hash}`;
   } catch {
     const baseVersionMatch = fallbackBase.match(/\/(?:api\/)?(v\d+(?:beta)?)$/i);
     const baseHasVersionSuffix = !!baseVersionMatch;
@@ -144,6 +160,7 @@ export function buildUpstreamUrl(siteUrl: string, requestPath: string): string {
       }
     }
 
-    return `${fallbackBase}${path}`;
+    const query = requestQuery ? `?${requestQuery}` : '';
+    return `${fallbackBase}${path}${query}${requestHash}`;
   }
 }

--- a/src/server/proxy-core/orchestration/upstreamRequest.ts
+++ b/src/server/proxy-core/orchestration/upstreamRequest.ts
@@ -111,25 +111,36 @@ export function buildUpstreamUrl(siteUrl: string, requestPath: string): string {
 
   try {
     const parsed = new URL(baseRaw);
-    const basePath = parsed.pathname.replace(/\/+$/, '');
-    const baseHasVersionSuffix = /\/(?:api\/)?v1$/i.test(basePath);
+    let basePath = parsed.pathname.replace(/\/+$/, '');
+    // Native Gemini fallbacks use /v1beta/models even when the configured
+    // compatibility base is /v1beta/openai. Remove only that known suffix so
+    // the request is not sent to /v1beta/openai/v1beta/models.
+    const nativeGeminiPath = /^\/(v\d+(?:beta)?)\/models(?:\/|$)/i.test(path);
+    if (nativeGeminiPath && /\/openai$/i.test(basePath)) {
+      basePath = basePath.slice(0, -'/openai'.length).replace(/\/+$/, '');
+    }
+    const baseVersionMatch = basePath.match(/\/(?:api\/)?(v\d+(?:beta)?)$/i);
+    const baseHasVersionSuffix = !!baseVersionMatch;
     if (baseHasVersionSuffix) {
-      if (path === '/v1') {
+      const baseVersion = baseVersionMatch?.[1] || 'v1';
+      if (path.toLowerCase() === `/${baseVersion.toLowerCase()}`) {
         path = '/';
-      } else if (path.startsWith('/v1/')) {
-        path = path.slice('/v1'.length) || '/';
+      } else if (path.toLowerCase().startsWith(`/${baseVersion.toLowerCase()}/`)) {
+        path = path.slice(baseVersion.length + 1) || '/';
       }
     }
 
     const joinedPath = joinPath(basePath, path);
     return `${formatUrlOrigin(parsed)}${joinedPath}${parsed.search}${parsed.hash}`;
   } catch {
-    const baseHasVersionSuffix = /\/(?:api\/)?v1$/i.test(fallbackBase);
+    const baseVersionMatch = fallbackBase.match(/\/(?:api\/)?(v\d+(?:beta)?)$/i);
+    const baseHasVersionSuffix = !!baseVersionMatch;
     if (baseHasVersionSuffix) {
-      if (path === '/v1') {
+      const baseVersion = baseVersionMatch?.[1] || 'v1';
+      if (path.toLowerCase() === `/${baseVersion.toLowerCase()}`) {
         path = '/';
-      } else if (path.startsWith('/v1/')) {
-        path = path.slice('/v1'.length) || '/';
+      } else if (path.toLowerCase().startsWith(`/${baseVersion.toLowerCase()}/`)) {
+        path = path.slice(baseVersion.length + 1) || '/';
       }
     }
 

--- a/src/server/proxy-core/providers/types.ts
+++ b/src/server/proxy-core/providers/types.ts
@@ -15,7 +15,7 @@ export type ProviderAction =
   | 'countTokens';
 
 export type ProviderRuntimeDescriptor = {
-  executor: 'default' | 'codex' | 'gemini-cli' | 'antigravity' | 'claude';
+  executor: 'default' | 'codex' | 'gemini-native' | 'gemini-cli' | 'antigravity' | 'claude';
   modelName?: string;
   stream?: boolean;
   oauthProjectId?: string | null;

--- a/src/server/proxy-core/surfaces/chatSurface.ts
+++ b/src/server/proxy-core/surfaces/chatSurface.ts
@@ -46,6 +46,7 @@ import {
   createGeminiCliStreamReader,
   unwrapGeminiCliPayload,
 } from '../../transformers/gemini/generate-content/cliBridge.js';
+import { geminiGenerateContentTransformer } from '../../transformers/gemini/generate-content/index.js';
 import { summarizeConversationFileInputsInOpenAiBody } from '../capabilities/conversationFileCapabilities.js';
 import { getObservedResponseMeta } from '../firstByteTimeout.js';
 import { getRuntimeResponseReader, readRuntimeResponseText } from '../executors/types.js';
@@ -92,6 +93,49 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function asTrimmedString(value: unknown): string {
   return typeof value === 'string' ? value.trim() : '';
+}
+
+function isGeminiNativeRuntimePath(path: string): boolean {
+  return /\/v1beta\/models\/[^/]+:(?:streamGenerateContent|generateContent)(?:\?|$)/.test(path);
+}
+
+function buildOpenAiFinalFromGeminiNativePayload(
+  payload: unknown,
+  modelName: string,
+  fallbackText = '',
+) {
+  const aggregate = geminiGenerateContentTransformer.aggregator.createState();
+  for (const item of geminiGenerateContentTransformer.stream.parseJsonArrayPayload(payload)) {
+    geminiGenerateContentTransformer.aggregator.apply(aggregate, item);
+  }
+  const geminiFinal = geminiGenerateContentTransformer.outbound.serializeAggregateResponse(aggregate);
+  return openAiChatTransformer.transformFinalResponse(geminiFinal, modelName, fallbackText);
+}
+
+function buildOpenAiStreamLinesFromGeminiNativeSse(
+  rawText: string,
+  modelName: string,
+): { lines: string[]; finalPayload: Record<string, unknown> } {
+  const aggregate = geminiGenerateContentTransformer.stream.createAggregateState();
+  const parsed = geminiGenerateContentTransformer.stream.parseSsePayloads(rawText);
+  for (const payload of parsed.events) {
+    geminiGenerateContentTransformer.stream.applyAggregate(aggregate, payload);
+  }
+
+  const geminiFinal = geminiGenerateContentTransformer.outbound.serializeAggregateResponse(aggregate);
+  const normalizedFinal = openAiChatTransformer.transformFinalResponse(geminiFinal, modelName, rawText);
+  const streamContext = openAiChatTransformer.createStreamContext(modelName);
+  streamContext.id = normalizedFinal.id;
+  streamContext.model = normalizedFinal.model;
+  streamContext.created = normalizedFinal.created;
+  return {
+    finalPayload: geminiFinal,
+    lines: [
+      ...openAiChatTransformer.buildSyntheticChunks(normalizedFinal)
+        .map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`),
+      'data: [DONE]\n\n',
+    ],
+  };
 }
 
 function finalizeRetryAsUpstreamFailure(status: number, message: string) {
@@ -641,6 +685,36 @@ export async function handleChatSurfaceRequest(
           },
         });
         let rawText = '';
+        if (isGeminiNativeRuntimePath(successfulUpstreamPath)) {
+          rawText = await readRuntimeResponseText(upstream);
+          const bridged = buildOpenAiStreamLinesFromGeminiNativeSse(
+            rawText,
+            modelName,
+          );
+          upstreamUsagePresent = upstreamUsagePresent || hasProxyUsagePayload(bridged.finalPayload);
+          parsedUsage = mergeProxyUsage(parsedUsage, parseProxyUsage(bridged.finalPayload));
+          writeLines(bridged.lines);
+          streamResponse.end();
+
+          const latency = Date.now() - startTime;
+          await recordStreamSuccess(latency);
+          await finalizeDebugSuccess(
+            200,
+            successfulUpstreamPath,
+            buildSurfaceProxyDebugResponseHeaders(upstream),
+            debugTrace?.options.captureStreamChunks
+              ? rawText
+              : {
+                stream: true,
+                usage: parsedUsage,
+              },
+          );
+          bindSurfaceStickyChannel({
+            stickySessionKey,
+            selected,
+          });
+          return;
+        }
         if (!upstreamContentType.includes('text/event-stream')) {
           const fallbackText = await readRuntimeResponseText(upstream);
           rawText = fallbackText;
@@ -949,7 +1023,9 @@ export async function handleChatSurfaceRequest(
         );
         return reply.code(terminalFailureOutcome.status).send(terminalFailureOutcome.payload);
       }
-      const normalizedFinal = downstreamTransformer.transformFinalResponse(upstreamData, modelName, rawText);
+      const normalizedFinal = isGeminiNativeRuntimePath(successfulUpstreamPath)
+        ? buildOpenAiFinalFromGeminiNativePayload(upstreamData, modelName, rawText)
+        : downstreamTransformer.transformFinalResponse(upstreamData, modelName, rawText);
       const downstreamResponse = downstreamTransformer.serializeFinalResponse(normalizedFinal, parsedUsage);
 
       await recordSurfaceSuccess({

--- a/src/server/proxy-core/surfaces/chatSurface.ts
+++ b/src/server/proxy-core/surfaces/chatSurface.ts
@@ -112,29 +112,149 @@ function buildOpenAiFinalFromGeminiNativePayload(
   return openAiChatTransformer.transformFinalResponse(geminiFinal, modelName, fallbackText);
 }
 
-function buildOpenAiStreamLinesFromGeminiNativeSse(
-  rawText: string,
-  modelName: string,
-): { lines: string[]; finalPayload: Record<string, unknown> } {
-  const aggregate = geminiGenerateContentTransformer.stream.createAggregateState();
-  const parsed = geminiGenerateContentTransformer.stream.parseSsePayloads(rawText);
-  for (const payload of parsed.events) {
-    geminiGenerateContentTransformer.stream.applyAggregate(aggregate, payload);
-  }
+type GeminiNativeStreamReader = {
+  read(): Promise<{ done: boolean; value?: Uint8Array }>;
+  cancel(reason?: unknown): Promise<unknown>;
+  releaseLock(): void;
+};
 
-  const geminiFinal = geminiGenerateContentTransformer.outbound.serializeAggregateResponse(aggregate);
-  const normalizedFinal = openAiChatTransformer.transformFinalResponse(geminiFinal, modelName, rawText);
-  const streamContext = openAiChatTransformer.createStreamContext(modelName);
-  streamContext.id = normalizedFinal.id;
-  streamContext.model = normalizedFinal.model;
-  streamContext.created = normalizedFinal.created;
+/**
+ * Adapt Gemini native SSE events to OpenAI chat SSE incrementally. Native
+ * Gemini chunks carry provider-specific candidate parts, so they cannot be
+ * passed through the generic stream bridge directly; this reader translates
+ * each complete event while retaining only the small tool-argument prefix
+ * needed to avoid repeating cumulative function-call arguments.
+ */
+function createGeminiNativeOpenAiStreamReader(
+  upstreamReader: GeminiNativeStreamReader | null | undefined,
+  modelName: string,
+  onPayload: (payload: unknown) => void,
+  onRawText: (chunk: string) => void,
+): GeminiNativeStreamReader | null {
+  if (!upstreamReader) return null;
+
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+  const queued: Uint8Array[] = [];
+  const toolArgumentsByIndex = new Map<number, string>();
+  let buffer = '';
+  let finished = false;
+  let doneEventQueued = false;
+  let stableId = '';
+  let roleSent = false;
+
+  const finishReasonFor = (payload: unknown): string | null => {
+    if (!isRecord(payload)) return null;
+    const candidate = Array.isArray(payload.candidates) && isRecord(payload.candidates[0])
+      ? payload.candidates[0]
+      : null;
+    const rawReason = asTrimmedString(candidate?.finishReason || payload.finishReason).toUpperCase();
+    if (!rawReason) return null;
+    if (rawReason === 'FUNCTION_CALL' || rawReason === 'TOOL_CALLS') return 'tool_calls';
+    if (rawReason === 'MAX_TOKENS' || rawReason === 'LENGTH') return 'length';
+    if (rawReason === 'SAFETY' || rawReason === 'RECITATION') return 'content_filter';
+    return 'stop';
+  };
+
+  const serializePayload = (payload: unknown): string => {
+    onPayload(payload);
+    const normalized = buildOpenAiFinalFromGeminiNativePayload(payload, modelName);
+    if (!stableId) stableId = normalized.id;
+
+    const delta: Record<string, unknown> = {};
+    if (!roleSent) {
+      delta.role = 'assistant';
+      roleSent = true;
+    }
+    if (normalized.content) delta.content = normalized.content;
+    if (normalized.reasoningContent) delta.reasoning_content = normalized.reasoningContent;
+    if (normalized.toolCalls.length > 0) {
+      delta.tool_calls = normalized.toolCalls.map((toolCall, index) => {
+        const previousArguments = toolArgumentsByIndex.get(index) || '';
+        const currentArguments = toolCall.arguments || '';
+        const argumentsDelta = currentArguments.startsWith(previousArguments)
+          ? currentArguments.slice(previousArguments.length)
+          : currentArguments;
+        toolArgumentsByIndex.set(index, currentArguments);
+        return {
+          index,
+          id: toolCall.id,
+          type: 'function',
+          function: {
+            name: toolCall.name,
+            ...(argumentsDelta ? { arguments: argumentsDelta } : {}),
+          },
+        };
+      });
+    }
+    const finishReason = finishReasonFor(payload);
+    if (finishReason) {
+      return `data: ${JSON.stringify({
+        id: stableId,
+        object: 'chat.completion.chunk',
+        created: normalized.created,
+        model: normalized.model,
+        choices: [{ index: 0, delta, finish_reason: finishReason }],
+      })}\n\n`;
+    }
+    if (Object.keys(delta).length <= 0) return '';
+    return `data: ${JSON.stringify({
+      id: stableId,
+      object: 'chat.completion.chunk',
+      created: normalized.created,
+      model: normalized.model,
+      choices: [{ index: 0, delta, finish_reason: null }],
+    })}\n\n`;
+  };
+
+  const queueParsedEvents = (input: string, flush = false) => {
+    buffer += input;
+    const parsed = geminiGenerateContentTransformer.stream.parseSsePayloads(
+      flush ? `${buffer}\n\n` : buffer,
+    );
+    buffer = parsed.rest;
+    for (const payload of parsed.events) {
+      const line = serializePayload(payload);
+      if (line) queued.push(encoder.encode(line));
+    }
+  };
+
   return {
-    finalPayload: geminiFinal,
-    lines: [
-      ...openAiChatTransformer.buildSyntheticChunks(normalizedFinal)
-        .map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`),
-      'data: [DONE]\n\n',
-    ],
+    async read() {
+      while (queued.length <= 0 && !finished) {
+        const result = await upstreamReader.read();
+        if (result.done) {
+          const tail = decoder.decode();
+          if (tail) {
+            onRawText(tail);
+            queueParsedEvents(tail, false);
+          }
+          queueParsedEvents('', true);
+          finished = true;
+          break;
+        }
+        if (!result.value) continue;
+        const chunk = decoder.decode(result.value, { stream: true });
+        if (!chunk) continue;
+        onRawText(chunk);
+        queueParsedEvents(chunk, false);
+      }
+      if (queued.length > 0) {
+        return { done: false, value: queued.shift() };
+      }
+      if (finished && !doneEventQueued) {
+        doneEventQueued = true;
+        return { done: false, value: encoder.encode('data: [DONE]\n\n') };
+      }
+      return { done: true };
+    },
+    cancel(reason?: unknown) {
+      finished = true;
+      return upstreamReader.cancel(reason);
+    },
+    releaseLock() {
+      upstreamReader.releaseLock();
+    },
   };
 }
 
@@ -686,17 +806,53 @@ export async function handleChatSurfaceRequest(
         });
         let rawText = '';
         if (isGeminiNativeRuntimePath(successfulUpstreamPath)) {
-          rawText = await readRuntimeResponseText(upstream);
-          const bridged = buildOpenAiStreamLinesFromGeminiNativeSse(
-            rawText,
+          const nativeReader = createGeminiNativeOpenAiStreamReader(
+            getRuntimeResponseReader(upstream),
             modelName,
+            (payload) => {
+              upstreamUsagePresent = upstreamUsagePresent || hasProxyUsagePayload(payload);
+              parsedUsage = mergeProxyUsage(parsedUsage, parseProxyUsage(payload));
+            },
+            (chunk) => {
+              rawText += chunk;
+            },
           );
-          upstreamUsagePresent = upstreamUsagePresent || hasProxyUsagePayload(bridged.finalPayload);
-          parsedUsage = mergeProxyUsage(parsedUsage, parseProxyUsage(bridged.finalPayload));
-          writeLines(bridged.lines);
-          streamResponse.end();
-
+          const streamResult = await streamSession.run(nativeReader, streamResponse);
           const latency = Date.now() - startTime;
+          if (streamResult.status === 'failed') {
+            clearSurfaceStickyChannel({
+              stickySessionKey,
+              selected,
+            });
+            await failureToolkit.recordStreamFailure({
+              selected,
+              requestedModel,
+              modelName,
+              errorMessage: streamResult.errorMessage,
+              latencyMs: latency,
+              retryCount,
+              promptTokens: parsedUsage.promptTokens,
+              completionTokens: parsedUsage.completionTokens,
+              totalTokens: parsedUsage.totalTokens,
+              upstreamPath: successfulUpstreamPath,
+              runtimeFailureStatus: 502,
+            });
+            await finalizeDebugFailure(502, {
+              error: {
+                message: streamResult.errorMessage,
+                type: 'stream_error',
+              },
+            }, successfulUpstreamPath);
+            if (!streamStarted) {
+              return reply.code(502).send({
+                error: {
+                  message: streamResult.errorMessage,
+                  type: 'upstream_error',
+                },
+              });
+            }
+            return;
+          }
           await recordStreamSuccess(latency);
           await finalizeDebugSuccess(
             200,

--- a/src/server/services/upstreamRequestBuilder.test.ts
+++ b/src/server/services/upstreamRequestBuilder.test.ts
@@ -6,6 +6,68 @@ import {
 } from './upstreamRequestBuilder.js';
 
 describe('upstreamRequestBuilder', () => {
+  it('routes Gemini official chat tool history through native generateContent with signed functionCall parts', () => {
+    const request = buildUpstreamEndpointRequest({
+      endpoint: 'chat',
+      modelName: 'gemini-3.5-flash',
+      stream: true,
+      tokenValue: 'sk-test',
+      sitePlatform: 'gemini',
+      siteUrl: 'https://generativelanguage.googleapis.com',
+      openaiBody: {
+        model: 'gemini-3.5-flash',
+        stream: true,
+        messages: [
+          { role: 'system', content: 'You are concise.' },
+          { role: 'user', content: 'List files.' },
+          {
+            role: 'assistant',
+            tool_calls: [
+              {
+                id: 'call_read',
+                type: 'function',
+                function: {
+                  name: 'read',
+                  arguments: '{"path":"/tmp/a"}',
+                },
+              },
+            ],
+          },
+          { role: 'tool', tool_call_id: 'call_read', content: 'file content' },
+        ],
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'read',
+              parameters: { type: 'object', properties: {} },
+            },
+          },
+        ],
+        tool_choice: 'auto',
+      },
+      downstreamFormat: 'openai',
+    });
+
+    expect(request.path).toBe('/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse');
+    expect(request.runtime).toMatchObject({
+      executor: 'gemini-native',
+      action: 'streamGenerateContent',
+      modelName: 'gemini-3.5-flash',
+      stream: true,
+    });
+    expect(request.body).toHaveProperty('contents');
+    expect(request.body).not.toHaveProperty('messages');
+
+    const contents = request.body.contents as Array<{ role: string; parts: Array<Record<string, unknown>> }>;
+    const functionCallParts = contents
+      .flatMap((content) => content.parts)
+      .filter((part) => 'functionCall' in part);
+
+    expect(functionCallParts).toHaveLength(1);
+    expect(functionCallParts[0].thoughtSignature).toEqual(expect.any(String));
+  });
+
   it('normalizes single-message OpenAI requests to structured responses input', () => {
     const request = buildUpstreamEndpointRequest({
       endpoint: 'responses',

--- a/src/server/services/upstreamRequestBuilder.test.ts
+++ b/src/server/services/upstreamRequestBuilder.test.ts
@@ -49,7 +49,8 @@ describe('upstreamRequestBuilder', () => {
       downstreamFormat: 'openai',
     });
 
-    expect(request.path).toBe('/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse');
+    expect(request.path).toBe('/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse&key=sk-test');
+    expect(request.headers.Authorization).toBeUndefined();
     expect(request.runtime).toMatchObject({
       executor: 'gemini-native',
       action: 'streamGenerateContent',

--- a/src/server/services/upstreamRequestBuilder.test.ts
+++ b/src/server/services/upstreamRequestBuilder.test.ts
@@ -96,6 +96,24 @@ describe('upstreamRequestBuilder', () => {
     expect(request.body.store).toBe(false);
   });
 
+  it('rejects insecure URLs before embedding a Gemini API key in a native path', () => {
+    expect(() => buildUpstreamEndpointRequest({
+      endpoint: 'chat',
+      modelName: 'gemini-3.5-flash',
+      stream: false,
+      tokenValue: 'sk-test',
+      sitePlatform: 'gemini',
+      siteUrl: 'http://generativelanguage.googleapis.com',
+      openaiBody: {
+        model: 'gemini-3.5-flash',
+        messages: [
+          { role: 'assistant', tool_calls: [{ id: 'call_1', type: 'function', function: { name: 'read', arguments: '{}' } }] },
+        ],
+      },
+      downstreamFormat: 'openai',
+    })).toThrow('HTTPS');
+  });
+
   it('forces store=false for sub2api native responses passthrough bodies', () => {
     const request = buildUpstreamEndpointRequest({
       endpoint: 'responses',

--- a/src/server/services/upstreamRequestBuilder.ts
+++ b/src/server/services/upstreamRequestBuilder.ts
@@ -424,7 +424,7 @@ export function buildUpstreamEndpointRequest(input: {
   headers: Record<string, string>;
   body: Record<string, unknown>;
   runtime?: {
-    executor: 'default' | 'codex' | 'gemini-cli' | 'antigravity' | 'claude';
+    executor: 'default' | 'codex' | 'gemini-native' | 'gemini-cli' | 'antigravity' | 'claude';
     modelName?: string;
     stream?: boolean;
     oauthProjectId?: string | null;
@@ -439,6 +439,27 @@ export function buildUpstreamEndpointRequest(input: {
   const isAntigravityUpstream = sitePlatform === 'antigravity';
   const isInternalGeminiUpstream = isGeminiCliUpstream || isAntigravityUpstream;
   const isClaudeOauthUpstream = isClaudeUpstream && input.oauthProvider === 'claude';
+
+  const hasAssistantToolCallHistory = (body: Record<string, unknown>): boolean => {
+    const messages = Array.isArray(body.messages) ? body.messages : [];
+    return messages.some((message) => (
+      isRecord(message)
+      && asTrimmedString(message.role).toLowerCase() === 'assistant'
+      && Array.isArray(message.tool_calls)
+      && message.tool_calls.length > 0
+    ));
+  };
+
+  const resolveGeminiNativeEndpointPath = (stream: boolean): string => {
+    const normalizedModel = asTrimmedString(input.modelName).replace(/^models\//, '');
+    const encodedModel = normalizedModel
+      .split('/')
+      .map((segment) => encodeURIComponent(segment))
+      .join('/');
+    return stream
+      ? `/v1beta/models/${encodedModel}:streamGenerateContent?alt=sse`
+      : `/v1beta/models/${encodedModel}:generateContent`;
+  };
 
   const resolveGeminiEndpointPath = (endpoint: UpstreamEndpoint): string => {
     const normalizedSiteUrl = asTrimmedString(input.siteUrl).toLowerCase();
@@ -526,7 +547,7 @@ export function buildUpstreamEndpointRequest(input: {
             : sitePlatform === 'claude'
               ? 'claude'
               : 'default'
-    ) as 'default' | 'codex' | 'gemini-cli' | 'antigravity' | 'claude',
+    ) as 'default' | 'codex' | 'gemini-native' | 'gemini-cli' | 'antigravity' | 'claude',
     modelName: input.modelName,
     stream: input.stream,
     oauthProjectId: asTrimmedString(input.oauthProjectId) || null,
@@ -571,6 +592,27 @@ export function buildUpstreamEndpointRequest(input: {
       body: configuredGeminiRequest,
       action: input.stream ? 'streamGenerateContent' : 'generateContent',
     });
+  }
+
+  if (isGeminiUpstream && input.endpoint === 'chat' && hasAssistantToolCallHistory(openaiBody)) {
+    const geminiRequest = buildGeminiGenerateContentRequestFromOpenAi({
+      body: openaiBody,
+      modelName: input.modelName,
+    });
+    const configuredGeminiRequest = applyConfiguredPayloadRules(geminiRequest);
+    const action = input.stream ? 'streamGenerateContent' : 'generateContent';
+    return {
+      path: resolveGeminiNativeEndpointPath(input.stream),
+      headers: ensureStreamAcceptHeader(commonHeaders, input.stream),
+      body: configuredGeminiRequest,
+      runtime: {
+        executor: 'gemini-native',
+        modelName: input.modelName,
+        stream: input.stream,
+        oauthProjectId: null,
+        action,
+      },
+    };
   }
 
   if (input.endpoint === 'messages') {

--- a/src/server/services/upstreamRequestBuilder.ts
+++ b/src/server/services/upstreamRequestBuilder.ts
@@ -456,9 +456,16 @@ export function buildUpstreamEndpointRequest(input: {
       .split('/')
       .map((segment) => encodeURIComponent(segment))
       .join('/');
-    return stream
-      ? `/v1beta/models/${encodedModel}:streamGenerateContent?alt=sse`
-      : `/v1beta/models/${encodedModel}:generateContent`;
+    const params = new URLSearchParams();
+    if (stream) params.set('alt', 'sse');
+    // Gemini's native API-key authentication is query based. The compatibility
+    // path normally uses an OpenAI-style bearer header, but this fallback is
+    // dispatched to /v1beta/models and must carry the key explicitly.
+    params.set('key', input.tokenValue);
+    const suffix = params.toString();
+    return `${stream
+      ? `/v1beta/models/${encodedModel}:streamGenerateContent`
+      : `/v1beta/models/${encodedModel}:generateContent`}${suffix ? `?${suffix}` : ''}`;
   };
 
   const resolveGeminiEndpointPath = (endpoint: UpstreamEndpoint): string => {
@@ -601,9 +608,13 @@ export function buildUpstreamEndpointRequest(input: {
     });
     const configuredGeminiRequest = applyConfiguredPayloadRules(geminiRequest);
     const action = input.stream ? 'streamGenerateContent' : 'generateContent';
+    const nativeHeaders = { ...ensureStreamAcceptHeader(commonHeaders, input.stream) };
+    // Do not send the compatibility bearer credential to the native endpoint;
+    // the API key in the query string above is the canonical Gemini auth mode.
+    delete nativeHeaders.Authorization;
     return {
       path: resolveGeminiNativeEndpointPath(input.stream),
-      headers: ensureStreamAcceptHeader(commonHeaders, input.stream),
+      headers: nativeHeaders,
       body: configuredGeminiRequest,
       runtime: {
         executor: 'gemini-native',

--- a/src/server/services/upstreamRequestBuilder.ts
+++ b/src/server/services/upstreamRequestBuilder.ts
@@ -451,6 +451,17 @@ export function buildUpstreamEndpointRequest(input: {
   };
 
   const resolveGeminiNativeEndpointPath = (stream: boolean): string => {
+    if (input.siteUrl) {
+      let parsedSiteUrl: URL;
+      try {
+        parsedSiteUrl = new URL(input.siteUrl);
+      } catch {
+        throw new Error('Gemini native API requires a valid HTTPS site URL');
+      }
+      if (parsedSiteUrl.protocol !== 'https:') {
+        throw new Error('Gemini native API requires an HTTPS site URL');
+      }
+    }
     const normalizedModel = asTrimmedString(input.modelName).replace(/^models\//, '');
     const encodedModel = normalizedModel
       .split('/')

--- a/src/server/transformers/gemini/generate-content/requestBridge.thoughtSignature.test.ts
+++ b/src/server/transformers/gemini/generate-content/requestBridge.thoughtSignature.test.ts
@@ -148,6 +148,38 @@ describe('thoughtSignature injection in OpenAI→Gemini conversion', () => {
     expect(fcParts[0].thoughtSignature).toBeUndefined();
   });
 
+  it('injects dummy signature for Gemini 3 tool history even without explicit thinking config', () => {
+    const result = buildGeminiGenerateContentRequestFromOpenAi({
+      body: {
+        model: 'gemini-3.5-flash',
+        messages: [
+          { role: 'user', content: 'List files.' },
+          {
+            role: 'assistant',
+            tool_calls: [
+              {
+                id: 'call_ls',
+                type: 'function',
+                function: { name: 'ls', arguments: '{"path":"/tmp"}' },
+              },
+            ],
+          },
+          { role: 'tool', tool_call_id: 'call_ls', content: 'file1\nfile2' },
+        ],
+      },
+      modelName: 'gemini-3.5-flash',
+    }) as Record<string, unknown>;
+
+    const contents = result.contents as Array<Record<string, unknown>>;
+    const modelMsgs = contents.filter((c) => c.role === 'model');
+    const fcParts = modelMsgs
+      .flatMap((m) => (m.parts as Array<Record<string, unknown>>))
+      .filter((p) => 'functionCall' in p);
+
+    expect(fcParts).toHaveLength(1);
+    expect(fcParts[0].thoughtSignature).toEqual(expect.any(String));
+  });
+
   it('does not inject dummy signature or preserve thinkingConfig for non-gemini targets when signature is missing', () => {
     const result = buildGeminiGenerateContentRequestFromOpenAi({
       body: {

--- a/src/server/transformers/gemini/generate-content/requestBridge.ts
+++ b/src/server/transformers/gemini/generate-content/requestBridge.ts
@@ -45,6 +45,11 @@ function isDummyThoughtSafeModel(modelName: string): boolean {
   return normalized.startsWith('gemini-') || normalized.startsWith('models/gemini-');
 }
 
+function requiresFunctionCallThoughtSignature(modelName: string): boolean {
+  const normalized = asTrimmedString(modelName).toLowerCase().replace(/^models\//, '');
+  return /gemini-3(?:[.-]|$)/i.test(normalized);
+}
+
 function parseInlineDataUrl(url: string): { mimeType: string; data: string } | null {
   if (!url.startsWith('data:')) return null;
   const [, rest] = url.split('data:', 2);
@@ -181,6 +186,7 @@ export function buildGeminiGenerateContentRequestFromOpenAi(input: {
 
   const hasThinkingEnabled = !!resolveGeminiThinkingConfigFromRequest(input.modelName, input.body);
   const allowsDummyThoughtSignature = isDummyThoughtSafeModel(input.modelName);
+  const requiresThoughtSignature = requiresFunctionCallThoughtSignature(input.modelName);
   let shouldDisableThinkingConfig = false;
 
   const thoughtSignatureById = new Map<string, string>();
@@ -256,7 +262,7 @@ export function buildGeminiGenerateContentRequestFromOpenAi(input: {
       const signature = thoughtSignatureById.get(id);
       if (signature) {
         fcPart.thoughtSignature = signature;
-      } else if (hasThinkingEnabled && allowsDummyThoughtSignature) {
+      } else if ((hasThinkingEnabled || requiresThoughtSignature) && allowsDummyThoughtSignature) {
         fcPart.thoughtSignature = DUMMY_THOUGHT_SIGNATURE;
       } else if (hasThinkingEnabled) {
         shouldDisableThinkingConfig = true;

--- a/src/server/transformers/shared/chatFormatsCore.ts
+++ b/src/server/transformers/shared/chatFormatsCore.ts
@@ -658,6 +658,32 @@ function collectToolCallsFromResponsesPayload(payload: Record<string, unknown>):
   return toolCalls;
 }
 
+function collectToolCallsFromGeminiParts(parts: unknown): Array<{ id: string; name: string; arguments: string }> {
+  const contentParts = Array.isArray(parts) ? parts : [];
+  const toolCalls: Array<{ id: string; name: string; arguments: string }> = [];
+
+  for (let index = 0; index < contentParts.length; index += 1) {
+    const part = contentParts[index];
+    if (!isRecord(part) || !isRecord(part.functionCall)) continue;
+
+    const functionCall = part.functionCall;
+    const id = (
+      typeof functionCall.id === 'string' && functionCall.id.trim().length > 0
+        ? functionCall.id.trim()
+        : `call_${index}`
+    );
+    const name = typeof functionCall.name === 'string' ? functionCall.name.trim() : '';
+    const argumentsText = stringifyUnknownValue(functionCall.args);
+    toolCalls.push({
+      id,
+      name,
+      arguments: argumentsText,
+    });
+  }
+
+  return toolCalls;
+}
+
 function collectIndexedToolCallsFromResponsesPayload(
   payload: Record<string, unknown>,
 ): Array<{ id: string; name: string; arguments: string; outputIndex: number }> {
@@ -1415,17 +1441,21 @@ export function normalizeUpstreamFinalResponse(
 
   if (isRecord(payload) && Array.isArray(payload.candidates)) {
     const candidate = payload.candidates[0] || {};
-    const parsedCandidate = extractTextAndReasoning(candidate?.content?.parts || candidate?.content);
+    const candidateParts = candidate?.content?.parts || candidate?.content;
+    const parsedCandidate = extractTextAndReasoning(candidateParts);
+    const toolCalls = collectToolCallsFromGeminiParts(candidateParts);
     return {
       id: isNonEmptyString((payload as any).responseId) ? (payload as any).responseId : fallbackId,
       model: isNonEmptyString((payload as any).modelVersion)
         ? (payload as any).modelVersion
         : fallbackModel,
       created: now,
-      content: parsedCandidate.content || fallbackText,
+      content: parsedCandidate.content || (toolCalls.length > 0 ? '' : fallbackText),
       reasoningContent: parsedCandidate.reasoning,
-      finishReason: normalizeStopReason(candidate?.finishReason || (payload as any).finishReason) || 'stop',
-      toolCalls: [],
+      finishReason: toolCalls.length > 0
+        ? 'tool_calls'
+        : (normalizeStopReason(candidate?.finishReason || (payload as any).finishReason) || 'stop'),
+      toolCalls,
     };
   }
 

--- a/src/server/transformers/shared/normalized.test.ts
+++ b/src/server/transformers/shared/normalized.test.ts
@@ -530,6 +530,58 @@ describe('shared normalized helpers', () => {
     });
   });
 
+  it('normalizes Gemini native function calls as OpenAI tool calls', () => {
+    const normalized = normalizeUpstreamFinalResponse({
+      responseId: 'resp-gemini-tool-1',
+      modelVersion: 'gemini-3.5-flash',
+      candidates: [{
+        index: 0,
+        finishReason: 'STOP',
+        content: {
+          role: 'model',
+          parts: [{
+            functionCall: {
+              id: 'call_read',
+              name: 'read',
+              args: { path: '/tmp/example.txt' },
+            },
+            thoughtSignature: 'sig-tool',
+          }],
+        },
+      }],
+    }, 'fallback-model');
+
+    expect(normalized.toolCalls).toEqual([{
+      id: 'call_read',
+      name: 'read',
+      arguments: '{"path":"/tmp/example.txt"}',
+    }]);
+    expect(normalized.content).toBe('');
+    expect(normalized.finishReason).toBe('tool_calls');
+
+    expect(serializeFinalResponse('openai', normalized, {
+      promptTokens: 4,
+      completionTokens: 6,
+      totalTokens: 10,
+    })).toMatchObject({
+      choices: [{
+        message: {
+          role: 'assistant',
+          content: '',
+          tool_calls: [{
+            id: 'call_read',
+            type: 'function',
+            function: {
+              name: 'read',
+              arguments: '{"path":"/tmp/example.txt"}',
+            },
+          }],
+        },
+        finish_reason: 'tool_calls',
+      }],
+    });
+  });
+
   it('serializes provider-tagged reasoning signatures for openai-compatible downstreams', () => {
     const normalized = {
       id: 'chatcmpl-2',


### PR DESCRIPTION
## Summary

Fixes Gemini official chat-completions tool-history failures by routing OpenAI chat requests with assistant `tool_calls` through the native Gemini `generateContent` bridge.

Closes #580.

## What changed

- Detect Gemini official `/v1/chat/completions` requests that replay assistant tool-call history.
- Build native Gemini `generateContent` / `streamGenerateContent` requests for that case instead of sending the history to `/v1beta/openai/chat/completions`.
- Add safe dummy `thoughtSignature` values for Gemini 3 function-call parts when downstream OpenAI clients cannot provide Gemini provider metadata.
- Convert native Gemini `functionCall` responses back into OpenAI-compatible `tool_calls` for non-stream and stream chat responses.
- Extend runtime executor typing with `gemini-native`.
- Add regression coverage for request routing, thought-signature injection, and response normalization.

## Why

Gemini 3.x official upstreams can reject OpenAI-compatible chat requests with prior assistant `tool_calls`:

```text
Function call is missing a thought_signature in functionCall parts.
```

PR #135 fixed the Gemini CLI/native conversion path, but the Gemini official OpenAI-compatible chat route could still hit `/v1beta/openai/chat/completions` with unsigned tool-call history. This change keeps the downstream OpenAI API stable while using Gemini's native format where the required tool-history metadata can be represented.

## Verification

- `npx vitest run --root . src/server/services/upstreamRequestBuilder.test.ts src/server/transformers/gemini/generate-content/requestBridge.thoughtSignature.test.ts src/server/transformers/shared/normalized.test.ts`
- `npx vitest run --root . src/server/transformers/gemini/generate-content/index.test.ts src/server/transformers/gemini/generate-content/streamBridge.test.ts src/server/transformers/openai/chat/streamBridge.test.ts src/server/routes/proxy/architecture-boundaries.test.ts`
- `npm run typecheck`
- `npm test`

Note: `npm test` needs permission to bind local `127.0.0.1` test servers; under a restricted sandbox it fails with `listen EPERM`, but it passes when run with normal local permissions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Gemini-native request execution with streaming and non-streaming responses.
  * Converted Gemini-native requests, tool calls, and responses to OpenAI-compatible formats.
  * Added routing for versioned Gemini API endpoints and support for tool-call history.

* **Bug Fixes**
  * Improved tool-call normalization, finish reasons, URL handling, and API-key authentication.
  * Rejects insecure HTTP endpoints before sending credentials.

* **Tests**
  * Expanded coverage for routing, transformations, streaming, authentication, and response normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->