### PR TITLE
feat: 优化自定义群组在通道重建后自动更新

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -1,0 +1,125 @@
+name: 手动发布 GHCR 镜像
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 镜像标签
+        required: false
+        default: latest
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ghcr-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish-ghcr-arch:
+    name: 发布 GHCR 镜像（${{ matrix.arch }}）
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    env:
+      GHCR_IMAGE: ghcr.io/${{ github.repository }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+          - arch: armv7
+            platform: linux/arm/v7
+            runner: ubuntu-latest
+
+    steps:
+      - name: 检出仓库
+        uses: actions/checkout@v7
+
+      - name: 设置 Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: 为 armv7 启用 QEMU
+        if: matrix.arch == 'armv7'
+        uses: docker/setup-qemu-action@v4
+
+      - name: 登录 GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 生成镜像元数据
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.GHCR_IMAGE }}
+          tags: |
+            type=raw,value=${{ inputs.tag }}
+
+      - name: 为每个架构追加后缀
+        id: arch-tags
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -f tags.txt
+          while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
+            echo "${tag}-${{ matrix.arch }}" >> tags.txt
+          done <<< "${{ steps.meta.outputs.tags }}"
+          {
+            echo 'tags<<EOF'
+            cat tags.txt
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: 构建并推送 ${{ matrix.platform }} 镜像
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: ${{ steps.arch-tags.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=ghcr-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=ghcr-${{ matrix.arch }}
+
+  publish-ghcr-manifest:
+    name: 发布 GHCR Manifest
+    needs: publish-ghcr-arch
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GHCR_IMAGE: ghcr.io/${{ github.repository }}
+
+    steps:
+      - name: 检出仓库
+        uses: actions/checkout@v7
+
+      - name: 设置 Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: 登录 GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 创建多架构 manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${GHCR_IMAGE}:${{ inputs.tag }}"
+          docker buildx imagetools create \
+            --tag "$tag" \
+            "${tag}-amd64" \
+            "${tag}-arm64" \
+            "${tag}-armv7"

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -13,16 +13,38 @@ permissions:
   packages: write
 
 concurrency:
-  group: ghcr-publish-${{ github.ref }}
+  # The tag is the shared output resource; serialize runs targeting the same tag.
+  group: ghcr-publish-${{ inputs.tag }}
   cancel-in-progress: false
 
 jobs:
+  validate_tag:
+    name: 校验镜像标签
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.validate.outputs.tag }}
+    steps:
+      - name: 校验 Docker 标签格式
+        id: validate
+        shell: bash
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$INPUT_TAG" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+            echo "Invalid Docker tag: $INPUT_TAG" >&2
+            exit 1
+          fi
+          printf 'tag=%s\n' "$INPUT_TAG" >> "$GITHUB_OUTPUT"
+
   publish-ghcr-arch:
     name: 发布 GHCR 镜像（${{ matrix.arch }}）
+    needs: validate_tag
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
     env:
       GHCR_IMAGE: ghcr.io/${{ github.repository }}
+      IMAGE_TAG: ${{ needs.validate_tag.outputs.tag }}
     strategy:
       fail-fast: false
       matrix:
@@ -61,7 +83,7 @@ jobs:
         with:
           images: ${{ env.GHCR_IMAGE }}
           tags: |
-            type=raw,value=${{ inputs.tag }}
+            type=raw,value=${{ needs.validate_tag.outputs.tag }}
 
       - name: 为每个架构追加后缀
         id: arch-tags
@@ -93,11 +115,12 @@ jobs:
 
   publish-ghcr-manifest:
     name: 发布 GHCR Manifest
-    needs: publish-ghcr-arch
+    needs: [validate_tag, publish-ghcr-arch]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
       GHCR_IMAGE: ghcr.io/${{ github.repository }}
+      IMAGE_TAG: ${{ needs.validate_tag.outputs.tag }}
 
     steps:
       - name: 检出仓库
@@ -117,7 +140,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          tag="${GHCR_IMAGE}:${{ inputs.tag }}"
+          tag="${GHCR_IMAGE}:${IMAGE_TAG}"
           docker buildx imagetools create \
             --tag "$tag" \
             "${tag}-amd64" \

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,3 @@ docker/.env
 docs/plan/
 docs/plans/
 .ace-tool/
-待修复问题.md

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ docker/.env
 docs/plan/
 docs/plans/
 .ace-tool/
+待修复问题.md

--- a/scripts/dev/docker.workflow.test.ts
+++ b/scripts/dev/docker.workflow.test.ts
@@ -50,4 +50,16 @@ describe('docker workflows', () => {
     expect(dockerfile).toContain('RUN npm run build:web && npm run build:server');
     expect(dockerfile).toContain('npm prune --omit=dev --no-audit --no-fund');
   });
+
+  it('validates manual GHCR tags before using them in publish commands', () => {
+    const workflow = readFileSync(resolve(process.cwd(), '.github/workflows/publish-ghcr.yml'), 'utf8');
+
+    expect(workflow).toContain('validate_tag:');
+    expect(workflow).toContain('INPUT_TAG: ${{ inputs.tag }}');
+    expect(workflow).toContain('^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$');
+    expect(workflow).toContain('tag: ${{ steps.validate.outputs.tag }}');
+    expect(workflow).toContain('type=raw,value=${{ needs.validate_tag.outputs.tag }}');
+    expect(workflow).toContain('tag="${GHCR_IMAGE}:${IMAGE_TAG}"');
+    expect(workflow).not.toContain('tag="${GHCR_IMAGE}:${{ inputs.tag }}"');
+  });
 });

--- a/src/server/routes/api/routeRefreshWorkflow.architecture.test.ts
+++ b/src/server/routes/api/routeRefreshWorkflow.architecture.test.ts
@@ -39,6 +39,16 @@ describe('route refresh workflow architecture boundaries', () => {
     expectCallsRebuildRoutesOnly(statsSource);
   });
 
