### PR TITLE
feat(chart): 支持通过 existingSecret 引用已有 Secret

### DIFF
--- a/deploy/k3s/chart/templates/_helpers.tpl
+++ b/deploy/k3s/chart/templates/_helpers.tpl
@@ -19,6 +19,20 @@
 {{- printf "%s-env" (include "metapi.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{/*
+Effective Secret name sourced by envFrom.
+When .Values.existingSecret is set the chart does not create its own Secret and
+the Deployment references the operator-supplied one; otherwise the chart-managed
+helper name is used.
+*/}}
+{{- define "metapi.envSecretRefName" -}}
+{{- if .Values.existingSecret -}}
+{{- .Values.existingSecret -}}
+{{- else -}}
+{{- include "metapi.envSecretName" . -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "metapi.labels" -}}
 app.kubernetes.io/name: {{ include "metapi.name" . }}
 helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/deploy/k3s/chart/templates/deployment.yaml
+++ b/deploy/k3s/chart/templates/deployment.yaml
@@ -27,7 +27,9 @@ spec:
       annotations:
         metapi/image-tag: {{ .Values.image.tag | quote }}
         metapi/image-digest: {{ .Values.image.digest | quote }}
+        {{- if not .Values.existingSecret }}
         checksum/env-secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum | quote }}
+        {{- end }}
     spec:
       containers:
         - name: metapi
@@ -35,7 +37,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           envFrom:
             - secretRef:
-                name: {{ include "metapi.envSecretName" . }}
+                name: {{ include "metapi.envSecretRefName" . }}
           ports:
             - name: http
               containerPort: 4000

--- a/deploy/k3s/chart/templates/secret.yaml
+++ b/deploy/k3s/chart/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.existingSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -21,3 +22,4 @@ stringData:
   CHECKIN_CRON: {{ .Values.env.checkinCron | quote }}
   BALANCE_REFRESH_CRON: {{ .Values.env.balanceRefreshCron | quote }}
   DEPLOY_HELPER_TOKEN: {{ .Values.env.deployHelperToken | quote }}
+{{- end -}}

--- a/deploy/k3s/chart/values.yaml
+++ b/deploy/k3s/chart/values.yaml
@@ -31,3 +31,5 @@ env:
   checkinCron: "0 8 * * *"
   balanceRefreshCron: "0 * * * *"
   deployHelperToken: ""
+
+existingSecret: ""

--- a/docs/k3s-update-center.md
+++ b/docs/k3s-update-center.md
@@ -272,7 +272,51 @@ helm template metapi /opt/metapi-k3s/chart \
 
 那说明这份 chart 还是 tag 语义，先不要继续配置更新中心。
 
