### PR TITLE
fix: preserve Codex additional_tools in Responses API conversion

### DIFF
--- a/src/server/transformers/openai/responses/conversion.ts
+++ b/src/server/transformers/openai/responses/conversion.ts
@@ -994,6 +994,7 @@ export function convertResponsesBodyToOpenAiBody(
     });
   };
 
+  const collectedAdditionalTools: Array<Record<string, unknown>> = [];
   const processInputItem = (item: unknown) => {
     if (typeof item === 'string') {
       flushPendingToolCalls();
@@ -1005,6 +1006,30 @@ export function convertResponsesBodyToOpenAiBody(
     if (!isRecord(item)) return;
 
     const itemType = asTrimmedString(item.type).toLowerCase();
+    if (itemType === 'additional_tools' && Array.isArray(item.tools)) {
+      for (const t of item.tools) {
+        if (!isRecord(t)) continue;
+        const fnType = asTrimmedString(t.type).toLowerCase();
+        if (fnType === 'function') {
+          const fn: Record<string, unknown> = { name: asTrimmedString(t.name) };
+          if (t.description) fn.description = t.description;
+          if (t.parameters !== undefined) fn.parameters = t.parameters;
+          if (t.strict !== undefined) fn.strict = t.strict;
+          collectedAdditionalTools.push({ type: 'function', function: fn });
+        } else if (fnType === 'namespace' && Array.isArray(t.tools)) {
+          for (const nt of t.tools) {
+            if (!isRecord(nt)) continue;
+            if (asTrimmedString(nt.type).toLowerCase() !== 'function') continue;
+            const fn: Record<string, unknown> = { name: asTrimmedString(nt.name) };
+            if (nt.description) fn.description = nt.description;
+            if (nt.parameters !== undefined) fn.parameters = nt.parameters;
+            if (nt.strict !== undefined) fn.strict = nt.strict;
+            collectedAdditionalTools.push({ type: 'function', function: fn });
+          }
+        }
+      }
+      return;
+    }
     if (itemType.startsWith('mcp_') && isResponsesMcpItem(item)) {
       const toolCall = toResponsesMcpCompatToolCall(item, `call_${Date.now()}_${functionCallIndex}`);
       if (toolCall) {
@@ -1110,6 +1135,11 @@ export function convertResponsesBodyToOpenAiBody(
   if (normalizedBody.audio !== undefined) payload.audio = cloneJsonValue(normalizedBody.audio);
   if (normalizedBody.parallel_tool_calls !== undefined) payload.parallel_tool_calls = normalizedBody.parallel_tool_calls;
   if (normalizedBody.tools !== undefined) payload.tools = convertResponsesToolsToOpenAi(normalizedBody.tools);
+  if (collectedAdditionalTools.length > 0) {
+    payload.tools = Array.isArray(payload.tools)
+      ? [...payload.tools as unknown[], ...collectedAdditionalTools]
+      : collectedAdditionalTools;
+  }
   if (normalizedBody.tool_choice !== undefined) payload.tool_choice = convertResponsesToolChoiceToOpenAi(normalizedBody.tool_choice);
   if (Array.isArray(payload.tools) && payload.tools.length === 0) {
     delete payload.tool_choice;

--- a/src/server/transformers/openai/responses/normalization.ts
+++ b/src/server/transformers/openai/responses/normalization.ts
@@ -239,6 +239,7 @@ function sanitizeResponsesInputToolLifecycle(items: unknown[]): unknown[] {
 
 export function normalizeResponsesMessageItem(item: Record<string, unknown>): Record<string, unknown> {
   const type = asTrimmedString(item.type).toLowerCase();
+  if (type === 'additional_tools') return item;
   if (RESPONSES_TOOL_CALL_ITEM_TYPES.has(type) || RESPONSES_TOOL_OUTPUT_ITEM_TYPES.has(type)) {
     return normalizeResponsesToolLifecycleItem(item) ?? item;
   }


### PR DESCRIPTION
## Problem

Codex 0.144+ sends tool definitions as `type: 'additional_tools'` items inside the `input[]` array (not at the top-level `tools` field). These tools use custom types like `function`, `custom` (exec), and `namespace`.

When Codex connects through Metapi, **all tool calls fail** — the model reports it has no tools available. Direct connection to the upstream (bypassing Metapi) works fine.

## Root Cause

Two bugs caused tool definitions to be silently dropped:

1. **`normalizeResponsesMessageItem()`** — saw the `role: developer` field on `additional_tools` items and force-converted them to `type: 'message'`, destroying the tool definitions. This affected `/v1/responses` passthrough.

2. **`convertResponsesBodyToOpenAiBody`'s `processInputItem()`** — had no handler for `additional_tools`, so they fell through to the generic message branch where tools were silently dropped. This affected the `/v1/chat/completions` fallback path.

## Fix

### `normalization.ts`
Add early-return for `additional_tools` items so they pass through unchanged during normalization:
```ts
if (type === 'additional_tools') return item;
```

### `conversion.ts`
- Add a handler in `processInputItem()` that extracts `function` and `namespace`-nested tools from `additional_tools` items into a `collectedAdditionalTools` array
- Merge `collectedAdditionalTools` into `payload.tools` when building the final Chat Completions payload

## Verification

Tested with Codex 0.144.1 through Metapi (upstream: New API gateway):
- ✅ `exec` tool (shell command execution)
- ✅ `apply_patch` tool (file creation/editing)
- ✅ Multi-turn tool calls (create file → read back → verify)
- ✅ Directory listing via exec

Before the fix, all of the above returned "I can't invoke the exec tool because it isn't available in this session."

## Changes

- `src/server/transformers/openai/responses/normalization.ts` (+1 line)
- `src/server/transformers/openai/responses/conversion.ts` (+30 lines)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for providing additional tools in Responses API input.
  * Supports nested tool groups and includes function-based tools in processing.
* **Bug Fixes**
  * Preserved additional tool entries without applying standard message normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->