+  it('keeps exact-route pattern sync detection behind the pattern sync service', () => {
+    const tokensSource = readSource('./tokens.ts');
+    const patternSyncServiceSource = readSource('../../services/patternRouteChannelSyncService.ts');
+
+    expect(tokensSource).toContain('syncPatternRouteChannelsAfterAffectedRouteChanges');
+    expect(tokensSource).not.toContain('rebuildPatternRouteChannelsAfterExactSourceRouteChange');
+    expect(tokensSource).not.toContain('rebuildAllPatternRouteChannels');
+    expect(patternSyncServiceSource).toContain('syncPatternRouteChannelsAfterAffectedRouteChanges');
+  });
+
   it('keeps proxy fallback refreshes and scheduler hooks on the route refresh workflow', () => {
     const completionsSource = readSource('../proxy/completions.ts');
     const embeddingsSource = readSource('../proxy/embeddings.ts');

--- a/src/server/routes/api/tokens.route-update-rebuild.test.ts
+++ b/src/server/routes/api/tokens.route-update-rebuild.test.ts
@@ -71,6 +71,8 @@ describe('PUT /api/routes/:id route rebuild', () => {
   beforeEach(async () => {
     resetTokenRouteReadLimitersForTests();
     await db.delete(schema.routeChannels).run();
+    await db.delete(schema.oauthRouteUnitMembers).run();
+    await db.delete(schema.oauthRouteUnits).run();
     await db.delete(schema.tokenRoutes).run();
     await db.delete(schema.tokenModelAvailability).run();
     await db.delete(schema.modelAvailability).run();
@@ -786,6 +788,83 @@ describe('PUT /api/routes/:id route rebuild', () => {
       .all();
     expect(patternChannels.map((channel) => channel.sourceModel).sort()).toEqual(['gpt-5-alpha', 'manual-special']);
     expect(patternChannels.some((channel) => channel.id === manualPatternChannel.id)).toBe(true);
+  });
+
+  it('preserves OAuth route-unit channels when rebuilding pattern groups from exact routes', async () => {
+    const sourceA = await seedAccountWithToken('gpt-5-route-unit');
+    const sourceB = await seedAccountWithToken('gpt-5-route-unit');
+
+    const routeUnit = await db.insert(schema.oauthRouteUnits).values({
+      siteId: sourceA.site.id,
+      provider: 'codex',
+      name: 'Codex Route Unit',
+      strategy: 'round_robin',
+      enabled: true,
+    }).returning().get();
+    await db.insert(schema.oauthRouteUnitMembers).values([
+      { unitId: routeUnit.id, accountId: sourceA.account.id, sortOrder: 0 },
+      { unitId: routeUnit.id, accountId: sourceB.account.id, sortOrder: 1 },
+    ]).run();
+
+    const exactRoute = await db.insert(schema.tokenRoutes).values({
+      modelPattern: 'gpt-5-route-unit',
+      enabled: true,
+    }).returning().get();
+    const exactChannel = await db.insert(schema.routeChannels).values({
+      routeId: exactRoute.id,
+      accountId: sourceA.account.id,
+      tokenId: null,
+      oauthRouteUnitId: routeUnit.id,
+      sourceModel: 'gpt-5-route-unit',
+      priority: 4,
+      weight: 6,
+      enabled: true,
+      manualOverride: false,
+    }).returning().get();
+
+    const patternResponse = await app.inject({
+      method: 'POST',
+      url: '/api/routes',
+      payload: {
+        modelPattern: 're:^gpt-5-route.*$',
+        displayName: 'gpt-route-unit-group',
+      },
+    });
+    expect(patternResponse.statusCode).toBe(200);
+    const patternRouteId = patternResponse.json().id as number;
+
+    let patternChannels = await db.select().from(schema.routeChannels)
+      .where(eq(schema.routeChannels.routeId, patternRouteId))
+      .all();
+    expect(patternChannels).toHaveLength(1);
+    expect(patternChannels[0]).toMatchObject({
+      accountId: sourceA.account.id,
+      tokenId: null,
+      oauthRouteUnitId: routeUnit.id,
+      sourceModel: 'gpt-5-route-unit',
+      priority: 4,
+      weight: 6,
+      manualOverride: false,
+    });
+
+    const updateResponse = await app.inject({
+      method: 'PUT',
+      url: `/api/channels/${exactChannel.id}`,
+      payload: {
+        priority: 7,
+      },
+    });
+    expect(updateResponse.statusCode).toBe(200);
+
+    patternChannels = await db.select().from(schema.routeChannels)
+      .where(eq(schema.routeChannels.routeId, patternRouteId))
+      .all();
+    expect(patternChannels).toHaveLength(1);
+    expect(patternChannels[0]).toMatchObject({
+      oauthRouteUnitId: routeUnit.id,
+      priority: 7,
+      manualOverride: false,
+    });
   });
 
   it('removes exact source channels from pattern groups when deleting an exact route', async () => {

--- a/src/server/routes/api/tokens.route-update-rebuild.test.ts
+++ b/src/server/routes/api/tokens.route-update-rebuild.test.ts
@@ -658,6 +658,181 @@ describe('PUT /api/routes/:id route rebuild', () => {
     expect(updated?.tokenId).toBe(seeded.token.id);
   });
 
+  it('syncs pattern-group channels when exact source route channels change or get disabled', async () => {
+    const sourceA = await seedAccountWithToken('gpt-5-alpha');
+    const sourceB = await seedAccountWithToken('gpt-5-mini');
+    const manualSource = await seedAccountWithToken('manual-special');
+
+    const exactRouteA = await db.insert(schema.tokenRoutes).values({
+      modelPattern: 'gpt-5-alpha',
+      enabled: true,
+    }).returning().get();
+    const exactRouteB = await db.insert(schema.tokenRoutes).values({
+      modelPattern: 'gpt-5-mini',
+      enabled: true,
+    }).returning().get();
+
+    await db.insert(schema.routeChannels).values({
+      routeId: exactRouteA.id,
+      accountId: sourceA.account.id,
+      tokenId: sourceA.token.id,
+      sourceModel: 'gpt-5-alpha',
+      priority: 0,
+      weight: 10,
+      enabled: true,
+      manualOverride: false,
+    }).run();
+    const sourceBChannel = await db.insert(schema.routeChannels).values({
+      routeId: exactRouteB.id,
+      accountId: sourceB.account.id,
+      tokenId: sourceB.token.id,
+      sourceModel: 'gpt-5-mini',
+      priority: 3,
+      weight: 7,
+      enabled: true,
+      manualOverride: true,
+    }).returning().get();
+
+    const patternResponse = await app.inject({
+      method: 'POST',
+      url: '/api/routes',
+      payload: {
+        modelPattern: 're:^gpt-5.*$',
+        displayName: 'gpt-5-group',
+      },
+    });
+    expect(patternResponse.statusCode).toBe(200);
+    const patternRouteId = patternResponse.json().id as number;
+
+    const initialPatternChannels = await db.select().from(schema.routeChannels)
+      .where(eq(schema.routeChannels.routeId, patternRouteId))
+      .all();
+    const copiedB = initialPatternChannels.find((channel) => channel.sourceModel === 'gpt-5-mini');
+    expect(initialPatternChannels.map((channel) => channel.sourceModel).sort()).toEqual(['gpt-5-alpha', 'gpt-5-mini']);
+    expect(copiedB?.priority).toBe(3);
+    expect(copiedB?.weight).toBe(7);
+    expect(copiedB?.manualOverride).toBe(false);
+
+    const manualPatternChannel = await db.insert(schema.routeChannels).values({
+      routeId: patternRouteId,
+      accountId: manualSource.account.id,
+      tokenId: manualSource.token.id,
+      sourceModel: 'manual-special',
+      priority: 9,
+      weight: 1,
+      enabled: true,
+      manualOverride: true,
+    }).returning().get();
+
+    const deleteResponse = await app.inject({
+      method: 'DELETE',
+      url: `/api/channels/${sourceBChannel.id}`,
+    });
+    expect(deleteResponse.statusCode).toBe(200);
+
+    let patternChannels = await db.select().from(schema.routeChannels)
+      .where(eq(schema.routeChannels.routeId, patternRouteId))
+      .all();
+    expect(patternChannels.map((channel) => channel.sourceModel).sort()).toEqual(['gpt-5-alpha', 'manual-special']);
+    expect(patternChannels.some((channel) => channel.id === manualPatternChannel.id)).toBe(true);
+
+    const addResponse = await app.inject({
+      method: 'POST',
+      url: `/api/routes/${exactRouteB.id}/channels`,
+      payload: {
+        accountId: sourceB.account.id,
+        tokenId: sourceB.token.id,
+        sourceModel: 'gpt-5-mini',
+      },
+    });
+    expect(addResponse.statusCode).toBe(200);
+    const readdedSourceBChannelId = addResponse.json().id as number;
+
+    patternChannels = await db.select().from(schema.routeChannels)
+      .where(eq(schema.routeChannels.routeId, patternRouteId))
+      .all();
+    expect(patternChannels.map((channel) => channel.sourceModel).sort()).toEqual(['gpt-5-alpha', 'gpt-5-mini', 'manual-special']);
+
+    const updateResponse = await app.inject({
+      method: 'PUT',
+      url: `/api/channels/${readdedSourceBChannelId}`,
+      payload: {
+        priority: 6,
+        weight: 4,
+      },
+    });
+    expect(updateResponse.statusCode).toBe(200);
+
+    patternChannels = await db.select().from(schema.routeChannels)
+      .where(eq(schema.routeChannels.routeId, patternRouteId))
+      .all();
+    const updatedPatternB = patternChannels.find((channel) => channel.sourceModel === 'gpt-5-mini');
+    expect(updatedPatternB?.priority).toBe(6);
+    expect(updatedPatternB?.weight).toBe(4);
+    expect(updatedPatternB?.manualOverride).toBe(false);
+
+    const disableResponse = await app.inject({
+      method: 'POST',
+      url: '/api/routes/batch',
+      payload: {
+        ids: [exactRouteB.id],
+        action: 'disable',
+      },
+    });
+    expect(disableResponse.statusCode).toBe(200);
+
+    patternChannels = await db.select().from(schema.routeChannels)
+      .where(eq(schema.routeChannels.routeId, patternRouteId))
+      .all();
+    expect(patternChannels.map((channel) => channel.sourceModel).sort()).toEqual(['gpt-5-alpha', 'manual-special']);
+    expect(patternChannels.some((channel) => channel.id === manualPatternChannel.id)).toBe(true);
+  });
+
+  it('removes exact source channels from pattern groups when deleting an exact route', async () => {
+    const source = await seedAccountWithToken('gpt-5-delete-me');
+    const exactRoute = await db.insert(schema.tokenRoutes).values({
+      modelPattern: 'gpt-5-delete-me',
+      enabled: true,
+    }).returning().get();
+    await db.insert(schema.routeChannels).values({
+      routeId: exactRoute.id,
+      accountId: source.account.id,
+      tokenId: source.token.id,
+      sourceModel: 'gpt-5-delete-me',
+      priority: 0,
+      weight: 10,
+      enabled: true,
+      manualOverride: false,
+    }).run();
+
+    const patternResponse = await app.inject({
+      method: 'POST',
+      url: '/api/routes',
+      payload: {
+        modelPattern: 're:^gpt-5.*$',
+        displayName: 'gpt-5-group',
+      },
+    });
+    expect(patternResponse.statusCode).toBe(200);
+    const patternRouteId = patternResponse.json().id as number;
+
+    let patternChannels = await db.select().from(schema.routeChannels)
+      .where(eq(schema.routeChannels.routeId, patternRouteId))
+      .all();
+    expect(patternChannels.map((channel) => channel.sourceModel)).toEqual(['gpt-5-delete-me']);
+
+    const deleteResponse = await app.inject({
+      method: 'DELETE',
+      url: `/api/routes/${exactRoute.id}`,
+    });
+    expect(deleteResponse.statusCode).toBe(200);
+
+    patternChannels = await db.select().from(schema.routeChannels)
+      .where(eq(schema.routeChannels.routeId, patternRouteId))
+      .all();
+    expect(patternChannels).toHaveLength(0);
+  });
+
   it('prefers an explicit-group display name over a colliding exact route', async () => {
     const exactCandidate = await seedAccountWithToken('claude-opus-4-6');
     const groupedCandidate = await seedAccountWithToken('claude-opus-4-5');

--- a/src/server/routes/api/tokens.route-update-rebuild.test.ts
+++ b/src/server/routes/api/tokens.route-update-rebuild.test.ts
@@ -73,6 +73,7 @@ describe('PUT /api/routes/:id route rebuild', () => {
     await db.delete(schema.routeChannels).run();
     await db.delete(schema.oauthRouteUnitMembers).run();
     await db.delete(schema.oauthRouteUnits).run();
+    await db.delete(schema.settings).run();
     await db.delete(schema.tokenRoutes).run();
     await db.delete(schema.tokenModelAvailability).run();
     await db.delete(schema.modelAvailability).run();

--- a/src/server/routes/api/tokens.ts
+++ b/src/server/routes/api/tokens.ts
@@ -43,8 +43,8 @@ import {
 } from '../../contracts/tokenRoutePayloads.js';
 import {
   populateRouteChannelsByModelPattern,
-  rebuildAllPatternRouteChannels,
   rebuildAutomaticRouteChannelsByModelPattern,
+  syncPatternRouteChannelsAfterAffectedRouteChanges,
 } from '../../services/patternRouteChannelSyncService.js';
 
 function createTokenRouteReadLimiter(keyPrefix: string, points = 60) {
@@ -271,31 +271,6 @@ async function clearDependentExplicitGroupSnapshotsBySourceRouteIds(sourceRouteI
   const dependentRouteIds = Array.from(dependentRouteIdSet);
   if (dependentRouteIds.length === 0) return;
   await clearRouteDecisionSnapshots(dependentRouteIds);
-}
-
-async function rebuildPatternRouteChannelsAfterExactSourceRouteChange(routeIds: number[]): Promise<void> {
-  const normalizedRouteIds = Array.from(new Set(
-    routeIds
-      .map((routeId) => Math.trunc(routeId))
-      .filter((routeId) => routeId > 0),
-  ));
-  if (normalizedRouteIds.length === 0) return;
-
-  const routes = await db.select({
-    id: schema.tokenRoutes.id,
-    modelPattern: schema.tokenRoutes.modelPattern,
-    routeMode: schema.tokenRoutes.routeMode,
-  }).from(schema.tokenRoutes)
-    .where(inArray(schema.tokenRoutes.id, normalizedRouteIds))
-    .all();
-
-  const hasExactSourceRoute = routes.some((route) => (
-    !isExplicitGroupRoute(route)
-    && isExactModelPattern(route.modelPattern)
-  ));
-  if (!hasExactSourceRoute) return;
-
-  await rebuildAllPatternRouteChannels();
 }
 
 async function getDefaultTokenId(accountId: number): Promise<number | null> {
@@ -819,9 +794,9 @@ export async function tokensRoutes(app: FastifyInstance) {
     if (created > 0) {
       await clearRouteDecisionSnapshot(routeId);
       await clearDependentExplicitGroupSnapshotsBySourceRouteIds([routeId]);
-      if (isExactModelPattern(route.modelPattern)) {
-        await rebuildAllPatternRouteChannels();
-      }
+      await syncPatternRouteChannelsAfterAffectedRouteChanges({
+        affectedRouteIds: [routeId],
+      });
       invalidateTokenRouterCache();
     }
 
@@ -1043,9 +1018,9 @@ export async function tokensRoutes(app: FastifyInstance) {
       }
     } else {
       await populateRouteChannelsByModelPattern(route.id, modelPattern);
-      if (isExactModelPattern(modelPattern)) {
-        await rebuildAllPatternRouteChannels();
-      }
+      await syncPatternRouteChannelsAfterAffectedRouteChanges({
+        affectedRouteIds: [route.id],
+      });
     }
     invalidateTokenRouterCache();
     return await getRouteWithSources(routeId);
@@ -1130,20 +1105,16 @@ export async function tokensRoutes(app: FastifyInstance) {
       || body.modelMapping !== undefined
       || body.routingStrategy !== undefined
       || body.enabled !== undefined;
-    const previousExactModelPattern = routeMode === 'pattern' && isExactModelPattern(existingRoute.modelPattern)
-      ? existingRoute.modelPattern
-      : null;
-    const nextIsExactModelPattern = routeMode === 'pattern' && isExactModelPattern(nextModelPattern);
     if (routeMode === 'pattern' && modelPatternChanged) {
       await rebuildAutomaticRouteChannelsByModelPattern(id, nextModelPattern);
     }
-    if (
-      routeMode === 'pattern'
-      && (previousExactModelPattern || nextIsExactModelPattern)
-      && (modelPatternChanged || body.enabled !== undefined)
-    ) {
-      await rebuildAllPatternRouteChannels({
-        excludeExactModelPatterns: previousExactModelPattern && modelPatternChanged ? [previousExactModelPattern] : [],
+    if (routeMode === 'pattern' && (modelPatternChanged || body.enabled !== undefined)) {
+      await syncPatternRouteChannelsAfterAffectedRouteChanges({
+        affectedRouteIds: [id],
+        removedRoutes: modelPatternChanged ? [{
+          modelPattern: existingRoute.modelPattern,
+          routeMode: existingRoute.routeMode,
+        }] : [],
       });
     }
     if (routeBehaviorChanged) {
@@ -1164,15 +1135,12 @@ export async function tokensRoutes(app: FastifyInstance) {
     const existingRoute = await db.select().from(schema.tokenRoutes).where(eq(schema.tokenRoutes.id, id)).get();
     await clearDependentExplicitGroupSnapshotsBySourceRouteIds([id]);
     await db.delete(schema.tokenRoutes).where(eq(schema.tokenRoutes.id, id)).run();
-    if (
-      existingRoute
-      && !isExplicitGroupRoute(existingRoute)
-      && isExactModelPattern(existingRoute.modelPattern)
-    ) {
-      await rebuildAllPatternRouteChannels({
-        excludeExactModelPatterns: [existingRoute.modelPattern],
-      });
-    }
+    await syncPatternRouteChannelsAfterAffectedRouteChanges({
+      removedRoutes: existingRoute ? [{
+        modelPattern: existingRoute.modelPattern,
+        routeMode: existingRoute.routeMode,
+      }] : [],
+    });
     invalidateTokenRouterCache();
     return { success: true };
   });
@@ -1216,7 +1184,9 @@ export async function tokensRoutes(app: FastifyInstance) {
 
     await clearRouteDecisionSnapshots(ids);
     await clearDependentExplicitGroupSnapshotsBySourceRouteIds(ids);
-    await rebuildPatternRouteChannelsAfterExactSourceRouteChange(ids);
+    await syncPatternRouteChannelsAfterAffectedRouteChanges({
+      affectedRouteIds: ids,
+    });
     invalidateTokenRouterCache();
 
     return { success: true, updatedCount: Number(updateResult?.changes || 0) };
@@ -1279,9 +1249,9 @@ export async function tokensRoutes(app: FastifyInstance) {
     }
     await clearRouteDecisionSnapshot(routeId);
     await clearDependentExplicitGroupSnapshotsBySourceRouteIds([routeId]);
-    if (isExactModelPattern(route.modelPattern)) {
-      await rebuildAllPatternRouteChannels();
-    }
+    await syncPatternRouteChannelsAfterAffectedRouteChanges({
+      affectedRouteIds: [routeId],
+    });
     invalidateTokenRouterCache();
     return created;
   });
@@ -1315,7 +1285,9 @@ export async function tokensRoutes(app: FastifyInstance) {
       .all();
     await clearRouteDecisionSnapshots(existingChannels.map((channel) => channel.routeId));
     await clearDependentExplicitGroupSnapshotsBySourceRouteIds(existingChannels.map((channel) => channel.routeId));
-    await rebuildPatternRouteChannelsAfterExactSourceRouteChange(existingChannels.map((channel) => channel.routeId));
+    await syncPatternRouteChannelsAfterAffectedRouteChanges({
+      affectedRouteIds: existingChannels.map((channel) => channel.routeId),
+    });
     invalidateTokenRouterCache();
     return { success: true, channels: updatedChannels };
   });
@@ -1369,7 +1341,9 @@ export async function tokensRoutes(app: FastifyInstance) {
     await db.update(schema.routeChannels).set(updates).where(eq(schema.routeChannels.id, channelId)).run();
     await clearRouteDecisionSnapshot(channel.routeId);
     await clearDependentExplicitGroupSnapshotsBySourceRouteIds([channel.routeId]);
-    await rebuildPatternRouteChannelsAfterExactSourceRouteChange([channel.routeId]);
+    await syncPatternRouteChannelsAfterAffectedRouteChanges({
+      affectedRouteIds: [channel.routeId],
+    });
     invalidateTokenRouterCache();
     return await db.select().from(schema.routeChannels).where(eq(schema.routeChannels.id, channelId)).get();
   });
@@ -1382,7 +1356,9 @@ export async function tokensRoutes(app: FastifyInstance) {
     if (channel) {
       await clearRouteDecisionSnapshot(channel.routeId);
       await clearDependentExplicitGroupSnapshotsBySourceRouteIds([channel.routeId]);
-      await rebuildPatternRouteChannelsAfterExactSourceRouteChange([channel.routeId]);
+      await syncPatternRouteChannelsAfterAffectedRouteChanges({
+        affectedRouteIds: [channel.routeId],
+      });
     }
     invalidateTokenRouterCache();
     return { success: true };

--- a/src/server/routes/api/tokens.ts
+++ b/src/server/routes/api/tokens.ts
@@ -41,6 +41,11 @@ import {
   parseTokenRouteCreatePayload,
   parseTokenRouteUpdatePayload,
 } from '../../contracts/tokenRoutePayloads.js';
+import {
+  populateRouteChannelsByModelPattern,
+  rebuildAllPatternRouteChannels,
+  rebuildAutomaticRouteChannelsByModelPattern,
+} from '../../services/patternRouteChannelSyncService.js';
 
 function createTokenRouteReadLimiter(keyPrefix: string, points = 60) {
   return new RateLimiterMemory({
@@ -268,6 +273,31 @@ async function clearDependentExplicitGroupSnapshotsBySourceRouteIds(sourceRouteI
   await clearRouteDecisionSnapshots(dependentRouteIds);
 }
 
+async function rebuildPatternRouteChannelsAfterExactSourceRouteChange(routeIds: number[]): Promise<void> {
+  const normalizedRouteIds = Array.from(new Set(
+    routeIds
+      .map((routeId) => Math.trunc(routeId))
+      .filter((routeId) => routeId > 0),
+  ));
+  if (normalizedRouteIds.length === 0) return;
+
+  const routes = await db.select({
+    id: schema.tokenRoutes.id,
+    modelPattern: schema.tokenRoutes.modelPattern,
+    routeMode: schema.tokenRoutes.routeMode,
+  }).from(schema.tokenRoutes)
+    .where(inArray(schema.tokenRoutes.id, normalizedRouteIds))
+    .all();
+
+  const hasExactSourceRoute = routes.some((route) => (
+    !isExplicitGroupRoute(route)
+    && isExactModelPattern(route.modelPattern)
+  ));
+  if (!hasExactSourceRoute) return;
+
+  await rebuildAllPatternRouteChannels();
+}
+
 async function getDefaultTokenId(accountId: number): Promise<number | null> {
   const token = await db.select().from(schema.accountTokens)
     .where(and(
@@ -317,143 +347,6 @@ async function checkTokenBelongsToAccount(tokenId: number, accountId: number): P
     .where(and(eq(schema.accountTokens.id, tokenId), eq(schema.accountTokens.accountId, accountId)))
     .get();
   return isUsableAccountToken(row ?? null);
-}
-
-async function getPatternTokenCandidates(modelPattern: string): Promise<Array<{ tokenId: number; accountId: number; sourceModel: string }>> {
-  const rows = await db.select().from(schema.tokenModelAvailability)
-    .innerJoin(schema.accountTokens, eq(schema.tokenModelAvailability.tokenId, schema.accountTokens.id))
-    .innerJoin(schema.accounts, eq(schema.accountTokens.accountId, schema.accounts.id))
-    .innerJoin(schema.sites, eq(schema.accounts.siteId, schema.sites.id))
-    .where(
-      and(
-        eq(schema.tokenModelAvailability.available, true),
-        eq(schema.accountTokens.enabled, true),
-        eq(schema.accountTokens.valueStatus, ACCOUNT_TOKEN_VALUE_STATUS_READY),
-        eq(schema.accounts.status, 'active'),
-        eq(schema.sites.status, 'active'),
-      ),
-    )
-    .all();
-
-  const result: Array<{ tokenId: number; accountId: number; sourceModel: string }> = [];
-  for (const row of rows) {
-    if (!isUsableAccountToken(row.account_tokens)) continue;
-    const modelName = row.token_model_availability.modelName?.trim();
-    if (!modelName) continue;
-    if (!matchesModelPattern(modelName, modelPattern)) continue;
-    result.push({
-      tokenId: row.account_tokens.id,
-      accountId: row.accounts.id,
-      sourceModel: modelName,
-    });
-  }
-
-  return result;
-}
-
-async function getMatchedExactRouteChannelCandidates(modelPattern: string): Promise<Array<{
-  tokenId: number | null;
-  accountId: number;
-  sourceModel: string;
-  priority: number;
-  weight: number;
-  enabled: boolean;
-  manualOverride: boolean;
-}>> {
-  const matchedRoutes = (await db.select().from(schema.tokenRoutes)
-    .where(eq(schema.tokenRoutes.enabled, true))
-    .all())
-    .filter((route) => isExactModelPattern(route.modelPattern) && matchesModelPattern(route.modelPattern, modelPattern));
-
-  if (matchedRoutes.length === 0) return [];
-  const routeMap = new Map<number, typeof matchedRoutes[number]>();
-  for (const route of matchedRoutes) routeMap.set(route.id, route);
-
-  const channels = await db.select().from(schema.routeChannels)
-    .where(inArray(schema.routeChannels.routeId, matchedRoutes.map((route) => route.id)))
-    .all();
-
-  return channels.map((channel) => ({
-    tokenId: channel.tokenId ?? null,
-    accountId: channel.accountId,
-    sourceModel: (channel.sourceModel || routeMap.get(channel.routeId)?.modelPattern || '').trim(),
-    priority: channel.priority ?? 0,
-    weight: channel.weight ?? 10,
-    enabled: !!channel.enabled,
-    manualOverride: !!channel.manualOverride,
-  })).filter((candidate) => candidate.sourceModel.length > 0);
-}
-
-async function populateRouteChannelsByModelPattern(routeId: number, modelPattern: string): Promise<number> {
-  const routeCandidates = await getMatchedExactRouteChannelCandidates(modelPattern);
-  const availabilityCandidates = (await getPatternTokenCandidates(modelPattern)).map((candidate) => ({
-    tokenId: candidate.tokenId,
-    accountId: candidate.accountId,
-    sourceModel: candidate.sourceModel,
-    priority: 0,
-    weight: 10,
-    enabled: true,
-    manualOverride: false,
-  }));
-  const candidates = [...routeCandidates, ...availabilityCandidates];
-  if (candidates.length === 0) return 0;
-
-  const existingChannels = await db.select().from(schema.routeChannels)
-    .where(eq(schema.routeChannels.routeId, routeId))
-    .all();
-  const existingPairs = new Set<string>(
-    existingChannels
-      .map((channel) => {
-        const tokenId = typeof channel.tokenId === 'number' && Number.isFinite(channel.tokenId) ? channel.tokenId : 0;
-        const sourceModel = (channel.sourceModel || '').trim().toLowerCase();
-        return `${channel.accountId}::${tokenId}::${sourceModel}`;
-      }),
-  );
-
-  let created = 0;
-  for (const candidate of candidates) {
-    const tokenId = typeof candidate.tokenId === 'number' && Number.isFinite(candidate.tokenId) ? candidate.tokenId : 0;
-    const pairKey = `${candidate.accountId}::${tokenId}::${candidate.sourceModel.trim().toLowerCase()}`;
-    if (existingPairs.has(pairKey)) continue;
-    await db.insert(schema.routeChannels).values({
-      routeId,
-      accountId: candidate.accountId,
-      tokenId: candidate.tokenId,
-      sourceModel: candidate.sourceModel,
-      priority: candidate.priority,
-      weight: candidate.weight,
-      enabled: candidate.enabled,
-      manualOverride: candidate.manualOverride,
-    }).run();
-    existingPairs.add(pairKey);
-    created += 1;
-  }
-
-  return created;
-}
-
-async function rebuildAutomaticRouteChannelsByModelPattern(routeId: number, modelPattern: string): Promise<{
-  removedChannels: number;
-  createdChannels: number;
-}> {
-  const removableChannels = await db.select().from(schema.routeChannels)
-    .where(
-      and(
-        eq(schema.routeChannels.routeId, routeId),
-        eq(schema.routeChannels.manualOverride, false),
-      ),
-    )
-    .all();
-
-  for (const channel of removableChannels) {
-    await db.delete(schema.routeChannels).where(eq(schema.routeChannels.id, channel.id)).run();
-  }
-
-  const createdChannels = await populateRouteChannelsByModelPattern(routeId, modelPattern);
-  return {
-    removedChannels: removableChannels.length,
-    createdChannels,
-  };
 }
 
 type BatchChannelPriorityUpdate = {
@@ -926,6 +819,9 @@ export async function tokensRoutes(app: FastifyInstance) {
     if (created > 0) {
       await clearRouteDecisionSnapshot(routeId);
       await clearDependentExplicitGroupSnapshotsBySourceRouteIds([routeId]);
+      if (isExactModelPattern(route.modelPattern)) {
+        await rebuildAllPatternRouteChannels();
+      }
       invalidateTokenRouterCache();
     }
 
@@ -1147,6 +1043,9 @@ export async function tokensRoutes(app: FastifyInstance) {
       }
     } else {
       await populateRouteChannelsByModelPattern(route.id, modelPattern);
+      if (isExactModelPattern(modelPattern)) {
+        await rebuildAllPatternRouteChannels();
+      }
     }
     invalidateTokenRouterCache();
     return await getRouteWithSources(routeId);
@@ -1231,8 +1130,21 @@ export async function tokensRoutes(app: FastifyInstance) {
       || body.modelMapping !== undefined
       || body.routingStrategy !== undefined
       || body.enabled !== undefined;
+    const previousExactModelPattern = routeMode === 'pattern' && isExactModelPattern(existingRoute.modelPattern)
+      ? existingRoute.modelPattern
+      : null;
+    const nextIsExactModelPattern = routeMode === 'pattern' && isExactModelPattern(nextModelPattern);
     if (routeMode === 'pattern' && modelPatternChanged) {
       await rebuildAutomaticRouteChannelsByModelPattern(id, nextModelPattern);
+    }
+    if (
+      routeMode === 'pattern'
+      && (previousExactModelPattern || nextIsExactModelPattern)
+      && (modelPatternChanged || body.enabled !== undefined)
+    ) {
+      await rebuildAllPatternRouteChannels({
+        excludeExactModelPatterns: previousExactModelPattern && modelPatternChanged ? [previousExactModelPattern] : [],
+      });
     }
     if (routeBehaviorChanged) {
       await clearRouteDecisionSnapshot(id);
@@ -1249,8 +1161,18 @@ export async function tokensRoutes(app: FastifyInstance) {
   // Delete a route
   app.delete<{ Params: { id: string } }>('/api/routes/:id', async (request) => {
     const id = parseInt(request.params.id, 10);
+    const existingRoute = await db.select().from(schema.tokenRoutes).where(eq(schema.tokenRoutes.id, id)).get();
     await clearDependentExplicitGroupSnapshotsBySourceRouteIds([id]);
     await db.delete(schema.tokenRoutes).where(eq(schema.tokenRoutes.id, id)).run();
+    if (
+      existingRoute
+      && !isExplicitGroupRoute(existingRoute)
+      && isExactModelPattern(existingRoute.modelPattern)
+    ) {
+      await rebuildAllPatternRouteChannels({
+        excludeExactModelPatterns: [existingRoute.modelPattern],
+      });
+    }
     invalidateTokenRouterCache();
     return { success: true };
   });
@@ -1294,6 +1216,7 @@ export async function tokensRoutes(app: FastifyInstance) {
 
     await clearRouteDecisionSnapshots(ids);
     await clearDependentExplicitGroupSnapshotsBySourceRouteIds(ids);
+    await rebuildPatternRouteChannelsAfterExactSourceRouteChange(ids);
     invalidateTokenRouterCache();
 
     return { success: true, updatedCount: Number(updateResult?.changes || 0) };
@@ -1356,6 +1279,9 @@ export async function tokensRoutes(app: FastifyInstance) {
     }
     await clearRouteDecisionSnapshot(routeId);
     await clearDependentExplicitGroupSnapshotsBySourceRouteIds([routeId]);
+    if (isExactModelPattern(route.modelPattern)) {
+      await rebuildAllPatternRouteChannels();
+    }
     invalidateTokenRouterCache();
     return created;
   });
@@ -1389,6 +1315,7 @@ export async function tokensRoutes(app: FastifyInstance) {
       .all();
     await clearRouteDecisionSnapshots(existingChannels.map((channel) => channel.routeId));
     await clearDependentExplicitGroupSnapshotsBySourceRouteIds(existingChannels.map((channel) => channel.routeId));
+    await rebuildPatternRouteChannelsAfterExactSourceRouteChange(existingChannels.map((channel) => channel.routeId));
     invalidateTokenRouterCache();
     return { success: true, channels: updatedChannels };
   });
@@ -1442,6 +1369,7 @@ export async function tokensRoutes(app: FastifyInstance) {
     await db.update(schema.routeChannels).set(updates).where(eq(schema.routeChannels.id, channelId)).run();
     await clearRouteDecisionSnapshot(channel.routeId);
     await clearDependentExplicitGroupSnapshotsBySourceRouteIds([channel.routeId]);
+    await rebuildPatternRouteChannelsAfterExactSourceRouteChange([channel.routeId]);
     invalidateTokenRouterCache();
     return await db.select().from(schema.routeChannels).where(eq(schema.routeChannels.id, channelId)).get();
   });
@@ -1454,6 +1382,7 @@ export async function tokensRoutes(app: FastifyInstance) {
     if (channel) {
       await clearRouteDecisionSnapshot(channel.routeId);
       await clearDependentExplicitGroupSnapshotsBySourceRouteIds([channel.routeId]);
+      await rebuildPatternRouteChannelsAfterExactSourceRouteChange([channel.routeId]);
     }
     invalidateTokenRouterCache();
     return { success: true };

--- a/src/server/routes/api/tokens.ts
+++ b/src/server/routes/api/tokens.ts
@@ -1364,12 +1364,12 @@ export async function tokensRoutes(app: FastifyInstance) {
 
     const body = parsedBody.data;
     if (body.refreshModels === false) {
-      const rebuild = await routeRefreshWorkflow.rebuildRoutesOnly();
+      const rebuild = await routeRefreshWorkflow.rebuildRoutesOnly({ rebuildPatternRoutes: true });
       return { success: true, rebuild };
     }
 
     if (body.wait) {
-      const result = await routeRefreshWorkflow.refreshModelsAndRebuildRoutes();
+      const result = await routeRefreshWorkflow.refreshModelsAndRebuildRoutes({ rebuildPatternRoutes: true });
       return { success: true, ...result };
     }
 
@@ -1386,7 +1386,7 @@ export async function tokensRoutes(app: FastifyInstance) {
         },
         failureMessage: (currentTask) => `刷新模型并重建路由失败：${currentTask.error || 'unknown error'}`,
       },
-      async () => routeRefreshWorkflow.refreshModelsAndRebuildRoutes(),
+      async () => routeRefreshWorkflow.refreshModelsAndRebuildRoutes({ rebuildPatternRoutes: true }),
     );
 
     return reply.code(202).send({

--- a/src/server/routes/api/tokens.ts
+++ b/src/server/routes/api/tokens.ts
@@ -42,6 +42,11 @@ import {
   parseTokenRouteUpdatePayload,
 } from '../../contracts/tokenRoutePayloads.js';
 import {
+  populateRouteChannelsByModelPattern as populatePatternRouteChannels,
+  rebuildAllPatternRouteChannels,
+  rebuildAutomaticRouteChannelsByModelPattern as rebuildAutomaticPatternRouteChannels,
+} from '../../services/patternRouteChannelSyncService.js';
+import {
   createRouteChannel,
   insertRouteChannelsWithAllocatedPriorities,
   replaceAutomaticRouteChannels,
@@ -275,6 +280,31 @@ async function clearDependentExplicitGroupSnapshotsBySourceRouteIds(sourceRouteI
   await clearRouteDecisionSnapshots(dependentRouteIds);
 }
 
+async function rebuildPatternRouteChannelsAfterExactSourceRouteChange(routeIds: number[]): Promise<void> {
+  const normalizedRouteIds = Array.from(new Set(
+    routeIds
+      .map((routeId) => Math.trunc(routeId))
+      .filter((routeId) => routeId > 0),
+  ));
+  if (normalizedRouteIds.length === 0) return;
+
+  const routes = await db.select({
+    id: schema.tokenRoutes.id,
+    modelPattern: schema.tokenRoutes.modelPattern,
+    routeMode: schema.tokenRoutes.routeMode,
+  }).from(schema.tokenRoutes)
+    .where(inArray(schema.tokenRoutes.id, normalizedRouteIds))
+    .all();
+
+  const hasExactSourceRoute = routes.some((route) => (
+    !isExplicitGroupRoute(route)
+    && isExactModelPattern(route.modelPattern)
+  ));
+  if (!hasExactSourceRoute) return;
+
+  await rebuildAllPatternRouteChannels();
+}
+
 async function getDefaultTokenId(accountId: number): Promise<number | null> {
   const token = await db.select().from(schema.accountTokens)
     .where(and(
@@ -324,107 +354,6 @@ async function checkTokenBelongsToAccount(tokenId: number, accountId: number): P
     .where(and(eq(schema.accountTokens.id, tokenId), eq(schema.accountTokens.accountId, accountId)))
     .get();
   return isUsableAccountToken(row ?? null);
-}
-
-async function getPatternTokenCandidates(modelPattern: string): Promise<Array<{ tokenId: number; accountId: number; sourceModel: string }>> {
-  const rows = await db.select().from(schema.tokenModelAvailability)
-    .innerJoin(schema.accountTokens, eq(schema.tokenModelAvailability.tokenId, schema.accountTokens.id))
-    .innerJoin(schema.accounts, eq(schema.accountTokens.accountId, schema.accounts.id))
-    .innerJoin(schema.sites, eq(schema.accounts.siteId, schema.sites.id))
-    .where(
-      and(
-        eq(schema.tokenModelAvailability.available, true),
-        eq(schema.accountTokens.enabled, true),
-        eq(schema.accountTokens.valueStatus, ACCOUNT_TOKEN_VALUE_STATUS_READY),
-        eq(schema.accounts.status, 'active'),
-        eq(schema.sites.status, 'active'),
-      ),
-    )
-    .all();
-
-  const result: Array<{ tokenId: number; accountId: number; sourceModel: string }> = [];
-  for (const row of rows) {
-    if (!isUsableAccountToken(row.account_tokens)) continue;
-    const modelName = row.token_model_availability.modelName?.trim();
-    if (!modelName) continue;
-    if (!matchesModelPattern(modelName, modelPattern)) continue;
-    result.push({
-      tokenId: row.account_tokens.id,
-      accountId: row.accounts.id,
-      sourceModel: modelName,
-    });
-  }
-
-  return result;
-}
-
-async function getMatchedExactRouteChannelCandidates(modelPattern: string): Promise<Array<{
-  tokenId: number | null;
-  accountId: number;
-  sourceModel: string;
-  priority: number;
-  weight: number;
-  enabled: boolean;
-  manualOverride: boolean;
-}>> {
-  const matchedRoutes = (await db.select().from(schema.tokenRoutes)
-    .where(eq(schema.tokenRoutes.enabled, true))
-    .all())
-    .filter((route) => isExactModelPattern(route.modelPattern) && matchesModelPattern(route.modelPattern, modelPattern));
-
-  if (matchedRoutes.length === 0) return [];
-  const routeMap = new Map<number, typeof matchedRoutes[number]>();
-  for (const route of matchedRoutes) routeMap.set(route.id, route);
-
-  const channels = await db.select().from(schema.routeChannels)
-    .where(inArray(schema.routeChannels.routeId, matchedRoutes.map((route) => route.id)))
-    .all();
-
-  return channels.map((channel) => ({
-    tokenId: channel.tokenId ?? null,
-    accountId: channel.accountId,
-    sourceModel: (channel.sourceModel || routeMap.get(channel.routeId)?.modelPattern || '').trim(),
-    priority: channel.priority ?? 0,
-    weight: channel.weight ?? 10,
-    enabled: !!channel.enabled,
-    manualOverride: !!channel.manualOverride,
-  })).filter((candidate) => candidate.sourceModel.length > 0);
-}
-
-async function populateRouteChannelsByModelPattern(routeId: number, modelPattern: string): Promise<number> {
-  const routeCandidates = await getMatchedExactRouteChannelCandidates(modelPattern);
-  const availabilityCandidates = (await getPatternTokenCandidates(modelPattern)).map((candidate) => ({
-    tokenId: candidate.tokenId,
-    accountId: candidate.accountId,
-    sourceModel: candidate.sourceModel,
-    weight: 10,
-    enabled: true,
-    manualOverride: false,
-  }));
-  const candidates = [...routeCandidates, ...availabilityCandidates];
-  if (candidates.length === 0) return 0;
-
-  const result = await insertRouteChannelsWithAllocatedPriorities({ routeId, candidates });
-  return result.created;
-}
-
-async function rebuildAutomaticRouteChannelsByModelPattern(routeId: number, modelPattern: string): Promise<{
-  removedChannels: number;
-  createdChannels: number;
-}> {
-  const routeCandidates = await getMatchedExactRouteChannelCandidates(modelPattern);
-  const availabilityCandidates = (await getPatternTokenCandidates(modelPattern)).map((candidate) => ({
-    tokenId: candidate.tokenId,
-    accountId: candidate.accountId,
-    sourceModel: candidate.sourceModel,
-    weight: 10,
-    enabled: true,
-    manualOverride: false,
-  }));
-  return await replaceAutomaticRouteChannels({
-    routeId,
-    candidates: [...routeCandidates, ...availabilityCandidates],
-  });
 }
 
 type BatchChannelPriorityUpdate = {
@@ -888,6 +817,9 @@ export async function tokensRoutes(app: FastifyInstance) {
     }
 
     const result = await insertRouteChannelsWithAllocatedPriorities({ routeId, candidates });
+    if (result.created > 0 && isExactModelPattern(route.modelPattern)) {
+      await rebuildAllPatternRouteChannels();
+    }
 
     return {
       success: true,
@@ -1111,7 +1043,10 @@ export async function tokensRoutes(app: FastifyInstance) {
         await clearDependentExplicitGroupSnapshotsBySourceRouteIds(syncedRouteIds);
       }
     } else {
-      await populateRouteChannelsByModelPattern(route.id, modelPattern);
+      await populatePatternRouteChannels(route.id, modelPattern);
+      if (isExactModelPattern(modelPattern)) {
+        await rebuildAllPatternRouteChannels();
+      }
     }
     invalidateTokenRouterCache();
     return await getRouteWithSources(routeId);
@@ -1196,8 +1131,21 @@ export async function tokensRoutes(app: FastifyInstance) {
       || body.modelMapping !== undefined
       || body.routingStrategy !== undefined
       || body.enabled !== undefined;
+    const previousExactModelPattern = routeMode === 'pattern' && isExactModelPattern(existingRoute.modelPattern)
+      ? existingRoute.modelPattern
+      : null;
+    const nextIsExactModelPattern = routeMode === 'pattern' && isExactModelPattern(nextModelPattern);
     if (routeMode === 'pattern' && modelPatternChanged) {
-      await rebuildAutomaticRouteChannelsByModelPattern(id, nextModelPattern);
+      await rebuildAutomaticPatternRouteChannels(id, nextModelPattern);
+    }
+    if (
+      routeMode === 'pattern'
+      && (previousExactModelPattern || nextIsExactModelPattern)
+      && (modelPatternChanged || body.enabled !== undefined)
+    ) {
+      await rebuildAllPatternRouteChannels({
+        excludeExactModelPatterns: previousExactModelPattern && modelPatternChanged ? [previousExactModelPattern] : [],
+      });
     }
     if (routeBehaviorChanged) {
       await clearRouteDecisionSnapshot(id);
@@ -1214,8 +1162,18 @@ export async function tokensRoutes(app: FastifyInstance) {
   // Delete a route
   app.delete<{ Params: { id: string } }>('/api/routes/:id', async (request) => {
     const id = parseInt(request.params.id, 10);
+    const existingRoute = await db.select().from(schema.tokenRoutes).where(eq(schema.tokenRoutes.id, id)).get();
     await clearDependentExplicitGroupSnapshotsBySourceRouteIds([id]);
     await db.delete(schema.tokenRoutes).where(eq(schema.tokenRoutes.id, id)).run();
+    if (
+      existingRoute
+      && !isExplicitGroupRoute(existingRoute)
+      && isExactModelPattern(existingRoute.modelPattern)
+    ) {
+      await rebuildAllPatternRouteChannels({
+        excludeExactModelPatterns: [existingRoute.modelPattern],
+      });
+    }
     invalidateTokenRouterCache();
     return { success: true };
   });
@@ -1259,6 +1217,7 @@ export async function tokensRoutes(app: FastifyInstance) {
 
     await clearRouteDecisionSnapshots(ids);
     await clearDependentExplicitGroupSnapshotsBySourceRouteIds(ids);
+    await rebuildPatternRouteChannelsAfterExactSourceRouteChange(ids);
     invalidateTokenRouterCache();
 
     return { success: true, updatedCount: Number(updateResult?.changes || 0) };
@@ -1322,6 +1281,9 @@ export async function tokensRoutes(app: FastifyInstance) {
         message: error instanceof Error ? error.message : '创建通道失败',
       });
     }
+    if (isExactModelPattern(route.modelPattern)) {
+      await rebuildAllPatternRouteChannels();
+    }
     return created;
   });
 
@@ -1332,15 +1294,17 @@ export async function tokensRoutes(app: FastifyInstance) {
       return reply.code(400).send({ success: false, message: parsed.message });
     }
 
+    let updatedChannels: typeof schema.routeChannels.$inferSelect[];
     try {
-      const updatedChannels = await updateRouteChannelPriorities(parsed.updates);
-      return { success: true, channels: updatedChannels };
+      updatedChannels = await updateRouteChannelPriorities(parsed.updates);
     } catch (error) {
       if (error instanceof RouteChannelNotFoundError) {
         return reply.code(404).send({ success: false, message: error.message });
       }
       throw error;
     }
+    await rebuildPatternRouteChannelsAfterExactSourceRouteChange(parsed.updates.map((update) => update.id));
+    return { success: true, channels: updatedChannels };
   });
 
   // Update a channel
@@ -1392,6 +1356,7 @@ export async function tokensRoutes(app: FastifyInstance) {
     await db.update(schema.routeChannels).set(updates).where(eq(schema.routeChannels.id, channelId)).run();
     await clearRouteDecisionSnapshot(channel.routeId);
     await clearDependentExplicitGroupSnapshotsBySourceRouteIds([channel.routeId]);
+    await rebuildPatternRouteChannelsAfterExactSourceRouteChange([channel.routeId]);
     invalidateTokenRouterCache();
     return await db.select().from(schema.routeChannels).where(eq(schema.routeChannels.id, channelId)).get();
   });
@@ -1404,6 +1369,7 @@ export async function tokensRoutes(app: FastifyInstance) {
     if (channel) {
       await clearRouteDecisionSnapshot(channel.routeId);
       await clearDependentExplicitGroupSnapshotsBySourceRouteIds([channel.routeId]);
+      await rebuildPatternRouteChannelsAfterExactSourceRouteChange([channel.routeId]);
     }
     invalidateTokenRouterCache();
     return { success: true };

--- a/src/server/routes/api/tokens.ts
+++ b/src/server/routes/api/tokens.ts
@@ -1117,6 +1117,7 @@ export async function tokensRoutes(app: FastifyInstance) {
         removedRoutes: modelPatternChanged ? [{
           modelPattern: existingRoute.modelPattern,
           routeMode: existingRoute.routeMode,
+          enabled: existingRoute.enabled,
         }] : [],
       });
     }
@@ -1142,6 +1143,7 @@ export async function tokensRoutes(app: FastifyInstance) {
       removedRoutes: existingRoute ? [{
         modelPattern: existingRoute.modelPattern,
         routeMode: existingRoute.routeMode,
+        enabled: existingRoute.enabled,
       }] : [],
     });
     invalidateTokenRouterCache();

--- a/src/server/routes/api/tokens.ts
+++ b/src/server/routes/api/tokens.ts
@@ -42,9 +42,9 @@ import {
   parseTokenRouteUpdatePayload,
 } from '../../contracts/tokenRoutePayloads.js';
 import {
-  populateRouteChannelsByModelPattern as populatePatternRouteChannels,
-  rebuildAllPatternRouteChannels,
-  rebuildAutomaticRouteChannelsByModelPattern as rebuildAutomaticPatternRouteChannels,
+  populateRouteChannelsByModelPattern,
+  rebuildAutomaticRouteChannelsByModelPattern,
+  syncPatternRouteChannelsAfterAffectedRouteChanges,
 } from '../../services/patternRouteChannelSyncService.js';
 import {
   createRouteChannel,
@@ -278,31 +278,6 @@ async function clearDependentExplicitGroupSnapshotsBySourceRouteIds(sourceRouteI
   const dependentRouteIds = Array.from(dependentRouteIdSet);
   if (dependentRouteIds.length === 0) return;
   await clearRouteDecisionSnapshots(dependentRouteIds);
-}
-
-async function rebuildPatternRouteChannelsAfterExactSourceRouteChange(routeIds: number[]): Promise<void> {
-  const normalizedRouteIds = Array.from(new Set(
-    routeIds
-      .map((routeId) => Math.trunc(routeId))
-      .filter((routeId) => routeId > 0),
-  ));
-  if (normalizedRouteIds.length === 0) return;
-
-  const routes = await db.select({
-    id: schema.tokenRoutes.id,
-    modelPattern: schema.tokenRoutes.modelPattern,
-    routeMode: schema.tokenRoutes.routeMode,
-  }).from(schema.tokenRoutes)
-    .where(inArray(schema.tokenRoutes.id, normalizedRouteIds))
-    .all();
-
-  const hasExactSourceRoute = routes.some((route) => (
-    !isExplicitGroupRoute(route)
-    && isExactModelPattern(route.modelPattern)
-  ));
-  if (!hasExactSourceRoute) return;
-
-  await rebuildAllPatternRouteChannels();
 }
 
 async function getDefaultTokenId(accountId: number): Promise<number | null> {
@@ -817,8 +792,10 @@ export async function tokensRoutes(app: FastifyInstance) {
     }
 
     const result = await insertRouteChannelsWithAllocatedPriorities({ routeId, candidates });
-    if (result.created > 0 && isExactModelPattern(route.modelPattern)) {
-      await rebuildAllPatternRouteChannels();
+    if (result.created > 0) {
+      await syncPatternRouteChannelsAfterAffectedRouteChanges({
+        affectedRouteIds: [routeId],
+      });
     }
 
     return {
@@ -1043,10 +1020,10 @@ export async function tokensRoutes(app: FastifyInstance) {
         await clearDependentExplicitGroupSnapshotsBySourceRouteIds(syncedRouteIds);
       }
     } else {
-      await populatePatternRouteChannels(route.id, modelPattern);
-      if (isExactModelPattern(modelPattern)) {
-        await rebuildAllPatternRouteChannels();
-      }
+      await populateRouteChannelsByModelPattern(route.id, modelPattern);
+      await syncPatternRouteChannelsAfterAffectedRouteChanges({
+        affectedRouteIds: [route.id],
+      });
     }
     invalidateTokenRouterCache();
     return await getRouteWithSources(routeId);
@@ -1131,20 +1108,16 @@ export async function tokensRoutes(app: FastifyInstance) {
       || body.modelMapping !== undefined
       || body.routingStrategy !== undefined
       || body.enabled !== undefined;
-    const previousExactModelPattern = routeMode === 'pattern' && isExactModelPattern(existingRoute.modelPattern)
-      ? existingRoute.modelPattern
-      : null;
-    const nextIsExactModelPattern = routeMode === 'pattern' && isExactModelPattern(nextModelPattern);
     if (routeMode === 'pattern' && modelPatternChanged) {
-      await rebuildAutomaticPatternRouteChannels(id, nextModelPattern);
+      await rebuildAutomaticRouteChannelsByModelPattern(id, nextModelPattern);
     }
-    if (
-      routeMode === 'pattern'
-      && (previousExactModelPattern || nextIsExactModelPattern)
-      && (modelPatternChanged || body.enabled !== undefined)
-    ) {
-      await rebuildAllPatternRouteChannels({
-        excludeExactModelPatterns: previousExactModelPattern && modelPatternChanged ? [previousExactModelPattern] : [],
+    if (routeMode === 'pattern' && (modelPatternChanged || body.enabled !== undefined)) {
+      await syncPatternRouteChannelsAfterAffectedRouteChanges({
+        affectedRouteIds: [id],
+        removedRoutes: modelPatternChanged ? [{
+          modelPattern: existingRoute.modelPattern,
+          routeMode: existingRoute.routeMode,
+        }] : [],
       });
     }
     if (routeBehaviorChanged) {
@@ -1165,15 +1138,12 @@ export async function tokensRoutes(app: FastifyInstance) {
     const existingRoute = await db.select().from(schema.tokenRoutes).where(eq(schema.tokenRoutes.id, id)).get();
     await clearDependentExplicitGroupSnapshotsBySourceRouteIds([id]);
     await db.delete(schema.tokenRoutes).where(eq(schema.tokenRoutes.id, id)).run();
-    if (
-      existingRoute
-      && !isExplicitGroupRoute(existingRoute)
-      && isExactModelPattern(existingRoute.modelPattern)
-    ) {
-      await rebuildAllPatternRouteChannels({
-        excludeExactModelPatterns: [existingRoute.modelPattern],
-      });
-    }
+    await syncPatternRouteChannelsAfterAffectedRouteChanges({
+      removedRoutes: existingRoute ? [{
+        modelPattern: existingRoute.modelPattern,
+        routeMode: existingRoute.routeMode,
+      }] : [],
+    });
     invalidateTokenRouterCache();
     return { success: true };
   });
@@ -1217,7 +1187,9 @@ export async function tokensRoutes(app: FastifyInstance) {
 
     await clearRouteDecisionSnapshots(ids);
     await clearDependentExplicitGroupSnapshotsBySourceRouteIds(ids);
-    await rebuildPatternRouteChannelsAfterExactSourceRouteChange(ids);
+    await syncPatternRouteChannelsAfterAffectedRouteChanges({
+      affectedRouteIds: ids,
+    });
     invalidateTokenRouterCache();
 
     return { success: true, updatedCount: Number(updateResult?.changes || 0) };
@@ -1281,9 +1253,9 @@ export async function tokensRoutes(app: FastifyInstance) {
         message: error instanceof Error ? error.message : '创建通道失败',
       });
     }
-    if (isExactModelPattern(route.modelPattern)) {
-      await rebuildAllPatternRouteChannels();
-    }
+    await syncPatternRouteChannelsAfterAffectedRouteChanges({
+      affectedRouteIds: [routeId],
+    });
     return created;
   });
 
@@ -1303,7 +1275,9 @@ export async function tokensRoutes(app: FastifyInstance) {
       }
       throw error;
     }
-    await rebuildPatternRouteChannelsAfterExactSourceRouteChange(parsed.updates.map((update) => update.id));
+    await syncPatternRouteChannelsAfterAffectedRouteChanges({
+      affectedRouteIds: updatedChannels.map((channel) => channel.routeId),
+    });
     return { success: true, channels: updatedChannels };
   });
 
@@ -1356,7 +1330,9 @@ export async function tokensRoutes(app: FastifyInstance) {
     await db.update(schema.routeChannels).set(updates).where(eq(schema.routeChannels.id, channelId)).run();
     await clearRouteDecisionSnapshot(channel.routeId);
     await clearDependentExplicitGroupSnapshotsBySourceRouteIds([channel.routeId]);
-    await rebuildPatternRouteChannelsAfterExactSourceRouteChange([channel.routeId]);
+    await syncPatternRouteChannelsAfterAffectedRouteChanges({
+      affectedRouteIds: [channel.routeId],
+    });
     invalidateTokenRouterCache();
     return await db.select().from(schema.routeChannels).where(eq(schema.routeChannels.id, channelId)).get();
   });
@@ -1369,7 +1345,9 @@ export async function tokensRoutes(app: FastifyInstance) {
     if (channel) {
       await clearRouteDecisionSnapshot(channel.routeId);
       await clearDependentExplicitGroupSnapshotsBySourceRouteIds([channel.routeId]);
-      await rebuildPatternRouteChannelsAfterExactSourceRouteChange([channel.routeId]);
+      await syncPatternRouteChannelsAfterAffectedRouteChanges({
+        affectedRouteIds: [channel.routeId],
+      });
     }
     invalidateTokenRouterCache();
     return { success: true };

--- a/src/server/services/modelService.siteDisable.test.ts
+++ b/src/server/services/modelService.siteDisable.test.ts
@@ -32,6 +32,7 @@ describe('rebuildTokenRoutesFromAvailability with site disabled models', () => {
         await db.delete(schema.tokenModelAvailability).run();
         await db.delete(schema.modelAvailability).run();
         await db.delete(schema.siteDisabledModels).run();
+        await db.delete(schema.settings).run();
         await db.delete(schema.accountTokens).run();
         await db.delete(schema.accounts).run();
         await db.delete(schema.sites).run();
@@ -173,5 +174,96 @@ describe('rebuildTokenRoutesFromAvailability with site disabled models', () => {
             .where(eq(schema.tokenRoutes.modelPattern, 'gpt-5'))
             .get();
         expect(route).toBeDefined();
+    });
+
+    it('does not repopulate a pattern group with a model filtered from the rebuild', async () => {
+        const disabledSite = await db.insert(schema.sites).values({
+            name: 'filtered-pattern-disabled-site',
+            url: 'https://filtered-pattern-disabled-site.example.com',
+            platform: 'new-api',
+        }).returning().get();
+        const allowedSite = await db.insert(schema.sites).values({
+            name: 'filtered-pattern-allowed-site',
+            url: 'https://filtered-pattern-allowed-site.example.com',
+            platform: 'new-api',
+        }).returning().get();
+        const disabledAccount = await db.insert(schema.accounts).values({
+            siteId: disabledSite.id,
+            username: 'filtered-pattern-disabled-user',
+            accessToken: 'filtered-pattern-access',
+            status: 'active',
+        }).returning().get();
+        const allowedAccount = await db.insert(schema.accounts).values({
+            siteId: allowedSite.id,
+            username: 'filtered-pattern-allowed-user',
+            accessToken: 'filtered-pattern-allowed-access',
+            status: 'active',
+        }).returning().get();
+        const disabledToken = await db.insert(schema.accountTokens).values({
+            accountId: disabledAccount.id,
+            name: 'default',
+            token: 'sk-filtered-pattern',
+            source: 'manual',
+            enabled: true,
+            isDefault: true,
+        }).returning().get();
+        const allowedToken = await db.insert(schema.accountTokens).values({
+            accountId: allowedAccount.id,
+            name: 'default',
+            token: 'sk-filtered-pattern-allowed',
+            source: 'manual',
+            enabled: true,
+            isDefault: true,
+        }).returning().get();
+        await db.insert(schema.tokenModelAvailability).values({
+            tokenId: disabledToken.id,
+            modelName: 'gpt-filtered',
+            available: true,
+        }).run();
+        await db.insert(schema.tokenModelAvailability).values({
+            tokenId: allowedToken.id,
+            modelName: 'gpt-filtered',
+            available: true,
+        }).run();
+        const exactRoute = await db.insert(schema.tokenRoutes).values({
+            modelPattern: 'gpt-filtered',
+            enabled: true,
+        }).returning().get();
+        const patternRoute = await db.insert(schema.tokenRoutes).values({
+            modelPattern: '*',
+            displayName: 'all-models',
+            enabled: true,
+        }).returning().get();
+        await db.insert(schema.routeChannels).values([
+            {
+            routeId: exactRoute.id,
+            accountId: disabledAccount.id,
+            tokenId: disabledToken.id,
+            sourceModel: 'gpt-filtered',
+                enabled: true,
+                manualOverride: false,
+            },
+            {
+            routeId: patternRoute.id,
+            accountId: disabledAccount.id,
+            tokenId: disabledToken.id,
+                sourceModel: 'gpt-filtered',
+                enabled: true,
+                manualOverride: false,
+            },
+        ]).run();
+        await db.insert(schema.siteDisabledModels).values({
+            siteId: disabledSite.id,
+            modelName: 'gpt-filtered',
+        }).run();
+
+        const rebuild = await rebuildTokenRoutesFromAvailability();
+        expect(rebuild.removedChannels).toBeGreaterThan(0);
+        const patternChannels = await db.select().from(schema.routeChannels)
+            .where(eq(schema.routeChannels.routeId, patternRoute.id))
+            .all();
+        expect(patternChannels).toHaveLength(1);
+        expect(patternChannels[0]?.accountId).toBe(allowedAccount.id);
+        expect(patternChannels[0]?.tokenId).toBe(allowedToken.id);
     });
 });

--- a/src/server/services/modelService.test.ts
+++ b/src/server/services/modelService.test.ts
@@ -332,4 +332,125 @@ describe('rebuildTokenRoutesFromAvailability', () => {
     const wildcardRouteAfter = await db.select().from(schema.tokenRoutes).where(eq(schema.tokenRoutes.id, wildcardRoute.id)).get();
     expect(wildcardRouteAfter).toBeDefined();
   });
+
+  it('removes stale pattern-group channels when automatic rebuild deletes exact routes', async () => {
+    const site = await db.insert(schema.sites).values({
+      name: 'site-stale-pattern',
+      url: 'https://site-stale-pattern.example.com',
+      platform: 'new-api',
+    }).returning().get();
+
+    const account = await db.insert(schema.accounts).values({
+      siteId: site.id,
+      username: 'user-stale-pattern',
+      accessToken: 'access-stale-pattern',
+      status: 'active',
+    }).returning().get();
+
+    const token = await db.insert(schema.accountTokens).values({
+      accountId: account.id,
+      name: 'default',
+      token: 'sk-stale-pattern',
+      source: 'manual',
+      enabled: true,
+      isDefault: true,
+    }).returning().get();
+
+    await db.insert(schema.tokenModelAvailability).values({
+      tokenId: token.id,
+      modelName: 'gpt-5-current',
+      available: true,
+    }).run();
+
+    const staleRoute = await db.insert(schema.tokenRoutes).values({
+      modelPattern: 'gpt-5-old',
+      enabled: true,
+    }).returning().get();
+    const patternRoute = await db.insert(schema.tokenRoutes).values({
+      modelPattern: 're:^gpt-5.*$',
+      displayName: 'gpt-5-group',
+      enabled: true,
+    }).returning().get();
+
+    await db.insert(schema.routeChannels).values([
+      {
+        routeId: staleRoute.id,
+        accountId: account.id,
+        tokenId: token.id,
+        sourceModel: 'gpt-5-old',
+        priority: 0,
+        weight: 10,
+        enabled: true,
+        manualOverride: false,
+      },
+      {
+        routeId: patternRoute.id,
+        accountId: account.id,
+        tokenId: token.id,
+        sourceModel: 'gpt-5-old',
+        priority: 0,
+        weight: 10,
+        enabled: true,
+        manualOverride: false,
+      },
+    ]).run();
+
+    const rebuild = await rebuildTokenRoutesFromAvailability();
+
+    expect(rebuild.removedRoutes).toBe(1);
+    expect(rebuild.patternRouteRemovedChannels).toBeGreaterThan(0);
+
+    const patternChannels = await db.select().from(schema.routeChannels)
+      .where(eq(schema.routeChannels.routeId, patternRoute.id))
+      .all();
+    expect(patternChannels.map((channel) => channel.sourceModel)).toEqual(['gpt-5-current']);
+  });
+
+  it('adds matching pattern-group channels when automatic rebuild creates exact routes', async () => {
+    const site = await db.insert(schema.sites).values({
+      name: 'site-new-pattern',
+      url: 'https://site-new-pattern.example.com',
+      platform: 'new-api',
+    }).returning().get();
+
+    const account = await db.insert(schema.accounts).values({
+      siteId: site.id,
+      username: 'user-new-pattern',
+      accessToken: 'access-new-pattern',
+      status: 'active',
+    }).returning().get();
+
+    const token = await db.insert(schema.accountTokens).values({
+      accountId: account.id,
+      name: 'default',
+      token: 'sk-new-pattern',
+      source: 'manual',
+      enabled: true,
+      isDefault: true,
+    }).returning().get();
+
+    await db.insert(schema.tokenModelAvailability).values({
+      tokenId: token.id,
+      modelName: 'gpt-5-new',
+      available: true,
+    }).run();
+
+    const patternRoute = await db.insert(schema.tokenRoutes).values({
+      modelPattern: 're:^gpt-5.*$',
+      displayName: 'gpt-5-group',
+      enabled: true,
+    }).returning().get();
+
+    const rebuild = await rebuildTokenRoutesFromAvailability();
+
+    expect(rebuild.createdRoutes).toBe(1);
+    expect(rebuild.patternRouteCreatedChannels).toBe(1);
+
+    const patternChannels = await db.select().from(schema.routeChannels)
+      .where(eq(schema.routeChannels.routeId, patternRoute.id))
+      .all();
+    expect(patternChannels).toHaveLength(1);
+    expect(patternChannels[0]?.sourceModel).toBe('gpt-5-new');
+    expect(patternChannels[0]?.manualOverride).toBe(false);
+  });
 });

--- a/src/server/services/modelService.test.ts
+++ b/src/server/services/modelService.test.ts
@@ -29,8 +29,10 @@ describe('rebuildTokenRoutesFromAvailability', () => {
   beforeEach(async () => {
     await db.delete(schema.routeChannels).run();
     await db.delete(schema.tokenRoutes).run();
+    await db.delete(schema.settings).run();
     await db.delete(schema.tokenModelAvailability).run();
     await db.delete(schema.modelAvailability).run();
+    await db.delete(schema.siteDisabledModels).run();
     await db.delete(schema.accountTokens).run();
     await db.delete(schema.accounts).run();
     await db.delete(schema.sites).run();
@@ -452,5 +454,49 @@ describe('rebuildTokenRoutesFromAvailability', () => {
     expect(patternChannels).toHaveLength(1);
     expect(patternChannels[0]?.sourceModel).toBe('gpt-5-new');
     expect(patternChannels[0]?.manualOverride).toBe(false);
+  });
+
+  it('force-rebuilds pattern groups when a manual rebuild finds stable exact routes', async () => {
+    const site = await db.insert(schema.sites).values({
+      name: 'site-manual-pattern-refresh',
+      url: 'https://site-manual-pattern-refresh.example.com',
+      platform: 'new-api',
+    }).returning().get();
+    const account = await db.insert(schema.accounts).values({
+      siteId: site.id,
+      username: 'user-manual-pattern-refresh',
+      accessToken: 'access-manual-pattern-refresh',
+      status: 'active',
+    }).returning().get();
+    const token = await db.insert(schema.accountTokens).values({
+      accountId: account.id,
+      name: 'default',
+      token: 'sk-manual-pattern-refresh',
+      source: 'manual',
+      enabled: true,
+      isDefault: true,
+    }).returning().get();
+    await db.insert(schema.tokenModelAvailability).values({
+      tokenId: token.id,
+      modelName: 'gpt-5-stable',
+      available: true,
+    }).run();
+    const patternRoute = await db.insert(schema.tokenRoutes).values({
+      modelPattern: 're:^gpt-5.*$',
+      displayName: 'gpt-5-group',
+      enabled: true,
+    }).returning().get();
+
+    await rebuildTokenRoutesFromAvailability();
+    await db.delete(schema.routeChannels)
+      .where(eq(schema.routeChannels.routeId, patternRoute.id))
+      .run();
+
+    const rebuild = await rebuildTokenRoutesFromAvailability({ rebuildPatternRoutes: true });
+    expect(rebuild.rebuiltPatternRoutes).toBe(1);
+    const channels = await db.select().from(schema.routeChannels)
+      .where(eq(schema.routeChannels.routeId, patternRoute.id))
+      .all();
+    expect(channels.map((channel) => channel.sourceModel)).toEqual(['gpt-5-stable']);
   });
 });

--- a/src/server/services/modelService.ts
+++ b/src/server/services/modelService.ts
@@ -22,6 +22,7 @@ import { getBlockedBrandRules, isModelBlockedByBrand } from './brandMatcher.js';
 import { config } from '../config.js';
 import { setAccountRuntimeHealth } from './accountHealthService.js';
 import { clearAllRouteDecisionSnapshots } from './routeDecisionSnapshotStore.js';
+import { rebuildAllPatternRouteChannels } from './patternRouteChannelSyncService.js';
 import { withAccountProxyOverride } from './siteProxy.js';
 import { isCodexPlatform } from './oauth/codexAccount.js';
 import { buildStoredOauthStateFromAccount, getOauthInfoFromAccount } from './oauth/oauthAccount.js';
@@ -1534,7 +1535,19 @@ export async function rebuildTokenRoutesFromAvailability() {
     }
   }
 
-  if (createdRoutes > 0 || createdChannels > 0 || removedChannels > 0 || removedRoutes > 0) {
+  const exactRouteTopologyChanged = createdRoutes > 0 || createdChannels > 0 || removedChannels > 0 || removedRoutes > 0;
+  const patternRouteSync = exactRouteTopologyChanged
+    ? await rebuildAllPatternRouteChannels()
+    : {
+      rebuiltRoutes: 0,
+      routeIds: [],
+      removedChannels: 0,
+      createdChannels: 0,
+    };
+  createdChannels += patternRouteSync.createdChannels;
+  removedChannels += patternRouteSync.removedChannels;
+
+  if (exactRouteTopologyChanged || patternRouteSync.createdChannels > 0 || patternRouteSync.removedChannels > 0) {
     await clearAllRouteDecisionSnapshots();
   }
 
@@ -1546,6 +1559,9 @@ export async function rebuildTokenRoutesFromAvailability() {
     createdChannels,
     removedChannels,
     removedRoutes,
+    rebuiltPatternRoutes: patternRouteSync.rebuiltRoutes,
+    patternRouteCreatedChannels: patternRouteSync.createdChannels,
+    patternRouteRemovedChannels: patternRouteSync.removedChannels,
   };
 }
 

--- a/src/server/services/modelService.ts
+++ b/src/server/services/modelService.ts
@@ -18,12 +18,14 @@ import {
   resolvePlatformUserId,
   supportsDirectAccountRoutingConnection,
 } from './accountExtraConfig.js';
-import { invalidateTokenRouterCache } from './tokenRouter.js';
+import { invalidateTokenRouterCache, normalizeModelAlias } from './tokenRouter.js';
 import { getBlockedBrandRules, isModelBlockedByBrand } from './brandMatcher.js';
 import { config } from '../config.js';
 import { setAccountRuntimeHealth } from './accountHealthService.js';
 import { clearAllRouteDecisionSnapshots } from './routeDecisionSnapshotStore.js';
-import { rebuildAllPatternRouteChannels } from './patternRouteChannelSyncService.js';
+import {
+  syncPatternRouteChannelsAfterAffectedRouteChanges,
+} from './patternRouteChannelSyncService.js';
 import { withAccountProxyOverride } from './siteProxy.js';
 import { isCodexPlatform } from './oauth/codexAccount.js';
 import { buildStoredOauthStateFromAccount, getOauthInfoFromAccount } from './oauth/oauthAccount.js';
@@ -47,6 +49,11 @@ import { probeRuntimeModel, type RuntimeModelProbeStatus } from './runtimeModelP
 const API_TOKEN_DISCOVERY_TIMEOUT_MS = 8_000;
 const MODEL_DISCOVERY_TIMEOUT_MS = 12_000;
 const MODEL_REFRESH_BATCH_SIZE = 3;
+
+export type RebuildTokenRoutesOptions = {
+  /** Rebuild every enabled pattern group even when exact-route topology is unchanged. */
+  rebuildPatternRoutes?: boolean;
+};
 const GEMINI_CLI_STATIC_MODELS = [
   'gemini-2.5-pro',
   'gemini-2.5-flash',
@@ -1382,7 +1389,9 @@ async function refreshModelsForAllActiveAccounts(): Promise<ModelRefreshResult[]
   return results;
 }
 
-export async function rebuildTokenRoutesFromAvailability() {
+export async function rebuildTokenRoutesFromAvailability(
+  options: RebuildTokenRoutesOptions = {},
+) {
   const tokenRows = await db.select().from(schema.tokenModelAvailability)
     .innerJoin(schema.accountTokens, eq(schema.tokenModelAvailability.tokenId, schema.accountTokens.id))
     .innerJoin(schema.accounts, eq(schema.accountTokens.accountId, schema.accounts.id))
@@ -1521,6 +1530,12 @@ export async function rebuildTokenRoutesFromAvailability() {
   let createdChannels = 0;
   let removedChannels = 0;
   let removedRoutes = 0;
+  const affectedExactRouteIds = new Set<number>();
+  const removedExactRouteSnapshots: Array<{
+    modelPattern: string;
+    routeMode: string | null;
+    enabled: boolean;
+  }> = [];
 
   for (const [modelName, candidateMap] of modelCandidates.entries()) {
     let route = routes.find((r) => (r.routeMode || 'pattern') !== 'explicit_group' && r.modelPattern === modelName);
@@ -1536,6 +1551,7 @@ export async function rebuildTokenRoutesFromAvailability() {
       if (!route) continue;
       routes.push(route);
       createdRoutes++;
+      affectedExactRouteIds.add(route.id);
     }
 
     const routeChannels = channels.filter((channel) => channel.routeId === route.id);
@@ -1561,6 +1577,7 @@ export async function rebuildTokenRoutesFromAvailability() {
       if (!created) continue;
       channels.push(created);
       createdChannels++;
+      affectedExactRouteIds.add(route.id);
       desiredKeys.add(candidateKey);
     }
 
@@ -1577,6 +1594,7 @@ export async function rebuildTokenRoutesFromAvailability() {
             .set({ tokenId: preferred.id })
             .where(eq(schema.routeChannels.id, channel.id))
             .run();
+          affectedExactRouteIds.add(route.id);
           continue;
         }
       }
@@ -1584,6 +1602,7 @@ export async function rebuildTokenRoutesFromAvailability() {
       if (!channel.manualOverride) {
         await db.delete(schema.routeChannels).where(eq(schema.routeChannels.id, channel.id)).run();
         removedChannels++;
+        affectedExactRouteIds.add(route.id);
       }
     }
   }
@@ -1606,12 +1625,29 @@ export async function rebuildTokenRoutesFromAvailability() {
     const deleted = (await db.delete(schema.tokenRoutes).where(eq(schema.tokenRoutes.id, route.id)).run()).changes;
     if (deleted > 0) {
       removedRoutes += deleted;
+      if ((route.routeMode || 'pattern') !== 'explicit_group') {
+        removedExactRouteSnapshots.push({
+          modelPattern,
+          routeMode: route.routeMode,
+          enabled: !!route.enabled,
+        });
+      }
     }
   }
 
   const exactRouteTopologyChanged = createdRoutes > 0 || createdChannels > 0 || removedChannels > 0 || removedRoutes > 0;
-  const patternRouteSync = exactRouteTopologyChanged
-    ? await rebuildAllPatternRouteChannels()
+  const patternRouteSync = exactRouteTopologyChanged || options.rebuildPatternRoutes
+    ? await syncPatternRouteChannelsAfterAffectedRouteChanges({
+      affectedRouteIds: [...affectedExactRouteIds],
+      removedRoutes: removedExactRouteSnapshots,
+      allowedModelNames: [...modelCandidates.keys()],
+      allowedAvailabilityCandidateKeys: Array.from(modelCandidates.entries()).flatMap(([modelName, candidates]) => (
+        Array.from(candidates.values())
+          .filter((candidate) => candidate.tokenId != null)
+          .map((candidate) => `${candidate.accountId}:${candidate.tokenId}:${normalizeModelAlias(modelName)}`)
+      )),
+      rebuildAllPatternRoutes: options.rebuildPatternRoutes === true,
+    })
     : {
       rebuiltRoutes: 0,
       routeIds: [],
@@ -1639,20 +1675,20 @@ export async function rebuildTokenRoutesFromAvailability() {
   };
 }
 
-async function runRefreshModelsAndRebuildRoutes() {
+async function runRefreshModelsAndRebuildRoutes(options: RebuildTokenRoutesOptions = {}) {
   const refresh = await refreshModelsForAllActiveAccounts();
-  const rebuild = await rebuildTokenRoutesFromAvailability();
+  const rebuild = await rebuildTokenRoutesFromAvailability(options);
   return { refresh, rebuild };
 }
 
-export async function refreshModelsAndRebuildRoutes() {
+export async function refreshModelsAndRebuildRoutes(options: RebuildTokenRoutesOptions = {}) {
   if (inFlightRefreshModelsAndRebuildRoutes) {
     return inFlightRefreshModelsAndRebuildRoutes;
   }
 
   inFlightRefreshModelsAndRebuildRoutes = (async () => {
     try {
-      return await runRefreshModelsAndRebuildRoutes();
+      return await runRefreshModelsAndRebuildRoutes(options);
     } finally {
       inFlightRefreshModelsAndRebuildRoutes = null;
     }

--- a/src/server/services/modelService.ts
+++ b/src/server/services/modelService.ts
@@ -23,6 +23,7 @@ import { getBlockedBrandRules, isModelBlockedByBrand } from './brandMatcher.js';
 import { config } from '../config.js';
 import { setAccountRuntimeHealth } from './accountHealthService.js';
 import { clearAllRouteDecisionSnapshots } from './routeDecisionSnapshotStore.js';
+import { rebuildAllPatternRouteChannels } from './patternRouteChannelSyncService.js';
 import { withAccountProxyOverride } from './siteProxy.js';
 import { isCodexPlatform } from './oauth/codexAccount.js';
 import { buildStoredOauthStateFromAccount, getOauthInfoFromAccount } from './oauth/oauthAccount.js';
@@ -1608,7 +1609,19 @@ export async function rebuildTokenRoutesFromAvailability() {
     }
   }
 
-  if (createdRoutes > 0 || createdChannels > 0 || removedChannels > 0 || removedRoutes > 0) {
+  const exactRouteTopologyChanged = createdRoutes > 0 || createdChannels > 0 || removedChannels > 0 || removedRoutes > 0;
+  const patternRouteSync = exactRouteTopologyChanged
+    ? await rebuildAllPatternRouteChannels()
+    : {
+      rebuiltRoutes: 0,
+      routeIds: [],
+      removedChannels: 0,
+      createdChannels: 0,
+    };
+  createdChannels += patternRouteSync.createdChannels;
+  removedChannels += patternRouteSync.removedChannels;
+
+  if (exactRouteTopologyChanged || patternRouteSync.createdChannels > 0 || patternRouteSync.removedChannels > 0) {
     await clearAllRouteDecisionSnapshots();
   }
 
@@ -1620,6 +1633,9 @@ export async function rebuildTokenRoutesFromAvailability() {
     createdChannels,
     removedChannels,
     removedRoutes,
+    rebuiltPatternRoutes: patternRouteSync.rebuiltRoutes,
+    patternRouteCreatedChannels: patternRouteSync.createdChannels,
+    patternRouteRemovedChannels: patternRouteSync.removedChannels,
   };
 }
 

--- a/src/server/services/patternRouteChannelSyncService.affected-routes.test.ts
+++ b/src/server/services/patternRouteChannelSyncService.affected-routes.test.ts
@@ -1,0 +1,200 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { eq } from 'drizzle-orm';
+
+type DbModule = typeof import('../db/index.js');
+type PatternRouteChannelSyncServiceModule = typeof import('./patternRouteChannelSyncService.js');
+
+describe('syncPatternRouteChannelsAfterAffectedRouteChanges', () => {
+  let db: DbModule['db'];
+  let schema: DbModule['schema'];
+  let syncPatternRouteChannelsAfterAffectedRouteChanges: PatternRouteChannelSyncServiceModule['syncPatternRouteChannelsAfterAffectedRouteChanges'];
+  let dataDir = '';
+  let seedId = 0;
+
+  const nextId = () => {
+    seedId += 1;
+    return seedId;
+  };
+
+  const seedAccountWithToken = async (modelName: string) => {
+    const id = nextId();
+    const site = await db.insert(schema.sites).values({
+      name: `site-${id}`,
+      url: `https://example.com/${id}`,
+      platform: 'new-api',
+      status: 'active',
+    }).returning().get();
+
+    const account = await db.insert(schema.accounts).values({
+      siteId: site.id,
+      username: `user-${id}`,
+      accessToken: `access-${id}`,
+      status: 'active',
+    }).returning().get();
+
+    const token = await db.insert(schema.accountTokens).values({
+      accountId: account.id,
+      name: `token-${id}`,
+      token: `sk-token-${id}`,
+      enabled: true,
+      isDefault: true,
+    }).returning().get();
+
+    await db.insert(schema.tokenModelAvailability).values({
+      tokenId: token.id,
+      modelName,
+      available: true,
+    }).run();
+
+    return { account, token };
+  };
+
+  beforeAll(async () => {
+    dataDir = mkdtempSync(join(tmpdir(), 'metapi-pattern-sync-affected-routes-'));
+    process.env.DATA_DIR = dataDir;
+
+    await import('../db/migrate.js');
+    const dbModule = await import('../db/index.js');
+    const serviceModule = await import('./patternRouteChannelSyncService.js');
+
+    db = dbModule.db;
+    schema = dbModule.schema;
+    syncPatternRouteChannelsAfterAffectedRouteChanges = serviceModule.syncPatternRouteChannelsAfterAffectedRouteChanges;
+  });
+
+  beforeEach(async () => {
+    await db.delete(schema.routeChannels).run();
+    await db.delete(schema.routeGroupSources).run();
+    await db.delete(schema.tokenRoutes).run();
+    await db.delete(schema.tokenModelAvailability).run();
+    await db.delete(schema.accountTokens).run();
+    await db.delete(schema.accounts).run();
+    await db.delete(schema.sites).run();
+    seedId = 0;
+  });
+
+  afterAll(() => {
+    delete process.env.DATA_DIR;
+  });
+
+  it('does not rebuild pattern routes for wildcard or explicit-group affected routes', async () => {
+    const wildcardRoute = await db.insert(schema.tokenRoutes).values({
+      modelPattern: 're:^gpt-5.*$',
+      enabled: true,
+    }).returning().get();
+    const explicitGroupRoute = await db.insert(schema.tokenRoutes).values({
+      modelPattern: 'gpt-5-group',
+      displayName: 'gpt-5-group',
+      routeMode: 'explicit_group',
+      enabled: true,
+    }).returning().get();
+
+    const result = await syncPatternRouteChannelsAfterAffectedRouteChanges({
+      affectedRouteIds: [wildcardRoute.id, explicitGroupRoute.id],
+      removedRoutes: [{
+        modelPattern: 'gpt-5-explicit',
+        routeMode: 'explicit_group',
+      }],
+    });
+
+    expect(result).toEqual({
+      rebuiltRoutes: 0,
+      routeIds: [],
+      removedChannels: 0,
+      createdChannels: 0,
+    });
+  });
+
+  it('rebuilds pattern route channels when an affected route id is an exact source route', async () => {
+    const seeded = await seedAccountWithToken('gpt-5-mini');
+    const exactRoute = await db.insert(schema.tokenRoutes).values({
+      modelPattern: 'gpt-5-mini',
+      enabled: true,
+    }).returning().get();
+    const patternRoute = await db.insert(schema.tokenRoutes).values({
+      modelPattern: 're:^gpt-5.*$',
+      enabled: true,
+    }).returning().get();
+
+    await db.insert(schema.routeChannels).values({
+      routeId: exactRoute.id,
+      accountId: seeded.account.id,
+      tokenId: seeded.token.id,
+      sourceModel: 'gpt-5-mini',
+      priority: 6,
+      weight: 4,
+      enabled: true,
+      manualOverride: true,
+    }).run();
+
+    const result = await syncPatternRouteChannelsAfterAffectedRouteChanges({
+      affectedRouteIds: [exactRoute.id],
+    });
+
+    expect(result.rebuiltRoutes).toBe(1);
+    expect(result.createdChannels).toBe(1);
+    expect(result.routeIds).toEqual([patternRoute.id]);
+
+    const patternChannels = await db.select().from(schema.routeChannels)
+      .where(eq(schema.routeChannels.routeId, patternRoute.id))
+      .all();
+    expect(patternChannels).toHaveLength(1);
+    expect(patternChannels[0]).toMatchObject({
+      accountId: seeded.account.id,
+      tokenId: seeded.token.id,
+      sourceModel: 'gpt-5-mini',
+      priority: 6,
+      weight: 4,
+      manualOverride: false,
+    });
+  });
+
+  it('uses removed exact route snapshots to clear stale pattern channels after deletion', async () => {
+    const seeded = await seedAccountWithToken('gpt-5-removed');
+    const exactRoute = await db.insert(schema.tokenRoutes).values({
+      modelPattern: 'gpt-5-removed',
+      enabled: true,
+    }).returning().get();
+    const patternRoute = await db.insert(schema.tokenRoutes).values({
+      modelPattern: 're:^gpt-5.*$',
+      enabled: true,
+    }).returning().get();
+
+    await db.insert(schema.routeChannels).values({
+      routeId: exactRoute.id,
+      accountId: seeded.account.id,
+      tokenId: seeded.token.id,
+      sourceModel: 'gpt-5-removed',
+      enabled: true,
+      manualOverride: false,
+    }).run();
+
+    await syncPatternRouteChannelsAfterAffectedRouteChanges({
+      affectedRouteIds: [exactRoute.id],
+    });
+    let patternChannels = await db.select().from(schema.routeChannels)
+      .where(eq(schema.routeChannels.routeId, patternRoute.id))
+      .all();
+    expect(patternChannels.map((channel) => channel.sourceModel)).toEqual(['gpt-5-removed']);
+
+    await db.delete(schema.tokenRoutes).where(eq(schema.tokenRoutes.id, exactRoute.id)).run();
+
+    const result = await syncPatternRouteChannelsAfterAffectedRouteChanges({
+      removedRoutes: [{
+        modelPattern: exactRoute.modelPattern,
+        routeMode: exactRoute.routeMode,
+      }],
+    });
+
+    expect(result.rebuiltRoutes).toBe(1);
+    expect(result.removedChannels).toBe(1);
+
+    patternChannels = await db.select().from(schema.routeChannels)
+      .where(eq(schema.routeChannels.routeId, patternRoute.id))
+      .all();
+    expect(patternChannels).toHaveLength(0);
+  });
+});

--- a/src/server/services/patternRouteChannelSyncService.affected-routes.test.ts
+++ b/src/server/services/patternRouteChannelSyncService.affected-routes.test.ts
@@ -186,6 +186,7 @@ describe('syncPatternRouteChannelsAfterAffectedRouteChanges', () => {
       removedRoutes: [{
         modelPattern: exactRoute.modelPattern,
         routeMode: exactRoute.routeMode,
+        enabled: true,
       }],
     });
 
@@ -196,5 +197,38 @@ describe('syncPatternRouteChannelsAfterAffectedRouteChanges', () => {
       .where(eq(schema.routeChannels.routeId, patternRoute.id))
       .all();
     expect(patternChannels).toHaveLength(0);
+  });
+
+  it('does not exclude availability models when a disabled exact route is removed', async () => {
+    const seeded = await seedAccountWithToken('gpt-5-disabled');
+    const exactRoute = await db.insert(schema.tokenRoutes).values({
+      modelPattern: 'gpt-5-disabled',
+      enabled: false,
+    }).returning().get();
+    const patternRoute = await db.insert(schema.tokenRoutes).values({
+      modelPattern: 're:^gpt-5.*$',
+      enabled: true,
+    }).returning().get();
+
+    await db.delete(schema.tokenRoutes).where(eq(schema.tokenRoutes.id, exactRoute.id)).run();
+
+    const result = await syncPatternRouteChannelsAfterAffectedRouteChanges({
+      removedRoutes: [{
+        modelPattern: exactRoute.modelPattern,
+        routeMode: exactRoute.routeMode,
+        enabled: false,
+      }],
+    });
+
+    expect(result.rebuiltRoutes).toBe(1);
+    const patternChannels = await db.select().from(schema.routeChannels)
+      .where(eq(schema.routeChannels.routeId, patternRoute.id))
+      .all();
+    expect(patternChannels).toHaveLength(1);
+    expect(patternChannels[0]).toMatchObject({
+      accountId: seeded.account.id,
+      tokenId: seeded.token.id,
+      sourceModel: 'gpt-5-disabled',
+    });
   });
 });

--- a/src/server/services/patternRouteChannelSyncService.affected-routes.test.ts
+++ b/src/server/services/patternRouteChannelSyncService.affected-routes.test.ts
@@ -11,6 +11,8 @@ describe('syncPatternRouteChannelsAfterAffectedRouteChanges', () => {
   let db: DbModule['db'];
   let schema: DbModule['schema'];
   let syncPatternRouteChannelsAfterAffectedRouteChanges: PatternRouteChannelSyncServiceModule['syncPatternRouteChannelsAfterAffectedRouteChanges'];
+  let TokenRouter: typeof import('./tokenRouter.js')['TokenRouter'];
+  let invalidateTokenRouterCache: typeof import('./tokenRouter.js')['invalidateTokenRouterCache'];
   let dataDir = '';
   let seedId = 0;
 
@@ -59,10 +61,13 @@ describe('syncPatternRouteChannelsAfterAffectedRouteChanges', () => {
     await import('../db/migrate.js');
     const dbModule = await import('../db/index.js');
     const serviceModule = await import('./patternRouteChannelSyncService.js');
+    const tokenRouterModule = await import('./tokenRouter.js');
 
     db = dbModule.db;
     schema = dbModule.schema;
     syncPatternRouteChannelsAfterAffectedRouteChanges = serviceModule.syncPatternRouteChannelsAfterAffectedRouteChanges;
+    TokenRouter = tokenRouterModule.TokenRouter;
+    invalidateTokenRouterCache = tokenRouterModule.invalidateTokenRouterCache;
   });
 
   beforeEach(async () => {
@@ -75,9 +80,11 @@ describe('syncPatternRouteChannelsAfterAffectedRouteChanges', () => {
     await db.delete(schema.accounts).run();
     await db.delete(schema.sites).run();
     seedId = 0;
+    invalidateTokenRouterCache();
   });
 
   afterAll(() => {
+    invalidateTokenRouterCache();
     delete process.env.DATA_DIR;
   });
 
@@ -341,5 +348,110 @@ describe('syncPatternRouteChannelsAfterAffectedRouteChanges', () => {
       tokenId: seeded.token.id,
       sourceModel: 'gpt-5-disabled',
     });
+  });
+
+  it('canonicalizes provider-qualified availability names when persisting exclusions', async () => {
+    const seeded = await seedAccountWithToken('openai/gpt-5');
+    const exactRoute = await db.insert(schema.tokenRoutes).values({
+      modelPattern: 'gpt-5',
+      enabled: true,
+    }).returning().get();
+    const patternRoute = await db.insert(schema.tokenRoutes).values({
+      modelPattern: '*',
+      enabled: true,
+    }).returning().get();
+
+    await db.insert(schema.routeChannels).values({
+      routeId: exactRoute.id,
+      accountId: seeded.account.id,
+      tokenId: seeded.token.id,
+      sourceModel: 'gpt-5',
+      enabled: true,
+      manualOverride: true,
+    }).run();
+    await syncPatternRouteChannelsAfterAffectedRouteChanges({
+      affectedRouteIds: [exactRoute.id],
+    });
+    await db.delete(schema.tokenRoutes).where(eq(schema.tokenRoutes.id, exactRoute.id)).run();
+
+    await syncPatternRouteChannelsAfterAffectedRouteChanges({
+      removedRoutes: [{
+        modelPattern: 'gpt-5',
+        routeMode: 'pattern',
+        enabled: true,
+      }],
+    });
+
+    const patternChannels = await db.select().from(schema.routeChannels)
+      .where(eq(schema.routeChannels.routeId, patternRoute.id))
+      .all();
+    expect(patternChannels).toHaveLength(0);
+  });
+
+  it('serializes concurrent deleted-model exclusion updates', async () => {
+    const first = await seedAccountWithToken('gpt-5-first');
+    const second = await seedAccountWithToken('gpt-5-second');
+    const firstRoute = await db.insert(schema.tokenRoutes).values({
+      modelPattern: 'gpt-5-first',
+      enabled: true,
+    }).returning().get();
+    const secondRoute = await db.insert(schema.tokenRoutes).values({
+      modelPattern: 'gpt-5-second',
+      enabled: true,
+    }).returning().get();
+    const patternRoute = await db.insert(schema.tokenRoutes).values({
+      modelPattern: '*',
+      enabled: true,
+    }).returning().get();
+
+    await db.delete(schema.tokenRoutes).where(eq(schema.tokenRoutes.id, firstRoute.id)).run();
+    await db.delete(schema.tokenRoutes).where(eq(schema.tokenRoutes.id, secondRoute.id)).run();
+
+    await Promise.all([
+      syncPatternRouteChannelsAfterAffectedRouteChanges({
+        removedRoutes: [{ modelPattern: 'gpt-5-first', routeMode: 'pattern', enabled: true }],
+      }),
+      syncPatternRouteChannelsAfterAffectedRouteChanges({
+        removedRoutes: [{ modelPattern: 'gpt-5-second', routeMode: 'pattern', enabled: true }],
+      }),
+    ]);
+
+    const exclusion = await db.select({ value: schema.settings.value })
+      .from(schema.settings)
+      .where(eq(schema.settings.key, 'token_route_deleted_model_exclusions_v1'))
+      .get();
+    const exclusions = JSON.parse(exclusion?.value || '[]') as string[];
+    expect(exclusions).toEqual(expect.arrayContaining(['gpt-5-first', 'gpt-5-second']));
+    const patternChannels = await db.select().from(schema.routeChannels)
+      .where(eq(schema.routeChannels.routeId, patternRoute.id))
+      .all();
+    expect(patternChannels).toHaveLength(0);
+  });
+
+  it('invalidates router caches after replacing automatic pattern channels', async () => {
+    const seeded = await seedAccountWithToken('gpt-5-cache-old');
+    const patternRoute = await db.insert(schema.tokenRoutes).values({
+      modelPattern: '*',
+      enabled: true,
+    }).returning().get();
+
+    await syncPatternRouteChannelsAfterAffectedRouteChanges({
+      rebuildAllPatternRoutes: true,
+      allowedModelNames: ['gpt-5-cache-old'],
+    });
+    const router = new TokenRouter();
+    expect((await router.selectChannel('gpt-5-cache-old'))?.channel.routeId).toBe(patternRoute.id);
+
+    await db.update(schema.tokenModelAvailability)
+      .set({ modelName: 'gpt-5-cache-new' })
+      .where(eq(schema.tokenModelAvailability.tokenId, seeded.token.id))
+      .run();
+    await syncPatternRouteChannelsAfterAffectedRouteChanges({
+      rebuildAllPatternRoutes: true,
+      allowedModelNames: ['gpt-5-cache-new'],
+    });
+
+    expect(await router.selectChannel('gpt-5-cache-old')).toBeNull();
+    expect((await router.selectChannel('gpt-5-cache-new'))?.channel.routeId).toBe(patternRoute.id);
   });
 });

--- a/src/server/services/patternRouteChannelSyncService.affected-routes.test.ts
+++ b/src/server/services/patternRouteChannelSyncService.affected-routes.test.ts
@@ -68,6 +68,7 @@ describe('syncPatternRouteChannelsAfterAffectedRouteChanges', () => {
   beforeEach(async () => {
     await db.delete(schema.routeChannels).run();
     await db.delete(schema.routeGroupSources).run();
+    await db.delete(schema.settings).run();
     await db.delete(schema.tokenRoutes).run();
     await db.delete(schema.tokenModelAvailability).run();
     await db.delete(schema.accountTokens).run();
@@ -152,6 +153,58 @@ describe('syncPatternRouteChannelsAfterAffectedRouteChanges', () => {
     });
   });
 
+  it('rebuilds only pattern groups matching the affected exact model', async () => {
+    const gpt = await seedAccountWithToken('gpt-5-mini');
+    const claude = await seedAccountWithToken('claude-3-7-sonnet');
+    const exactRoute = await db.insert(schema.tokenRoutes).values({
+      modelPattern: 'gpt-5-mini',
+      enabled: true,
+    }).returning().get();
+    const gptPatternRoute = await db.insert(schema.tokenRoutes).values({
+      modelPattern: 're:^gpt-5.*$',
+      enabled: true,
+    }).returning().get();
+    const claudePatternRoute = await db.insert(schema.tokenRoutes).values({
+      modelPattern: 're:^claude-3.*$',
+      enabled: true,
+    }).returning().get();
+
+    await db.insert(schema.routeChannels).values([
+      {
+        routeId: exactRoute.id,
+        accountId: gpt.account.id,
+        tokenId: gpt.token.id,
+        sourceModel: 'gpt-5-mini',
+        enabled: true,
+        manualOverride: true,
+      },
+      {
+        routeId: claudePatternRoute.id,
+        accountId: claude.account.id,
+        tokenId: claude.token.id,
+        sourceModel: 'claude-3-7-sonnet',
+        enabled: true,
+        manualOverride: false,
+      },
+    ]).run();
+
+    const result = await syncPatternRouteChannelsAfterAffectedRouteChanges({
+      affectedRouteIds: [exactRoute.id],
+    });
+
+    expect(result.routeIds).toEqual([gptPatternRoute.id]);
+    expect(result.rebuiltRoutes).toBe(1);
+
+    const claudeChannels = await db.select().from(schema.routeChannels)
+      .where(eq(schema.routeChannels.routeId, claudePatternRoute.id))
+      .all();
+    expect(claudeChannels).toHaveLength(1);
+    expect(claudeChannels[0]).toMatchObject({
+      sourceModel: 'claude-3-7-sonnet',
+      manualOverride: false,
+    });
+  });
+
   it('uses removed exact route snapshots to clear stale pattern channels after deletion', async () => {
     const seeded = await seedAccountWithToken('gpt-5-removed');
     const exactRoute = await db.insert(schema.tokenRoutes).values({
@@ -197,6 +250,64 @@ describe('syncPatternRouteChannelsAfterAffectedRouteChanges', () => {
       .where(eq(schema.routeChannels.routeId, patternRoute.id))
       .all();
     expect(patternChannels).toHaveLength(0);
+  });
+
+  it('keeps deleted exact models excluded during later affected-route rebuilds', async () => {
+    const removed = await seedAccountWithToken('gpt-5-removed');
+    const replacement = await seedAccountWithToken('gpt-5-replacement');
+    const exactRemovedRoute = await db.insert(schema.tokenRoutes).values({
+      modelPattern: 'gpt-5-removed',
+      enabled: true,
+    }).returning().get();
+    const exactReplacementRoute = await db.insert(schema.tokenRoutes).values({
+      modelPattern: 'gpt-5-replacement',
+      enabled: true,
+    }).returning().get();
+    const patternRoute = await db.insert(schema.tokenRoutes).values({
+      modelPattern: 're:^gpt-5.*$',
+      enabled: true,
+    }).returning().get();
+
+    await db.insert(schema.routeChannels).values([
+      {
+        routeId: exactRemovedRoute.id,
+        accountId: removed.account.id,
+        tokenId: removed.token.id,
+        sourceModel: 'gpt-5-removed',
+        enabled: true,
+        manualOverride: true,
+      },
+      {
+        routeId: exactReplacementRoute.id,
+        accountId: replacement.account.id,
+        tokenId: replacement.token.id,
+        sourceModel: 'gpt-5-replacement',
+        enabled: true,
+        manualOverride: true,
+      },
+    ]).run();
+
+    await syncPatternRouteChannelsAfterAffectedRouteChanges({
+      affectedRouteIds: [exactRemovedRoute.id],
+    });
+    await db.delete(schema.tokenRoutes).where(eq(schema.tokenRoutes.id, exactRemovedRoute.id)).run();
+    await syncPatternRouteChannelsAfterAffectedRouteChanges({
+      removedRoutes: [{
+        modelPattern: 'gpt-5-removed',
+        routeMode: 'pattern',
+        enabled: true,
+      }],
+    });
+
+    const laterResult = await syncPatternRouteChannelsAfterAffectedRouteChanges({
+      affectedRouteIds: [exactReplacementRoute.id],
+    });
+    expect(laterResult.routeIds).toEqual([patternRoute.id]);
+
+    const patternChannels = await db.select().from(schema.routeChannels)
+      .where(eq(schema.routeChannels.routeId, patternRoute.id))
+      .all();
+    expect(patternChannels.map((channel) => channel.sourceModel)).toEqual(['gpt-5-replacement']);
   });
 
   it('does not exclude availability models when a disabled exact route is removed', async () => {

--- a/src/server/services/patternRouteChannelSyncService.ts
+++ b/src/server/services/patternRouteChannelSyncService.ts
@@ -29,6 +29,21 @@ type RebuildPatternRouteOptions = {
   excludeExactModelPatterns?: string[];
 };
 
+type PatternRouteChannelAffectedRouteSnapshot = {
+  modelPattern: string;
+  routeMode?: string | null;
+};
+
+type SyncPatternRouteChannelsAfterAffectedRouteChangesInput = {
+  affectedRouteIds?: number[];
+  removedRoutes?: PatternRouteChannelAffectedRouteSnapshot[];
+};
+
+type RouteModeModelPattern = {
+  modelPattern: string;
+  routeMode?: string | null;
+};
+
 function isExactModelPattern(modelPattern: string): boolean {
   const normalized = modelPattern.trim();
   if (!normalized) return false;
@@ -36,9 +51,45 @@ function isExactModelPattern(modelPattern: string): boolean {
   return !/[\*\?]/.test(normalized);
 }
 
-function isPatternGroupRoute(route: Pick<typeof schema.tokenRoutes.$inferSelect, 'routeMode' | 'modelPattern'>): boolean {
+function isPatternGroupRoute(route: RouteModeModelPattern): boolean {
   return normalizeTokenRouteMode(route.routeMode) !== 'explicit_group'
     && !isExactModelPattern(route.modelPattern);
+}
+
+function isExactSourceRoute(route: RouteModeModelPattern): boolean {
+  return normalizeTokenRouteMode(route.routeMode) !== 'explicit_group'
+    && isExactModelPattern(route.modelPattern);
+}
+
+function normalizeAffectedRouteIds(routeIds: number[] | undefined): number[] {
+  const normalized: number[] = [];
+  for (const rawRouteId of routeIds || []) {
+    const routeId = Math.trunc(Number(rawRouteId));
+    if (!Number.isFinite(routeId) || routeId <= 0 || normalized.includes(routeId)) continue;
+    normalized.push(routeId);
+  }
+  return normalized;
+}
+
+function createEmptyPatternRouteChannelSyncResult(): PatternRouteChannelSyncResult {
+  return {
+    rebuiltRoutes: 0,
+    routeIds: [],
+    removedChannels: 0,
+    createdChannels: 0,
+  };
+}
+
+function collectRemovedExactModelPatterns(routes: PatternRouteChannelAffectedRouteSnapshot[] | undefined): string[] {
+  const normalized: string[] = [];
+  for (const route of routes || []) {
+    if (!isExactSourceRoute(route)) continue;
+    const modelPattern = route.modelPattern.trim();
+    const modelKey = normalizeModelKey(modelPattern);
+    if (!modelKey || normalized.some((item) => normalizeModelKey(item) === modelKey)) continue;
+    normalized.push(modelPattern);
+  }
+  return normalized;
 }
 
 function normalizeModelKey(modelName: string): string {
@@ -251,4 +302,35 @@ export async function rebuildAllPatternRouteChannels(
   }
 
   return result;
+}
+
+export async function syncPatternRouteChannelsAfterAffectedRouteChanges(
+  input: SyncPatternRouteChannelsAfterAffectedRouteChangesInput = {},
+): Promise<PatternRouteChannelSyncResult> {
+  const affectedRouteIds = normalizeAffectedRouteIds(input.affectedRouteIds);
+  const removedExactModelPatterns = collectRemovedExactModelPatterns(input.removedRoutes);
+  if (affectedRouteIds.length === 0 && removedExactModelPatterns.length === 0) {
+    return createEmptyPatternRouteChannelSyncResult();
+  }
+
+  let hasAffectedExactSourceRoute = false;
+  if (affectedRouteIds.length > 0) {
+    const routes = await db.select({
+      id: schema.tokenRoutes.id,
+      modelPattern: schema.tokenRoutes.modelPattern,
+      routeMode: schema.tokenRoutes.routeMode,
+    }).from(schema.tokenRoutes)
+      .where(inArray(schema.tokenRoutes.id, affectedRouteIds))
+      .all();
+
+    hasAffectedExactSourceRoute = routes.some(isExactSourceRoute);
+  }
+
+  if (!hasAffectedExactSourceRoute && removedExactModelPatterns.length === 0) {
+    return createEmptyPatternRouteChannelSyncResult();
+  }
+
+  return rebuildAllPatternRouteChannels({
+    excludeExactModelPatterns: removedExactModelPatterns,
+  });
 }

--- a/src/server/services/patternRouteChannelSyncService.ts
+++ b/src/server/services/patternRouteChannelSyncService.ts
@@ -11,6 +11,7 @@ import { normalizeTokenRouteMode } from '../../shared/tokenRouteContract.js';
 type PatternRouteChannelCandidate = {
   tokenId: number | null;
   accountId: number;
+  oauthRouteUnitId: number | null;
   sourceModel: string;
   priority: number;
   weight: number;
@@ -47,11 +48,15 @@ function normalizeModelKey(modelName: string): string {
 function buildChannelPairKey(input: {
   accountId: number;
   tokenId: number | null;
+  oauthRouteUnitId?: number | null;
   sourceModel: string | null;
 }): string {
-  const tokenId = typeof input.tokenId === 'number' && Number.isFinite(input.tokenId) ? input.tokenId : 0;
   const sourceModel = (input.sourceModel || '').trim().toLowerCase();
-  return `${input.accountId}::${tokenId}::${sourceModel}`;
+  if (typeof input.oauthRouteUnitId === 'number' && Number.isFinite(input.oauthRouteUnitId) && input.oauthRouteUnitId > 0) {
+    return `route-unit:${input.oauthRouteUnitId}::${sourceModel}`;
+  }
+  const tokenId = typeof input.tokenId === 'number' && Number.isFinite(input.tokenId) ? input.tokenId : 0;
+  return `account:${input.accountId}::${tokenId}::${sourceModel}`;
 }
 
 async function getPatternTokenCandidates(
@@ -83,6 +88,7 @@ async function getPatternTokenCandidates(
     candidates.push({
       tokenId: row.account_tokens.id,
       accountId: row.accounts.id,
+      oauthRouteUnitId: null,
       sourceModel: modelName,
       priority: 0,
       weight: 10,
@@ -129,6 +135,7 @@ async function getMatchedExactRouteChannelCandidates(
     candidates: channels.map((channel) => ({
       tokenId: channel.tokenId ?? null,
       accountId: channel.accountId,
+      oauthRouteUnitId: channel.oauthRouteUnitId ?? null,
       sourceModel: (channel.sourceModel || routeMap.get(channel.routeId)?.modelPattern || '').trim(),
       priority: channel.priority ?? 0,
       weight: channel.weight ?? 10,
@@ -161,6 +168,7 @@ export async function populateRouteChannelsByModelPattern(
   const existingPairs = new Set(existingChannels.map((channel) => buildChannelPairKey({
     accountId: channel.accountId,
     tokenId: channel.tokenId ?? null,
+    oauthRouteUnitId: channel.oauthRouteUnitId ?? null,
     sourceModel: channel.sourceModel,
   })));
 
@@ -172,6 +180,7 @@ export async function populateRouteChannelsByModelPattern(
       routeId,
       accountId: candidate.accountId,
       tokenId: candidate.tokenId,
+      oauthRouteUnitId: candidate.oauthRouteUnitId,
       sourceModel: candidate.sourceModel,
       priority: candidate.priority,
       weight: candidate.weight,

--- a/src/server/services/patternRouteChannelSyncService.ts
+++ b/src/server/services/patternRouteChannelSyncService.ts
@@ -1,0 +1,245 @@
+import { and, eq, inArray } from 'drizzle-orm';
+import { db, schema } from '../db/index.js';
+import {
+  ACCOUNT_TOKEN_VALUE_STATUS_READY,
+  isUsableAccountToken,
+} from './accountTokenService.js';
+import { clearRouteDecisionSnapshot, clearRouteDecisionSnapshots } from './routeDecisionSnapshotStore.js';
+import { matchesModelPattern } from './tokenRouter.js';
+import { normalizeTokenRouteMode } from '../../shared/tokenRouteContract.js';
+
+type PatternRouteChannelCandidate = {
+  tokenId: number | null;
+  accountId: number;
+  sourceModel: string;
+  priority: number;
+  weight: number;
+  enabled: boolean;
+};
+
+export type PatternRouteChannelSyncResult = {
+  rebuiltRoutes: number;
+  routeIds: number[];
+  removedChannels: number;
+  createdChannels: number;
+};
+
+type RebuildPatternRouteOptions = {
+  excludeExactModelPatterns?: string[];
+};
+
+function isExactModelPattern(modelPattern: string): boolean {
+  const normalized = modelPattern.trim();
+  if (!normalized) return false;
+  if (normalized.toLowerCase().startsWith('re:')) return false;
+  return !/[\*\?]/.test(normalized);
+}
+
+function isPatternGroupRoute(route: Pick<typeof schema.tokenRoutes.$inferSelect, 'routeMode' | 'modelPattern'>): boolean {
+  return normalizeTokenRouteMode(route.routeMode) !== 'explicit_group'
+    && !isExactModelPattern(route.modelPattern);
+}
+
+function normalizeModelKey(modelName: string): string {
+  return modelName.trim().toLowerCase();
+}
+
+function buildChannelPairKey(input: {
+  accountId: number;
+  tokenId: number | null;
+  sourceModel: string | null;
+}): string {
+  const tokenId = typeof input.tokenId === 'number' && Number.isFinite(input.tokenId) ? input.tokenId : 0;
+  const sourceModel = (input.sourceModel || '').trim().toLowerCase();
+  return `${input.accountId}::${tokenId}::${sourceModel}`;
+}
+
+async function getPatternTokenCandidates(
+  modelPattern: string,
+  excludedExactModelNames: Set<string>,
+): Promise<PatternRouteChannelCandidate[]> {
+  const rows = await db.select().from(schema.tokenModelAvailability)
+    .innerJoin(schema.accountTokens, eq(schema.tokenModelAvailability.tokenId, schema.accountTokens.id))
+    .innerJoin(schema.accounts, eq(schema.accountTokens.accountId, schema.accounts.id))
+    .innerJoin(schema.sites, eq(schema.accounts.siteId, schema.sites.id))
+    .where(
+      and(
+        eq(schema.tokenModelAvailability.available, true),
+        eq(schema.accountTokens.enabled, true),
+        eq(schema.accountTokens.valueStatus, ACCOUNT_TOKEN_VALUE_STATUS_READY),
+        eq(schema.accounts.status, 'active'),
+        eq(schema.sites.status, 'active'),
+      ),
+    )
+    .all();
+
+  const candidates: PatternRouteChannelCandidate[] = [];
+  for (const row of rows) {
+    if (!isUsableAccountToken(row.account_tokens)) continue;
+    const modelName = row.token_model_availability.modelName?.trim();
+    if (!modelName) continue;
+    if (excludedExactModelNames.has(normalizeModelKey(modelName))) continue;
+    if (!matchesModelPattern(modelName, modelPattern)) continue;
+    candidates.push({
+      tokenId: row.account_tokens.id,
+      accountId: row.accounts.id,
+      sourceModel: modelName,
+      priority: 0,
+      weight: 10,
+      enabled: true,
+    });
+  }
+
+  return candidates;
+}
+
+async function getMatchedExactRouteChannelCandidates(
+  modelPattern: string,
+  excludedExactModelNames: Set<string>,
+): Promise<{
+  candidates: PatternRouteChannelCandidate[];
+  exactModelNames: Set<string>;
+}> {
+  const matchedExactRoutes = (await db.select().from(schema.tokenRoutes).all())
+    .filter((route) => (
+      normalizeTokenRouteMode(route.routeMode) !== 'explicit_group'
+      && isExactModelPattern(route.modelPattern)
+      && matchesModelPattern(route.modelPattern, modelPattern)
+    ));
+
+  const exactModelNames = new Set<string>(excludedExactModelNames);
+  for (const route of matchedExactRoutes) {
+    exactModelNames.add(normalizeModelKey(route.modelPattern));
+  }
+
+  const enabledRoutes = matchedExactRoutes.filter((route) => route.enabled);
+  if (enabledRoutes.length === 0) {
+    return { candidates: [], exactModelNames };
+  }
+
+  const routeMap = new Map<number, typeof enabledRoutes[number]>();
+  for (const route of enabledRoutes) routeMap.set(route.id, route);
+
+  const channels = await db.select().from(schema.routeChannels)
+    .where(inArray(schema.routeChannels.routeId, enabledRoutes.map((route) => route.id)))
+    .all();
+
+  return {
+    exactModelNames,
+    candidates: channels.map((channel) => ({
+      tokenId: channel.tokenId ?? null,
+      accountId: channel.accountId,
+      sourceModel: (channel.sourceModel || routeMap.get(channel.routeId)?.modelPattern || '').trim(),
+      priority: channel.priority ?? 0,
+      weight: channel.weight ?? 10,
+      enabled: !!channel.enabled,
+    })).filter((candidate) => candidate.sourceModel.length > 0),
+  };
+}
+
+export async function populateRouteChannelsByModelPattern(
+  routeId: number,
+  modelPattern: string,
+  options: RebuildPatternRouteOptions = {},
+): Promise<number> {
+  const excludedExactModelNames = new Set(
+    (options.excludeExactModelPatterns || [])
+      .map(normalizeModelKey)
+      .filter(Boolean),
+  );
+  const routeCandidates = await getMatchedExactRouteChannelCandidates(modelPattern, excludedExactModelNames);
+  const availabilityExclusions = isExactModelPattern(modelPattern)
+    ? excludedExactModelNames
+    : routeCandidates.exactModelNames;
+  const availabilityCandidates = await getPatternTokenCandidates(modelPattern, availabilityExclusions);
+  const candidates = [...routeCandidates.candidates, ...availabilityCandidates];
+  if (candidates.length === 0) return 0;
+
+  const existingChannels = await db.select().from(schema.routeChannels)
+    .where(eq(schema.routeChannels.routeId, routeId))
+    .all();
+  const existingPairs = new Set(existingChannels.map((channel) => buildChannelPairKey({
+    accountId: channel.accountId,
+    tokenId: channel.tokenId ?? null,
+    sourceModel: channel.sourceModel,
+  })));
+
+  let created = 0;
+  for (const candidate of candidates) {
+    const pairKey = buildChannelPairKey(candidate);
+    if (existingPairs.has(pairKey)) continue;
+    await db.insert(schema.routeChannels).values({
+      routeId,
+      accountId: candidate.accountId,
+      tokenId: candidate.tokenId,
+      sourceModel: candidate.sourceModel,
+      priority: candidate.priority,
+      weight: candidate.weight,
+      enabled: candidate.enabled,
+      manualOverride: false,
+    }).run();
+    existingPairs.add(pairKey);
+    created += 1;
+  }
+
+  return created;
+}
+
+export async function rebuildAutomaticRouteChannelsByModelPattern(
+  routeId: number,
+  modelPattern: string,
+  options: RebuildPatternRouteOptions = {},
+): Promise<PatternRouteChannelSyncResult> {
+  const removableChannels = await db.select().from(schema.routeChannels)
+    .where(
+      and(
+        eq(schema.routeChannels.routeId, routeId),
+        eq(schema.routeChannels.manualOverride, false),
+      ),
+    )
+    .all();
+
+  for (const channel of removableChannels) {
+    await db.delete(schema.routeChannels).where(eq(schema.routeChannels.id, channel.id)).run();
+  }
+
+  const createdChannels = await populateRouteChannelsByModelPattern(routeId, modelPattern, options);
+  if (removableChannels.length > 0 || createdChannels > 0) {
+    await clearRouteDecisionSnapshot(routeId);
+  }
+
+  return {
+    rebuiltRoutes: 1,
+    routeIds: [routeId],
+    removedChannels: removableChannels.length,
+    createdChannels,
+  };
+}
+
+export async function rebuildAllPatternRouteChannels(
+  options: RebuildPatternRouteOptions = {},
+): Promise<PatternRouteChannelSyncResult> {
+  const patternRoutes = (await db.select().from(schema.tokenRoutes).all())
+    .filter((route) => route.enabled && isPatternGroupRoute(route));
+
+  const result: PatternRouteChannelSyncResult = {
+    rebuiltRoutes: 0,
+    routeIds: [],
+    removedChannels: 0,
+    createdChannels: 0,
+  };
+
+  for (const route of patternRoutes) {
+    const routeResult = await rebuildAutomaticRouteChannelsByModelPattern(route.id, route.modelPattern, options);
+    result.rebuiltRoutes += 1;
+    result.routeIds.push(route.id);
+    result.removedChannels += routeResult.removedChannels;
+    result.createdChannels += routeResult.createdChannels;
+  }
+
+  if (result.removedChannels > 0 || result.createdChannels > 0) {
+    await clearRouteDecisionSnapshots(result.routeIds);
+  }
+
+  return result;
+}

--- a/src/server/services/patternRouteChannelSyncService.ts
+++ b/src/server/services/patternRouteChannelSyncService.ts
@@ -5,7 +5,7 @@ import {
   isUsableAccountToken,
 } from './accountTokenService.js';
 import { clearRouteDecisionSnapshot, clearRouteDecisionSnapshots } from './routeDecisionSnapshotStore.js';
-import { matchesModelPattern } from './tokenRouter.js';
+import { invalidateTokenRouterCache, matchesModelPattern, normalizeModelAlias } from './tokenRouter.js';
 import { normalizeTokenRouteMode } from '../../shared/tokenRouteContract.js';
 import { isExactTokenRouteModelPattern } from '../../shared/tokenRoutePatterns.js';
 import { upsertSetting } from '../db/upsertSetting.js';
@@ -31,9 +31,22 @@ export type PatternRouteChannelSyncResult = {
   createdChannels: number;
 };
 
-type RebuildPatternRouteOptions = {
+export type RebuildPatternRouteOptions = {
   excludeExactModelPatterns?: string[];
   includeModelPatterns?: string[];
+  /**
+   * Restrict availability-backed candidates to the models that survived the
+   * normal model rebuild filters (whitelist, site disables, and brand rules).
+   * `undefined` means no restriction; an empty array intentionally allows no
+   * availability-backed candidates.
+  */
+  allowedModelNames?: string[];
+  /**
+   * Restrict token-availability candidates to the exact account/token/model
+   * tuples that survived the model rebuild filters. This preserves
+   * per-site filtering when another site still exposes the same model.
+   */
+  allowedAvailabilityCandidateKeys?: string[];
 };
 
 type PatternRouteChannelAffectedRouteSnapshot = {
@@ -45,7 +58,29 @@ type PatternRouteChannelAffectedRouteSnapshot = {
 type SyncPatternRouteChannelsAfterAffectedRouteChangesInput = {
   affectedRouteIds?: number[];
   removedRoutes?: PatternRouteChannelAffectedRouteSnapshot[];
+  allowedModelNames?: string[];
+  allowedAvailabilityCandidateKeys?: string[];
+  rebuildAllPatternRoutes?: boolean;
 };
+
+// Route mutations can arrive concurrently from separate requests.  Keep the
+// read/modify/write of the persisted exclusion set and the corresponding
+// pattern replacement together so one deletion cannot overwrite another.
+let patternRouteMutationTail: Promise<void> = Promise.resolve();
+
+async function withPatternRouteMutation<T>(operation: () => Promise<T>): Promise<T> {
+  const previous = patternRouteMutationTail;
+  let release!: () => void;
+  patternRouteMutationTail = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  await previous;
+  try {
+    return await operation();
+  } finally {
+    release();
+  }
+}
 
 type RouteModeModelPattern = {
   modelPattern: string;
@@ -94,7 +129,25 @@ function collectRemovedExactModelPatterns(routes: PatternRouteChannelAffectedRou
 }
 
 function normalizeModelKey(modelName: string): string {
-  return modelName.trim().toLowerCase();
+  return normalizeModelAlias(modelName);
+}
+
+function normalizeAllowedModelKeys(modelNames: string[] | undefined): Set<string> | undefined {
+  if (modelNames === undefined) return undefined;
+  return new Set(modelNames.map(normalizeModelKey).filter(Boolean));
+}
+
+function normalizeAllowedAvailabilityCandidateKeys(keys: string[] | undefined): Set<string> | undefined {
+  if (keys === undefined) return undefined;
+  return new Set(keys.map((key) => key.trim().toLowerCase()).filter(Boolean));
+}
+
+function buildAvailabilityCandidateKey(input: {
+  accountId: number;
+  tokenId: number;
+  modelName: string;
+}): string {
+  return `${input.accountId}:${input.tokenId}:${normalizeModelKey(input.modelName)}`;
 }
 
 async function getPersistedModelExclusions(database: DbExecutor = db): Promise<Set<string>> {
@@ -174,6 +227,8 @@ function buildChannelPairKey(input: {
 async function getPatternTokenCandidates(
   modelPattern: string,
   excludedExactModelNames: Set<string>,
+  allowedModelKeys: Set<string> | undefined,
+  allowedAvailabilityCandidateKeys: Set<string> | undefined,
   database: DbExecutor = db,
 ): Promise<PatternRouteChannelCandidate[]> {
   const rows = await database.select().from(schema.tokenModelAvailability)
@@ -197,6 +252,12 @@ async function getPatternTokenCandidates(
     const modelName = row.token_model_availability.modelName?.trim();
     if (!modelName) continue;
     if (excludedExactModelNames.has(normalizeModelKey(modelName))) continue;
+    if (allowedModelKeys && !allowedModelKeys.has(normalizeModelKey(modelName))) continue;
+    if (allowedAvailabilityCandidateKeys && !allowedAvailabilityCandidateKeys.has(buildAvailabilityCandidateKey({
+      accountId: row.accounts.id,
+      tokenId: row.account_tokens.id,
+      modelName,
+    }))) continue;
     if (!matchesModelPattern(modelName, modelPattern)) continue;
     candidates.push({
       tokenId: row.account_tokens.id,
@@ -258,7 +319,7 @@ async function getMatchedExactRouteChannelCandidates(
   };
 }
 
-export async function populateRouteChannelsByModelPattern(
+async function populateRouteChannelsByModelPatternInternal(
   routeId: number,
   modelPattern: string,
   options: RebuildPatternRouteOptions = {},
@@ -278,7 +339,13 @@ export async function populateRouteChannelsByModelPattern(
   const availabilityExclusions = isExactTokenRouteModelPattern(modelPattern)
     ? excludedExactModelNames
     : routeCandidates.exactModelNames;
-  const availabilityCandidates = await getPatternTokenCandidates(modelPattern, availabilityExclusions, database);
+  const availabilityCandidates = await getPatternTokenCandidates(
+    modelPattern,
+    availabilityExclusions,
+    normalizeAllowedModelKeys(options.allowedModelNames),
+    normalizeAllowedAvailabilityCandidateKeys(options.allowedAvailabilityCandidateKeys),
+    database,
+  );
   const candidates = [...routeCandidates.candidates, ...availabilityCandidates];
   if (candidates.length === 0) return 0;
 
@@ -314,7 +381,21 @@ export async function populateRouteChannelsByModelPattern(
   return created;
 }
 
-export async function rebuildAutomaticRouteChannelsByModelPattern(
+export async function populateRouteChannelsByModelPattern(
+  routeId: number,
+  modelPattern: string,
+  options: RebuildPatternRouteOptions = {},
+  database: DbExecutor = db,
+): Promise<number> {
+  return withPatternRouteMutation(() => populateRouteChannelsByModelPatternInternal(
+    routeId,
+    modelPattern,
+    options,
+    database,
+  ));
+}
+
+async function rebuildAutomaticRouteChannelsByModelPatternInternal(
   routeId: number,
   modelPattern: string,
   options: RebuildPatternRouteOptions = {},
@@ -335,11 +416,12 @@ export async function rebuildAutomaticRouteChannelsByModelPattern(
       await tx.delete(schema.routeChannels).where(eq(schema.routeChannels.id, channel.id)).run();
     }
 
-    createdChannels = await populateRouteChannelsByModelPattern(routeId, modelPattern, options, tx);
+    createdChannels = await populateRouteChannelsByModelPatternInternal(routeId, modelPattern, options, tx);
     removedChannels = removableChannels.length;
   });
   if (removedChannels > 0 || createdChannels > 0) {
     await clearRouteDecisionSnapshot(routeId);
+    invalidateTokenRouterCache();
   }
 
   return {
@@ -350,7 +432,19 @@ export async function rebuildAutomaticRouteChannelsByModelPattern(
   };
 }
 
-export async function rebuildAllPatternRouteChannels(
+export async function rebuildAutomaticRouteChannelsByModelPattern(
+  routeId: number,
+  modelPattern: string,
+  options: RebuildPatternRouteOptions = {},
+): Promise<PatternRouteChannelSyncResult> {
+  return withPatternRouteMutation(() => rebuildAutomaticRouteChannelsByModelPatternInternal(
+    routeId,
+    modelPattern,
+    options,
+  ));
+}
+
+async function rebuildAllPatternRouteChannelsInternal(
   options: RebuildPatternRouteOptions = {},
 ): Promise<PatternRouteChannelSyncResult> {
   const includedModelPatterns = (options.includeModelPatterns || [])
@@ -372,7 +466,7 @@ export async function rebuildAllPatternRouteChannels(
   };
 
   for (const route of patternRoutes) {
-    const routeResult = await rebuildAutomaticRouteChannelsByModelPattern(route.id, route.modelPattern, options);
+    const routeResult = await rebuildAutomaticRouteChannelsByModelPatternInternal(route.id, route.modelPattern, options);
     result.rebuiltRoutes += 1;
     result.routeIds.push(route.id);
     result.removedChannels += routeResult.removedChannels;
@@ -381,19 +475,27 @@ export async function rebuildAllPatternRouteChannels(
 
   if (result.removedChannels > 0 || result.createdChannels > 0) {
     await clearRouteDecisionSnapshots(result.routeIds);
+    invalidateTokenRouterCache();
   }
 
   return result;
 }
 
-export async function syncPatternRouteChannelsAfterAffectedRouteChanges(
+export async function rebuildAllPatternRouteChannels(
+  options: RebuildPatternRouteOptions = {},
+): Promise<PatternRouteChannelSyncResult> {
+  return withPatternRouteMutation(() => rebuildAllPatternRouteChannelsInternal(options));
+}
+
+async function syncPatternRouteChannelsAfterAffectedRouteChangesInternal(
   input: SyncPatternRouteChannelsAfterAffectedRouteChangesInput = {},
 ): Promise<PatternRouteChannelSyncResult> {
   const affectedRouteIds = normalizeAffectedRouteIds(input.affectedRouteIds);
   const removedRoutes = input.removedRoutes || [];
   const removedExactModelPatterns = collectRemovedExactModelPatterns(removedRoutes);
   const hasRemovedExactSourceRoute = removedRoutes.some(isExactSourceRoute);
-  if (affectedRouteIds.length === 0 && !hasRemovedExactSourceRoute) {
+  const rebuildAllPatternRoutes = input.rebuildAllPatternRoutes === true;
+  if (affectedRouteIds.length === 0 && !hasRemovedExactSourceRoute && !rebuildAllPatternRoutes) {
     return createEmptyPatternRouteChannelSyncResult();
   }
 
@@ -414,17 +516,29 @@ export async function syncPatternRouteChannelsAfterAffectedRouteChanges(
     }
   }
 
-  if (!hasAffectedExactSourceRoute && !hasRemovedExactSourceRoute) {
+  if (!hasAffectedExactSourceRoute && !hasRemovedExactSourceRoute && !rebuildAllPatternRoutes) {
     return createEmptyPatternRouteChannelSyncResult();
   }
 
   await clearModelExclusions(affectedExactModelPatterns);
   await persistModelExclusions(removedExactModelPatterns);
 
-  return rebuildAllPatternRouteChannels({
+  const rebuildOptions: RebuildPatternRouteOptions = {
     excludeExactModelPatterns: removedExactModelPatterns,
     includeModelPatterns: [...affectedExactModelPatterns, ...removedRoutes
       .filter(isExactSourceRoute)
       .map((route) => route.modelPattern)],
-  });
+    allowedModelNames: input.allowedModelNames,
+    allowedAvailabilityCandidateKeys: input.allowedAvailabilityCandidateKeys,
+  };
+  if (rebuildAllPatternRoutes) {
+    delete rebuildOptions.includeModelPatterns;
+  }
+  return rebuildAllPatternRouteChannelsInternal(rebuildOptions);
+}
+
+export async function syncPatternRouteChannelsAfterAffectedRouteChanges(
+  input: SyncPatternRouteChannelsAfterAffectedRouteChangesInput = {},
+): Promise<PatternRouteChannelSyncResult> {
+  return withPatternRouteMutation(() => syncPatternRouteChannelsAfterAffectedRouteChangesInternal(input));
 }

--- a/src/server/services/patternRouteChannelSyncService.ts
+++ b/src/server/services/patternRouteChannelSyncService.ts
@@ -7,6 +7,12 @@ import {
 import { clearRouteDecisionSnapshot, clearRouteDecisionSnapshots } from './routeDecisionSnapshotStore.js';
 import { matchesModelPattern } from './tokenRouter.js';
 import { normalizeTokenRouteMode } from '../../shared/tokenRouteContract.js';
+import { isExactTokenRouteModelPattern } from '../../shared/tokenRoutePatterns.js';
+import { upsertSetting } from '../db/upsertSetting.js';
+
+type DbExecutor = Pick<typeof db, 'select' | 'insert' | 'delete'>;
+
+const MODEL_EXCLUSIONS_SETTING_KEY = 'token_route_deleted_model_exclusions_v1';
 
 type PatternRouteChannelCandidate = {
   tokenId: number | null;
@@ -27,6 +33,7 @@ export type PatternRouteChannelSyncResult = {
 
 type RebuildPatternRouteOptions = {
   excludeExactModelPatterns?: string[];
+  includeModelPatterns?: string[];
 };
 
 type PatternRouteChannelAffectedRouteSnapshot = {
@@ -45,21 +52,14 @@ type RouteModeModelPattern = {
   routeMode?: string | null;
 };
 
-function isExactModelPattern(modelPattern: string): boolean {
-  const normalized = modelPattern.trim();
-  if (!normalized) return false;
-  if (normalized.toLowerCase().startsWith('re:')) return false;
-  return !/[\*\?]/.test(normalized);
-}
-
 function isPatternGroupRoute(route: RouteModeModelPattern): boolean {
   return normalizeTokenRouteMode(route.routeMode) !== 'explicit_group'
-    && !isExactModelPattern(route.modelPattern);
+    && !isExactTokenRouteModelPattern(route.modelPattern);
 }
 
 function isExactSourceRoute(route: RouteModeModelPattern): boolean {
   return normalizeTokenRouteMode(route.routeMode) !== 'explicit_group'
-    && isExactModelPattern(route.modelPattern);
+    && isExactTokenRouteModelPattern(route.modelPattern);
 }
 
 function normalizeAffectedRouteIds(routeIds: number[] | undefined): number[] {
@@ -97,6 +97,66 @@ function normalizeModelKey(modelName: string): string {
   return modelName.trim().toLowerCase();
 }
 
+async function getPersistedModelExclusions(database: DbExecutor = db): Promise<Set<string>> {
+  const row = await database.select({ value: schema.settings.value })
+    .from(schema.settings)
+    .where(eq(schema.settings.key, MODEL_EXCLUSIONS_SETTING_KEY))
+    .get();
+  if (!row?.value) return new Set();
+  try {
+    const parsed = JSON.parse(row.value);
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed
+      .filter((modelName): modelName is string => typeof modelName === 'string')
+      .map(normalizeModelKey)
+      .filter(Boolean));
+  } catch {
+    return new Set();
+  }
+}
+
+async function savePersistedModelExclusions(
+  exclusions: Set<string>,
+  database: DbExecutor = db,
+): Promise<void> {
+  await upsertSetting(
+    MODEL_EXCLUSIONS_SETTING_KEY,
+    [...exclusions].sort(),
+    database as typeof db,
+  );
+}
+
+async function persistModelExclusions(
+  modelPatterns: string[],
+  database: DbExecutor = db,
+): Promise<void> {
+  const exclusions = new Set(modelPatterns.map(normalizeModelKey).filter(Boolean));
+  if (exclusions.size === 0) return;
+  const existing = await getPersistedModelExclusions(database);
+  let changed = false;
+  for (const modelName of exclusions) {
+    if (existing.has(modelName)) continue;
+    existing.add(modelName);
+    changed = true;
+  }
+  if (changed) await savePersistedModelExclusions(existing, database);
+}
+
+async function clearModelExclusions(
+  modelPatterns: string[],
+  database: DbExecutor = db,
+): Promise<void> {
+  const exclusions = new Set(modelPatterns.map(normalizeModelKey).filter(Boolean));
+  if (exclusions.size === 0) return;
+  const existing = await getPersistedModelExclusions(database);
+  let changed = false;
+  for (const modelName of exclusions) {
+    if (!existing.delete(modelName)) continue;
+    changed = true;
+  }
+  if (changed) await savePersistedModelExclusions(existing, database);
+}
+
 function buildChannelPairKey(input: {
   accountId: number;
   tokenId: number | null;
@@ -114,8 +174,9 @@ function buildChannelPairKey(input: {
 async function getPatternTokenCandidates(
   modelPattern: string,
   excludedExactModelNames: Set<string>,
+  database: DbExecutor = db,
 ): Promise<PatternRouteChannelCandidate[]> {
-  const rows = await db.select().from(schema.tokenModelAvailability)
+  const rows = await database.select().from(schema.tokenModelAvailability)
     .innerJoin(schema.accountTokens, eq(schema.tokenModelAvailability.tokenId, schema.accountTokens.id))
     .innerJoin(schema.accounts, eq(schema.accountTokens.accountId, schema.accounts.id))
     .innerJoin(schema.sites, eq(schema.accounts.siteId, schema.sites.id))
@@ -154,14 +215,15 @@ async function getPatternTokenCandidates(
 async function getMatchedExactRouteChannelCandidates(
   modelPattern: string,
   excludedExactModelNames: Set<string>,
+  database: DbExecutor = db,
 ): Promise<{
   candidates: PatternRouteChannelCandidate[];
   exactModelNames: Set<string>;
 }> {
-  const matchedExactRoutes = (await db.select().from(schema.tokenRoutes).all())
+  const matchedExactRoutes = (await database.select().from(schema.tokenRoutes).all())
     .filter((route) => (
       normalizeTokenRouteMode(route.routeMode) !== 'explicit_group'
-      && isExactModelPattern(route.modelPattern)
+      && isExactTokenRouteModelPattern(route.modelPattern)
       && matchesModelPattern(route.modelPattern, modelPattern)
     ));
 
@@ -178,7 +240,7 @@ async function getMatchedExactRouteChannelCandidates(
   const routeMap = new Map<number, typeof enabledRoutes[number]>();
   for (const route of enabledRoutes) routeMap.set(route.id, route);
 
-  const channels = await db.select().from(schema.routeChannels)
+  const channels = await database.select().from(schema.routeChannels)
     .where(inArray(schema.routeChannels.routeId, enabledRoutes.map((route) => route.id)))
     .all();
 
@@ -200,21 +262,27 @@ export async function populateRouteChannelsByModelPattern(
   routeId: number,
   modelPattern: string,
   options: RebuildPatternRouteOptions = {},
+  database: DbExecutor = db,
 ): Promise<number> {
   const excludedExactModelNames = new Set(
     (options.excludeExactModelPatterns || [])
       .map(normalizeModelKey)
       .filter(Boolean),
   );
-  const routeCandidates = await getMatchedExactRouteChannelCandidates(modelPattern, excludedExactModelNames);
-  const availabilityExclusions = isExactModelPattern(modelPattern)
+  if (!isExactTokenRouteModelPattern(modelPattern)) {
+    for (const modelName of await getPersistedModelExclusions(database)) {
+      excludedExactModelNames.add(modelName);
+    }
+  }
+  const routeCandidates = await getMatchedExactRouteChannelCandidates(modelPattern, excludedExactModelNames, database);
+  const availabilityExclusions = isExactTokenRouteModelPattern(modelPattern)
     ? excludedExactModelNames
     : routeCandidates.exactModelNames;
-  const availabilityCandidates = await getPatternTokenCandidates(modelPattern, availabilityExclusions);
+  const availabilityCandidates = await getPatternTokenCandidates(modelPattern, availabilityExclusions, database);
   const candidates = [...routeCandidates.candidates, ...availabilityCandidates];
   if (candidates.length === 0) return 0;
 
-  const existingChannels = await db.select().from(schema.routeChannels)
+  const existingChannels = await database.select().from(schema.routeChannels)
     .where(eq(schema.routeChannels.routeId, routeId))
     .all();
   const existingPairs = new Set(existingChannels.map((channel) => buildChannelPairKey({
@@ -228,7 +296,7 @@ export async function populateRouteChannelsByModelPattern(
   for (const candidate of candidates) {
     const pairKey = buildChannelPairKey(candidate);
     if (existingPairs.has(pairKey)) continue;
-    await db.insert(schema.routeChannels).values({
+    await database.insert(schema.routeChannels).values({
       routeId,
       accountId: candidate.accountId,
       tokenId: candidate.tokenId,
@@ -251,28 +319,33 @@ export async function rebuildAutomaticRouteChannelsByModelPattern(
   modelPattern: string,
   options: RebuildPatternRouteOptions = {},
 ): Promise<PatternRouteChannelSyncResult> {
-  const removableChannels = await db.select().from(schema.routeChannels)
-    .where(
-      and(
-        eq(schema.routeChannels.routeId, routeId),
-        eq(schema.routeChannels.manualOverride, false),
-      ),
-    )
-    .all();
+  let removedChannels = 0;
+  let createdChannels = 0;
+  await db.transaction(async (tx) => {
+    const removableChannels = await tx.select().from(schema.routeChannels)
+      .where(
+        and(
+          eq(schema.routeChannels.routeId, routeId),
+          eq(schema.routeChannels.manualOverride, false),
+        ),
+      )
+      .all();
 
-  for (const channel of removableChannels) {
-    await db.delete(schema.routeChannels).where(eq(schema.routeChannels.id, channel.id)).run();
-  }
+    for (const channel of removableChannels) {
+      await tx.delete(schema.routeChannels).where(eq(schema.routeChannels.id, channel.id)).run();
+    }
 
-  const createdChannels = await populateRouteChannelsByModelPattern(routeId, modelPattern, options);
-  if (removableChannels.length > 0 || createdChannels > 0) {
+    createdChannels = await populateRouteChannelsByModelPattern(routeId, modelPattern, options, tx);
+    removedChannels = removableChannels.length;
+  });
+  if (removedChannels > 0 || createdChannels > 0) {
     await clearRouteDecisionSnapshot(routeId);
   }
 
   return {
     rebuiltRoutes: 1,
     routeIds: [routeId],
-    removedChannels: removableChannels.length,
+    removedChannels,
     createdChannels,
   };
 }
@@ -280,8 +353,16 @@ export async function rebuildAutomaticRouteChannelsByModelPattern(
 export async function rebuildAllPatternRouteChannels(
   options: RebuildPatternRouteOptions = {},
 ): Promise<PatternRouteChannelSyncResult> {
+  const includedModelPatterns = (options.includeModelPatterns || [])
+    .map((modelPattern) => modelPattern.trim())
+    .filter(Boolean);
   const patternRoutes = (await db.select().from(schema.tokenRoutes).all())
-    .filter((route) => route.enabled && isPatternGroupRoute(route));
+    .filter((route) => (
+      route.enabled
+      && isPatternGroupRoute(route)
+      && (includedModelPatterns.length === 0
+        || includedModelPatterns.some((modelPattern) => matchesModelPattern(modelPattern, route.modelPattern)))
+    ));
 
   const result: PatternRouteChannelSyncResult = {
     rebuiltRoutes: 0,
@@ -317,6 +398,7 @@ export async function syncPatternRouteChannelsAfterAffectedRouteChanges(
   }
 
   let hasAffectedExactSourceRoute = false;
+  const affectedExactModelPatterns: string[] = [];
   if (affectedRouteIds.length > 0) {
     const routes = await db.select({
       id: schema.tokenRoutes.id,
@@ -327,13 +409,22 @@ export async function syncPatternRouteChannelsAfterAffectedRouteChanges(
       .all();
 
     hasAffectedExactSourceRoute = routes.some(isExactSourceRoute);
+    for (const route of routes) {
+      if (isExactSourceRoute(route)) affectedExactModelPatterns.push(route.modelPattern);
+    }
   }
 
   if (!hasAffectedExactSourceRoute && !hasRemovedExactSourceRoute) {
     return createEmptyPatternRouteChannelSyncResult();
   }
 
+  await clearModelExclusions(affectedExactModelPatterns);
+  await persistModelExclusions(removedExactModelPatterns);
+
   return rebuildAllPatternRouteChannels({
     excludeExactModelPatterns: removedExactModelPatterns,
+    includeModelPatterns: [...affectedExactModelPatterns, ...removedRoutes
+      .filter(isExactSourceRoute)
+      .map((route) => route.modelPattern)],
   });
 }

--- a/src/server/services/patternRouteChannelSyncService.ts
+++ b/src/server/services/patternRouteChannelSyncService.ts
@@ -32,6 +32,7 @@ type RebuildPatternRouteOptions = {
 type PatternRouteChannelAffectedRouteSnapshot = {
   modelPattern: string;
   routeMode?: string | null;
+  enabled?: boolean | null;
 };
 
 type SyncPatternRouteChannelsAfterAffectedRouteChangesInput = {
@@ -83,7 +84,7 @@ function createEmptyPatternRouteChannelSyncResult(): PatternRouteChannelSyncResu
 function collectRemovedExactModelPatterns(routes: PatternRouteChannelAffectedRouteSnapshot[] | undefined): string[] {
   const normalized: string[] = [];
   for (const route of routes || []) {
-    if (!isExactSourceRoute(route)) continue;
+    if (!isExactSourceRoute(route) || route.enabled !== true) continue;
     const modelPattern = route.modelPattern.trim();
     const modelKey = normalizeModelKey(modelPattern);
     if (!modelKey || normalized.some((item) => normalizeModelKey(item) === modelKey)) continue;
@@ -308,8 +309,10 @@ export async function syncPatternRouteChannelsAfterAffectedRouteChanges(
   input: SyncPatternRouteChannelsAfterAffectedRouteChangesInput = {},
 ): Promise<PatternRouteChannelSyncResult> {
   const affectedRouteIds = normalizeAffectedRouteIds(input.affectedRouteIds);
-  const removedExactModelPatterns = collectRemovedExactModelPatterns(input.removedRoutes);
-  if (affectedRouteIds.length === 0 && removedExactModelPatterns.length === 0) {
+  const removedRoutes = input.removedRoutes || [];
+  const removedExactModelPatterns = collectRemovedExactModelPatterns(removedRoutes);
+  const hasRemovedExactSourceRoute = removedRoutes.some(isExactSourceRoute);
+  if (affectedRouteIds.length === 0 && !hasRemovedExactSourceRoute) {
     return createEmptyPatternRouteChannelSyncResult();
   }
 
@@ -326,7 +329,7 @@ export async function syncPatternRouteChannelsAfterAffectedRouteChanges(
     hasAffectedExactSourceRoute = routes.some(isExactSourceRoute);
   }
 
-  if (!hasAffectedExactSourceRoute && removedExactModelPatterns.length === 0) {
+  if (!hasAffectedExactSourceRoute && !hasRemovedExactSourceRoute) {
     return createEmptyPatternRouteChannelSyncResult();
   }
 

--- a/src/server/services/routeRefreshWorkflow.ts
+++ b/src/server/services/routeRefreshWorkflow.ts
@@ -1,11 +1,12 @@
 import { startBackgroundTask } from './backgroundTaskService.js';
 import {
   rebuildTokenRoutesFromAvailability,
+  type RebuildTokenRoutesOptions,
   refreshModelsAndRebuildRoutes as refreshModelsAndRebuildRoutesViaModelService,
 } from './modelService.js';
 
-export async function rebuildRoutesOnly() {
-  return rebuildTokenRoutesFromAvailability();
+export async function rebuildRoutesOnly(options: RebuildTokenRoutesOptions = {}) {
+  return rebuildTokenRoutesFromAvailability(options);
 }
 
 export async function rebuildRoutesBestEffort() {
@@ -17,8 +18,8 @@ export async function rebuildRoutesBestEffort() {
   }
 }
 
-export async function refreshModelsAndRebuildRoutes() {
-  return refreshModelsAndRebuildRoutesViaModelService();
+export async function refreshModelsAndRebuildRoutes(options: RebuildTokenRoutesOptions = {}) {
+  return refreshModelsAndRebuildRoutesViaModelService(options);
 }
 
 export function queueRefreshModelsAndRebuildRoutesTask(input: {

--- a/src/server/services/tokenRouter.cache.test.ts
+++ b/src/server/services/tokenRouter.cache.test.ts
@@ -541,7 +541,7 @@ describe('TokenRouter runtime cache', () => {
     expect(record?.failCount).toBe(1);
   });
 
-  it('applies short-window cooldown to sibling channels that share the same account-level credential', async () => {
+  it('keeps short-window cooldown scoped to the channel that received the failure', async () => {
     const site = await db.insert(schema.sites).values({
       name: 'shared-credential-site',
       url: 'https://shared-credential.example.com',
@@ -609,10 +609,15 @@ describe('TokenRouter runtime cache', () => {
     const cooledSibling = await db.select().from(schema.routeChannels)
       .where(eq(schema.routeChannels.id, siblingChannel.id))
       .get();
+    const cooledPrimary = await db.select().from(schema.routeChannels)
+      .where(eq(schema.routeChannels.id, primaryChannel.id))
+      .get();
 
-    expect(cooledSibling?.cooldownUntil).toBeTruthy();
+    expect(cooledPrimary?.cooldownUntil).toBeTruthy();
+    expect(cooledSibling?.cooldownUntil).toBeNull();
+    expect(cooledSibling?.lastFailAt).toBeNull();
     expect(cooledSibling?.failCount).toBe(0);
-    expect(await router.selectChannel('gpt-4o-mini')).toBeNull();
+    expect((await router.selectChannel('gpt-4o-mini'))?.channel.id).toBe(siblingChannel.id);
   });
 
   it('clears short-window cooldown on sibling channels after a successful recovery probe', async () => {

--- a/src/server/services/tokenRouter.patterns.test.ts
+++ b/src/server/services/tokenRouter.patterns.test.ts
@@ -218,6 +218,25 @@ describe('TokenRouter patterns and model mapping', () => {
     expect(decision.actualModel).toBe('claude-opus-4-5');
   });
 
+  it('keeps exact routes out of exposed models when covered by an explicit group', async () => {
+    const source = await createRouteWithSingleChannel('gpt-5.5-openai-compact');
+    await createRouteWithSingleChannel('gpt-5.5-openai-compact-high');
+    const exact = await createRouteWithSingleChannel('gpt-5.5-openai-compact-xhigh');
+    const group = await createExplicitGroupRoute('gpt-5.5-openai-compact', [source.route.id]);
+    const router = new TokenRouter();
+
+    const exposedModels = await router.getAvailableModels();
+    const selected = await router.selectChannel('gpt-5.5-openai-compact-xhigh');
+    const decision = await router.explainSelection('gpt-5.5-openai-compact-xhigh');
+
+    expect(group.routeMode).toBe('explicit_group');
+    expect(exposedModels).toEqual(['gpt-5.5-openai-compact']);
+    expect(selected).toBeTruthy();
+    expect(selected?.channel.routeId).toBe(exact.route.id);
+    expect(decision.routeId).toBe(exact.route.id);
+    expect(decision.actualModel).toBe('gpt-5.5-openai-compact-xhigh');
+  });
+
   it('falls back to the source exact-route model when explicit-group channels omit sourceModel', async () => {
     const source = await createRouteWithSingleChannel('claude-opus-4-5');
     await createExplicitGroupRoute('claude-test-4.6-sonnet', [source.route.id]);

--- a/src/server/services/tokenRouter.patterns.test.ts
+++ b/src/server/services/tokenRouter.patterns.test.ts
@@ -220,9 +220,13 @@ describe('TokenRouter patterns and model mapping', () => {
 
   it('keeps exact routes out of exposed models when covered by an explicit group', async () => {
     const source = await createRouteWithSingleChannel('gpt-5.5-openai-compact');
-    await createRouteWithSingleChannel('gpt-5.5-openai-compact-high');
+    const high = await createRouteWithSingleChannel('gpt-5.5-openai-compact-high');
     const exact = await createRouteWithSingleChannel('gpt-5.5-openai-compact-xhigh');
-    const group = await createExplicitGroupRoute('gpt-5.5-openai-compact', [source.route.id]);
+    const group = await createExplicitGroupRoute('gpt-5.5-openai-compact', [
+      source.route.id,
+      high.route.id,
+      exact.route.id,
+    ]);
     const router = new TokenRouter();
 
     const exposedModels = await router.getAvailableModels();

--- a/src/server/services/tokenRouter.ts
+++ b/src/server/services/tokenRouter.ts
@@ -1378,12 +1378,6 @@ function hasCustomDisplayName(route: Pick<RouteRow, 'modelPattern' | 'displayNam
 }
 
 function buildVisibleEnabledRoutes(routes: RouteRow[]): RouteRow[] {
-  const exactModelNames = new Set(
-    routes
-      .filter((route) => !isExplicitGroupRoute(route) && isExactRouteModelPattern(route.modelPattern))
-      .map((route) => (route.modelPattern || '').trim())
-      .filter(Boolean),
-  );
   const coveringGroups = routes.filter((route) => (
     route.enabled
     && (
@@ -1406,8 +1400,7 @@ function buildVisibleEnabledRoutes(routes: RouteRow[]): RouteRow[] {
 
     return !coveringGroups.some((groupRoute) => {
       if (groupRoute.id === route.id) return false;
-      const groupDisplayName = normalizeRouteDisplayName(groupRoute.displayName);
-      if (!groupDisplayName || exactModelNames.has(groupDisplayName)) return false;
+      if (!normalizeRouteDisplayName(groupRoute.displayName)) return false;
       if (isExplicitGroupRoute(groupRoute)) {
         return groupRoute.sourceRouteIds.includes(route.id);
       }

--- a/src/server/services/tokenRouter.ts
+++ b/src/server/services/tokenRouter.ts
@@ -1356,12 +1356,6 @@ function hasCustomDisplayName(route: Pick<RouteRow, 'modelPattern' | 'displayNam
 }
 
 function buildVisibleEnabledRoutes(routes: RouteRow[]): RouteRow[] {
-  const exactModelNames = new Set(
-    routes
-      .filter((route) => !isExplicitGroupRoute(route) && isExactRouteModelPattern(route.modelPattern))
-      .map((route) => (route.modelPattern || '').trim())
-      .filter(Boolean),
-  );
   const coveringGroups = routes.filter((route) => (
     route.enabled
     && (
@@ -1384,8 +1378,7 @@ function buildVisibleEnabledRoutes(routes: RouteRow[]): RouteRow[] {
 
     return !coveringGroups.some((groupRoute) => {
       if (groupRoute.id === route.id) return false;
-      const groupDisplayName = normalizeRouteDisplayName(groupRoute.displayName);
-      if (!groupDisplayName || exactModelNames.has(groupDisplayName)) return false;
+      if (!normalizeRouteDisplayName(groupRoute.displayName)) return false;
       if (isExplicitGroupRoute(groupRoute)) {
         return groupRoute.sourceRouteIds.includes(route.id);
       }

--- a/src/server/services/tokenRouter.ts
+++ b/src/server/services/tokenRouter.ts
@@ -1389,7 +1389,17 @@ function buildVisibleEnabledRoutes(routes: RouteRow[]): RouteRow[] {
     return !coveringGroups.some((groupRoute) => {
       if (groupRoute.id === route.id) return false;
       const groupDisplayName = normalizeRouteDisplayName(groupRoute.displayName);
-      if (!groupDisplayName || exactModelNames.has(groupDisplayName.toLowerCase())) return false;
+      if (
+        !groupDisplayName
+        || exactModelNames.has(groupDisplayName.toLowerCase())
+        // A pattern alias that is identical to an unnamed exact route cannot
+        // replace that route in dispatch: findRoute() gives exact matches
+        // precedence. Keep the exact route visible so the UI reflects this.
+        || (
+          !isExplicitGroupRoute(groupRoute)
+          && groupDisplayName.toLowerCase() === exactModel.toLowerCase()
+        )
+      ) return false;
       if (isExplicitGroupRoute(groupRoute)) {
         return groupRoute.sourceRouteIds.includes(route.id);
       }
@@ -1398,7 +1408,7 @@ function buildVisibleEnabledRoutes(routes: RouteRow[]): RouteRow[] {
   });
 }
 
-function normalizeModelAlias(modelName: string): string {
+export function normalizeModelAlias(modelName: string): string {
   const normalized = (modelName || '').trim().toLowerCase();
   if (!normalized) return '';
   const slashIndex = normalized.lastIndexOf('/');

--- a/src/server/services/tokenRouter.ts
+++ b/src/server/services/tokenRouter.ts
@@ -1356,6 +1356,16 @@ function hasCustomDisplayName(route: Pick<RouteRow, 'modelPattern' | 'displayNam
 }
 
 function buildVisibleEnabledRoutes(routes: RouteRow[]): RouteRow[] {
+  const exactModelNames = new Set(
+    routes
+      .filter((route) => (
+        !isExplicitGroupRoute(route)
+        && isExactRouteModelPattern(route.modelPattern)
+        && !!normalizeRouteDisplayName(route.displayName)
+      ))
+      .map((route) => (route.modelPattern || '').trim().toLowerCase())
+      .filter(Boolean),
+  );
   const coveringGroups = routes.filter((route) => (
     route.enabled
     && (
@@ -1378,7 +1388,8 @@ function buildVisibleEnabledRoutes(routes: RouteRow[]): RouteRow[] {
 
     return !coveringGroups.some((groupRoute) => {
       if (groupRoute.id === route.id) return false;
-      if (!normalizeRouteDisplayName(groupRoute.displayName)) return false;
+      const groupDisplayName = normalizeRouteDisplayName(groupRoute.displayName);
+      if (!groupDisplayName || exactModelNames.has(groupDisplayName.toLowerCase())) return false;
       if (isExplicitGroupRoute(groupRoute)) {
         return groupRoute.sourceRouteIds.includes(route.id);
       }

--- a/src/web/pages/helpers/routeListVisibility.test.ts
+++ b/src/web/pages/helpers/routeListVisibility.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { buildVisibleRouteList } from './routeListVisibility.js';
+
+describe('routeListVisibility', () => {
+  it('hides exact routes covered by an explicit group', () => {
+    const routes = [
+      {
+        id: 1,
+        modelPattern: 'gpt-5.5',
+        displayName: null,
+        routeMode: 'pattern',
+        sourceRouteIds: [],
+        enabled: true,
+      },
+      {
+        id: 2,
+        modelPattern: 'gpt-5.5-high',
+        displayName: null,
+        routeMode: 'pattern',
+        sourceRouteIds: [],
+        enabled: true,
+      },
+      {
+        id: 3,
+        modelPattern: 'gpt-5.5',
+        displayName: 'gpt-5.5',
+        routeMode: 'explicit_group',
+        sourceRouteIds: [1, 2],
+        enabled: true,
+      },
+    ];
+
+    const visible = buildVisibleRouteList(
+      routes,
+      (pattern) => !pattern.includes('*') && !pattern.startsWith('re:'),
+      (model, pattern) => {
+        if (pattern.startsWith('re:')) return /^gpt-5\.5.*$/.test(model);
+        return pattern === model;
+      },
+    );
+
+    expect(visible.map((route) => route.id)).toEqual([3]);
+  });
+
+  it('hides exact routes covered by a regex group', () => {
+    const routes = [
+      {
+        id: 1,
+        modelPattern: 'gpt-5.5',
+        displayName: null,
+        routeMode: 'pattern',
+        sourceRouteIds: [],
+        enabled: true,
+      },
+      {
+        id: 2,
+        modelPattern: 'gpt-5.5-high',
+        displayName: null,
+        routeMode: 'pattern',
+        sourceRouteIds: [],
+        enabled: true,
+      },
+      {
+        id: 3,
+        modelPattern: 're:^gpt-5\\.5.*$',
+        displayName: 'gpt-5.5',
+        routeMode: 'pattern',
+        sourceRouteIds: [],
+        enabled: true,
+      },
+    ];
+
+    const visible = buildVisibleRouteList(
+      routes,
+      (pattern) => !pattern.includes('*') && !pattern.startsWith('re:'),
+      (model, pattern) => {
+        if (pattern.startsWith('re:')) return /^gpt-5\.5.*$/.test(model);
+        return pattern === model;
+      },
+    );
+
+    expect(visible.map((route) => route.id)).toEqual([3]);
+  });
+});

--- a/src/web/pages/helpers/routeListVisibility.test.ts
+++ b/src/web/pages/helpers/routeListVisibility.test.ts
@@ -63,7 +63,7 @@ describe('routeListVisibility', () => {
       {
         id: 3,
         modelPattern: 're:^gpt-5\\.5.*$',
-        displayName: 'gpt-5.5',
+        displayName: 'gpt-5.5-group',
         routeMode: 'pattern',
         sourceRouteIds: [],
         enabled: true,
@@ -106,6 +106,35 @@ describe('routeListVisibility', () => {
       routes,
       (pattern) => !pattern.includes('*') && !pattern.startsWith('re:'),
       (model, pattern) => pattern.startsWith('re:') && /^gpt-5\.5.*$/.test(model),
+    );
+
+    expect(visible.map((route) => route.id)).toEqual([1, 2]);
+  });
+
+  it('keeps an unnamed exact route visible when a pattern alias collides with it', () => {
+    const routes = [
+      {
+        id: 1,
+        modelPattern: 'gpt-5',
+        displayName: null,
+        routeMode: 'pattern',
+        sourceRouteIds: [],
+        enabled: true,
+      },
+      {
+        id: 2,
+        modelPattern: 're:^gpt-5.*$',
+        displayName: 'gpt-5',
+        routeMode: 'pattern',
+        sourceRouteIds: [],
+        enabled: true,
+      },
+    ];
+
+    const visible = buildVisibleRouteList(
+      routes,
+      (pattern) => !pattern.includes('*') && !pattern.startsWith('re:'),
+      (model, pattern) => pattern.startsWith('re:') && /^gpt-5.*$/.test(model),
     );
 
     expect(visible.map((route) => route.id)).toEqual([1, 2]);

--- a/src/web/pages/helpers/routeListVisibility.test.ts
+++ b/src/web/pages/helpers/routeListVisibility.test.ts
@@ -81,4 +81,33 @@ describe('routeListVisibility', () => {
 
     expect(visible.map((route) => route.id)).toEqual([3]);
   });
+
+  it('keeps disabled exact routes visible when a group covers their model', () => {
+    const routes = [
+      {
+        id: 1,
+        modelPattern: 'gpt-5.5',
+        displayName: null,
+        routeMode: 'pattern',
+        sourceRouteIds: [],
+        enabled: false,
+      },
+      {
+        id: 2,
+        modelPattern: 're:^gpt-5.5.*$',
+        displayName: 'gpt-5-group',
+        routeMode: 'pattern',
+        sourceRouteIds: [],
+        enabled: true,
+      },
+    ];
+
+    const visible = buildVisibleRouteList(
+      routes,
+      (pattern) => !pattern.includes('*') && !pattern.startsWith('re:'),
+      (model, pattern) => pattern.startsWith('re:') && /^gpt-5\.5.*$/.test(model),
+    );
+
+    expect(visible.map((route) => route.id)).toEqual([1, 2]);
+  });
 });

--- a/src/web/pages/helpers/routeListVisibility.ts
+++ b/src/web/pages/helpers/routeListVisibility.ts
@@ -28,12 +28,6 @@ export function buildVisibleRouteList<T extends RouteListVisibilityItem>(
   isExactModelPattern: (pattern: string) => boolean,
   matchesModelPattern: (model: string, pattern: string) => boolean,
 ): T[] {
-  const exactModelNames = new Set(
-    routes
-      .filter((route) => !isExplicitGroupRoute(route) && isExactModelPattern(route.modelPattern))
-      .map((route) => (route.modelPattern || '').trim())
-      .filter(Boolean),
-  );
   const coveringGroups = routes.filter((route) => (
     route.enabled
     && (
@@ -52,13 +46,13 @@ export function buildVisibleRouteList<T extends RouteListVisibilityItem>(
     const exactModel = (route.modelPattern || '').trim();
     if (!exactModel) return true;
 
-    return !coveringGroups.some((groupRoute) => (
-      groupRoute.id !== route.id
-      && !exactModelNames.has((groupRoute.displayName || '').trim())
-      && (
-        (isExplicitGroupRoute(groupRoute) && (groupRoute.sourceRouteIds || []).includes(route.id))
-        || (!isExplicitGroupRoute(groupRoute) && matchesModelPattern(exactModel, groupRoute.modelPattern))
-      )
-    ));
+    return !coveringGroups.some((groupRoute) => {
+      if (groupRoute.id === route.id) return false;
+      if (!((groupRoute.displayName || '').trim())) return false;
+      if (isExplicitGroupRoute(groupRoute)) {
+        return (groupRoute.sourceRouteIds || []).includes(route.id);
+      }
+      return matchesModelPattern(exactModel, groupRoute.modelPattern);
+    });
   });
 }

--- a/src/web/pages/helpers/routeListVisibility.ts
+++ b/src/web/pages/helpers/routeListVisibility.ts
@@ -51,6 +51,7 @@ export function buildVisibleRouteList<T extends RouteListVisibilityItem>(
   return routes.filter((route) => {
     if (isExplicitGroupRoute(route)) return true;
     if (!isExactModelPattern(route.modelPattern)) return true;
+    if (!route.enabled) return true;
     if (hasCustomDisplayName(route)) return true;
 
     const exactModel = (route.modelPattern || '').trim();

--- a/src/web/pages/helpers/routeListVisibility.ts
+++ b/src/web/pages/helpers/routeListVisibility.ts
@@ -63,7 +63,16 @@ export function buildVisibleRouteList<T extends RouteListVisibilityItem>(
     return !coveringGroups.some((groupRoute) => {
       if (groupRoute.id === route.id) return false;
       const groupDisplayName = (groupRoute.displayName || '').trim();
-      if (!groupDisplayName || exactModelNames.has(groupDisplayName.toLowerCase())) return false;
+      if (
+        !groupDisplayName
+        || exactModelNames.has(groupDisplayName.toLowerCase())
+        // Pattern aliases do not override exact dispatch matches; keep a
+        // colliding unnamed exact route visible in the management UI.
+        || (
+          !isExplicitGroupRoute(groupRoute)
+          && groupDisplayName.toLowerCase() === exactModel.toLowerCase()
+        )
+      ) return false;
       if (isExplicitGroupRoute(groupRoute)) {
         return (groupRoute.sourceRouteIds || []).includes(route.id);
       }

--- a/src/web/pages/helpers/routeListVisibility.ts
+++ b/src/web/pages/helpers/routeListVisibility.ts
@@ -7,6 +7,9 @@ export type RouteListVisibilityItem = {
   routeMode?: string | null;
   sourceRouteIds?: number[];
   enabled: boolean;
+  kind?: string;
+  readOnly?: boolean;
+  isVirtual?: boolean;
 };
 
 function normalizeRouteMode(routeMode: string | null | undefined): 'pattern' | 'explicit_group' {
@@ -51,7 +54,7 @@ export function buildVisibleRouteList<T extends RouteListVisibilityItem>(
   return routes.filter((route) => {
     if (isExplicitGroupRoute(route)) return true;
     if (!isExactModelPattern(route.modelPattern)) return true;
-    if (!route.enabled) return true;
+    if (!route.enabled && route.kind !== 'zero_channel' && route.readOnly !== true && route.isVirtual !== true) return true;
     if (hasCustomDisplayName(route)) return true;
 
     const exactModel = (route.modelPattern || '').trim();

--- a/src/web/pages/helpers/routeListVisibility.ts
+++ b/src/web/pages/helpers/routeListVisibility.ts
@@ -28,6 +28,16 @@ export function buildVisibleRouteList<T extends RouteListVisibilityItem>(
   isExactModelPattern: (pattern: string) => boolean,
   matchesModelPattern: (model: string, pattern: string) => boolean,
 ): T[] {
+  const exactModelNames = new Set(
+    routes
+      .filter((route) => (
+        !isExplicitGroupRoute(route)
+        && isExactModelPattern(route.modelPattern)
+        && !!(route.displayName || '').trim()
+      ))
+      .map((route) => (route.modelPattern || '').trim().toLowerCase())
+      .filter(Boolean),
+  );
   const coveringGroups = routes.filter((route) => (
     route.enabled
     && (
@@ -48,7 +58,8 @@ export function buildVisibleRouteList<T extends RouteListVisibilityItem>(
 
     return !coveringGroups.some((groupRoute) => {
       if (groupRoute.id === route.id) return false;
-      if (!((groupRoute.displayName || '').trim())) return false;
+      const groupDisplayName = (groupRoute.displayName || '').trim();
+      if (!groupDisplayName || exactModelNames.has(groupDisplayName.toLowerCase())) return false;
       if (isExplicitGroupRoute(groupRoute)) {
         return (groupRoute.sourceRouteIds || []).includes(route.id);
       }


### PR DESCRIPTION
### 摘要

- 新增路由通道同步服务，统一重建自定义群组的自动派生通道
- 在自动重建、精确路由增删启停、精确路由通道增删改后同步更新匹配的群组
- 已匹配群组的路由通道，将自动从路由面板中隐藏，仅在该群组内展示（大部分人应该都用群组来聚合路由，这是该项目主要特色，因此优化路由展示逻辑，避免上游数量较多时路由UI过于臃肿。路由后端调度策略未做修改）

### 测试

- npm test -- src/server/routes/api/tokens.route-update-rebuild.test.ts
- npm test -- src/server/services/modelService.test.ts

### Summary

- Added a new service module: patternRouteChannelSyncService.ts
- Updated token route API logic in tokens.ts to:
  - trigger pattern-group channel rebuilds when exact source routes or channels change
  - handle exact pattern route updates and deletions more consistently
  - centralize rebuild behavior through `rebuildAllPatternRouteChannels()` and related helpers
- Expanded tests in:
  - tokens.route-update-rebuild.test.ts
    - added coverage for syncing pattern-group channels when exact source route channels are changed, deleted, re-added, updated, or when exact routes are disabled
    - added coverage for removing exact source channels from pattern groups when an exact route is deleted
  - modelService.test.ts
    - added cases for automatic rebuilds removing stale pattern-group channels and adding matching pattern-group channels during exact route topology changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Pattern-group routes now automatically synchronize derived channels after route or channel changes.
- OAuth-backed channel associations are preserved during synchronization.
- Added manual multi-architecture container image publishing for amd64, arm64, and armv7.

## Bug Fixes
- Removed stale derived channels after source route updates or deletions.
- Preserved manually created pattern-group channels during automatic refreshes.
- Improved route list visibility so only appropriate covering group routes appear.

## Tests
- Expanded coverage for synchronization, route visibility, and selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->