-### 2. 让主 Metapi 和 helper 用同一个 token
+### 1.2 自带 chart 的 Secret：自建 vs 引用已有 Secret
+
+仓库自带的 `deploy/k3s/chart` 默认行为是：chart 自己创建一个名为 `<release>-env` 的 Secret，把 `values.yaml` 里的 `env.*` 写进去，Deployment 再通过 `envFrom` 引用它。
+
+但很多自托管 K3s 场景下，运维方已经有自己的密钥交付方式（External Secrets、Sealed Secrets、GitOps 等），并不想把敏感值写进 `values.yaml`。这时可以设置：
+
+```yaml
+existingSecret: "ops-metapi-env"
+```
+
+`existingSecret` 非空时：
+
+- chart **不再创建自带 Secret**，Deployment 的 `envFrom` 改为引用你指定的 Secret 名称。
+- `values.yaml` 里的 `env.*` **被忽略**，且其 `required` 校验会被跳过——即使 `env.*` 为空也不会报错。(共存时也会静默忽略 `env.*`，chart 不报冲突。)
+- 你引用的那个外部 Secret 必须提供**完整固定的 11 个键**，chart 不做逐键映射，仍用 `envFrom` 整体注入：
+  - `AUTH_TOKEN`、`PROXY_TOKEN`、`DB_TYPE`、`DB_URL`、`DB_SSL`、`DATA_DIR`、`PORT`、`TZ`、`CHECKIN_CRON`、`BALANCE_REFRESH_CRON`、`DEPLOY_HELPER_TOKEN`
+
+> [!IMPORTANT]
+> 启用 `existingSecret` 后，chart **不会在 Secret 内容变化时自动滚动 Pod**。
+>
+> 这是因为自建 Secret 模式下，chart 会在 Pod 模板上实时写入一个 `checksum/env-secret` 注解（对 Secret 内容取哈希），Secret 一变、注解一变、Deployment 就会自动滚动。而 `existingSecret` 模式下 chart 不接触该 Secret 内容，自然无法算哈希，这个注解会被省略。
+>
+> 所以你的外部 Secret 轮换后，需要自行触发滚动——例如：
+>
+> - 用 [Reloader](https://github.com/stakater/Reloader) 之类的机制监听 Secret 变化自动滚动；或
+> - 手动 `kubectl rollout restart deployment/<release> -n <namespace>`。
+>
+> 否则会出现「Secret 已经更新，但 Pod 还在用旧值」的静默不一致，更新中心也不会察觉。
+
+`existingSecret` 留空（默认）时，行为与上一节一致，完全向后兼容——chart 自建 `<release>-env` 并写入 `checksum/env-secret` 注解，Secret 变更会自动滚动 Pod。
+
+你可以在接入前先跑一次自检，确认两种模式各自的渲染产物符合预期：
+
+```bash
+# 自建 Secret 模式（默认）：Secret 资源存在，checksum 注解存在，envFrom 指向 <release>-env
+helm template metapi /opt/metapi-k3s/chart \
+  --set env.authToken=demo --set env.proxyToken=demo --set env.dbType=sqlite \
+  | grep -nE 'checksum/env-secret|secretRef|kind: Secret'
+
+# existingSecret 模式：无 Secret 资源、无 checksum 注解，envFrom 指向 ops-metapi-env
+helm template metapi /opt/metapi-k3s/chart --set existingSecret=ops-metapi-env \
+  | grep -nE 'checksum/env-secret|secretRef|kind: Secret|ops-metapi-env'
+```
+
+
 
 主 Metapi 端支持这两个环境变量，设置一个即可：
 

--- a/src/server/update-helper/k3sAssets.test.ts
+++ b/src/server/update-helper/k3sAssets.test.ts
@@ -42,7 +42,11 @@ describe('k3s deploy assets', () => {
     expect(normalizedServiceTemplate).toContain('{{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) .Values.service.nodePort }}');
     expect(helpersTemplate).toContain('define "metapi.envSecretName"');
     expect(helpersTemplate).toContain('printf "%s-env"');
-    expect(deploymentTemplate).toContain('include "metapi.envSecretName"');
+    // envFrom resolves the chart-managed Secret name unless existingSecret is set,
+    // in which case the operator-supplied Secret is referenced instead.
+    expect(helpersTemplate).toContain('define "metapi.envSecretRefName"');
+    expect(helpersTemplate).toContain('.Values.existingSecret');
+    expect(deploymentTemplate).toContain('include "metapi.envSecretRefName"');
     expect(readRepoFile('deploy/k3s/chart/templates/secret.yaml')).toContain('include "metapi.envSecretName"');
   });
 


### PR DESCRIPTION
## 背景

对应 issue:#595

当前 `deploy/k3s/chart` 总是自行创建一个 Secret,并由 Deployment 通过 `envFrom` 引用它。对于自托管 k3s 场景,运维方往往已有自己的 Secret 交付方式(External Secrets、Sealed Secrets、GitOps 等),被迫把敏感值写进 `values.yaml` / Helm values 并不理想。本 PR 新增 `existingSecret` 值,允许引用集群中已存在的 Secret,而不再由 chart 生成。

## 设计要点

- 新增值 `existingSecret: ""`(无注释,沿用 `values.yaml` 现有裸值风格)。
- `existingSecret` 非空 → 不渲染 `templates/secret.yaml`,Deployment 的 `envFrom.secretRef.name` 指向该名称。
- `existingSecret` 为空 → 行为不变:chart 创建 `<release-fullname>-env` 并引用它(完全向后兼容)。
- `existingSecret` 已设时,`.Values.env.*` 被忽略,其 `required` 校验**被跳过**(因 `secret.yaml` 整文件条件性不渲染,校验位于其内自然不执行);若 `existingSecret` 与 `env.*` 同时存在,chart 不报错(不做冲突检测)。
- 外部 Secret 须提供完整固定键集(AUTH_TOKEN、PROXY_TOKEN、DB_TYPE、DB_URL、DB_SSL、DATA_DIR、PORT、TZ、CHECKIN_CRON、BALANCE_REFRESH_CRON、DEPLOY_HELPER_TOKEN)。不做逐键映射,仍用 `envFrom`,不引入 per-key `secretKeyRef`。
- chart **不在安装时** `lookup`/校验外部 Secret;缺失或缺键时由 Pod 启动失败、Kubernetes 上报——保持 `helm template` / dry-run / GitOps 渲染可离线进行,也不要求 Helm 身份持有 Secret 读权限。
- `checksum/env-secret` 注解**仅在 chart 自建 Secret 时渲染**;使用 `existingSecret` 时省略,chart 不承诺外部 Secret 内容变化时滚动 Pod,由运维方(或 Reloader 等机制)触发。
- 不新增 NOTES.txt / README / 示例清单,文档面保持与当前 chart 一致。

## 变更范围

4 个文件,+21/-1:
- `deploy/k3s/chart/values.yaml`:新增 `existingSecret: ""`。
- `deploy/k3s/chart/templates/_helpers.tpl`:新增 `metapi.envSecretRefName` helper(单一真值:返回 `existingSecret`,否则回退 chart 自建名)。
- `deploy/k3s/chart/templates/secret.yaml`:整文件包在 `{{- if not .Values.existingSecret -}}` / `{{- end -}}` 内。
- `deploy/k3s/chart/templates/deployment.yaml`:`envFrom.secretRef.name` 改用 `metapi.envSecretRefName`;`checksum/env-secret` 注解外包 `{{- if not .Values.existingSecret }}` / `{{- end }}`。

## 验证

用 `helm template` 在两种模式下各渲染一次:
- 未设 `existingSecret` + 提供 `env.*`:Secret 正常渲染,`checksum/env-secret` 存在,`envFrom` 指向 `<release>-env`,缺失 `authToken` 时按原信息报错(回归安全)。
- `existingSecret=ops-metapi-env`:无 Secret 资源、无 checksum 注解,`envFrom` 指向 `ops-metapi-env`,即使 `env.*` 为空也不触发 `required` 校验。

## 与 issue #595 验收标准的对应

- [x] `values.yaml` 新增 `existingSecret: ""`(无注释,裸值风格)
- [x] `existingSecret` 非空时 `secret.yaml` 不渲染
- [x] `existingSecret` 非空时 `.Values.env.*` 的 `required` 校验被跳过,且共存不报错
- [x] `existingSecret` 非空时 Deployment 的 `envFrom.secretRef.name` 指向所供名称
- [x] `checksum/env-secret` 注解仅在 chart 自建 Secret 时渲染
- [x] `existingSecret` 为空时行为与当前 chart 一致(回归安全)
- [x] `helm template` 在两种模式下均干净渲染

遵循 `CONTRIBUTING.md`:使用 `feat:` 约定式提交前缀,PR 聚焦单一功能,未引入运行时数据/文档文件。

Closes #595

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for using an existing Kubernetes Secret for environment configuration.
  * Added a configuration value to indicate the existing Secret to reference.
* **Bug Fixes**
  * Avoided creating the managed environment Secret when an existing Secret is configured.
  * Updated Pod behavior so environment variables come from the referenced Secret and automatic rollout-on-Self-mananged Secret rotation is disabled in this mode.
* **Documentation**
  * Documented the differences between chart-managed Secret vs referencing an existing Secret, including rollout implications.
* **Tests**
  * Updated asset/deployment templating assertions to match the new Secret-selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->