### PR TITLE
fix(docker): forward every variable declared in docker/.env.example

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -10,12 +10,19 @@ PROXY_TOKEN=change-me-proxy-sk-token
 PORT=4000
 NOTIFY_COOLDOWN_SEC=300
 ADMIN_IP_ALLOWLIST=
+SYSTEM_PROXY_URL=
 TELEGRAM_ENABLED=false
 TELEGRAM_BOT_TOKEN=
 TELEGRAM_CHAT_ID=
+TELEGRAM_API_BASE_URL=
+TELEGRAM_MESSAGE_THREAD_ID=
+TELEGRAM_USE_SYSTEM_PROXY=false
 
 # Auto check-in cron (default: 8:00 AM every day)
 CHECKIN_CRON=0 8 * * *
 
 # Balance refresh cron (default: every hour)
 BALANCE_REFRESH_CRON=0 * * * *
+
+# Container timezone
+TZ=Asia/Shanghai

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,15 +2,24 @@ services:
   metapi:
     image: 1467078763/metapi:latest
     ports:
-      - "127.0.0.1:4000:4000"
+      - "127.0.0.1:${PORT:-4000}:${PORT:-4000}"
     volumes:
       - ./data:/app/data
     environment:
       AUTH_TOKEN: ${AUTH_TOKEN:?AUTH_TOKEN is required}
       PROXY_TOKEN: ${PROXY_TOKEN:?PROXY_TOKEN is required}
-      CHECKIN_CRON: "0 8 * * *"
-      BALANCE_REFRESH_CRON: "0 * * * *"
+      CHECKIN_CRON: "${CHECKIN_CRON:-0 8 * * *}"
+      BALANCE_REFRESH_CRON: "${BALANCE_REFRESH_CRON:-0 * * * *}"
       PORT: ${PORT:-4000}
       DATA_DIR: /app/data
       TZ: ${TZ:-Asia/Shanghai}
+      NOTIFY_COOLDOWN_SEC: ${NOTIFY_COOLDOWN_SEC:-300}
+      ADMIN_IP_ALLOWLIST: "${ADMIN_IP_ALLOWLIST:-}"
+      SYSTEM_PROXY_URL: "${SYSTEM_PROXY_URL:-}"
+      TELEGRAM_ENABLED: ${TELEGRAM_ENABLED:-false}
+      TELEGRAM_BOT_TOKEN: "${TELEGRAM_BOT_TOKEN:-}"
+      TELEGRAM_CHAT_ID: "${TELEGRAM_CHAT_ID:-}"
+      TELEGRAM_API_BASE_URL: "${TELEGRAM_API_BASE_URL:-}"
+      TELEGRAM_MESSAGE_THREAD_ID: "${TELEGRAM_MESSAGE_THREAD_ID:-}"
+      TELEGRAM_USE_SYSTEM_PROXY: ${TELEGRAM_USE_SYSTEM_PROXY:-false}
     restart: unless-stopped


### PR DESCRIPTION
## Problem

`docker/docker-compose.yml` forwards only 7 variables to the container, but `docker/.env.example` tells Compose users to set more than that. The variables it declares but never forwards are silently inert: a user follows the example file, sets a value, restarts, and nothing changes.

This was surfaced during review of #601 (Telegram `TELEGRAM_*` variables specifically). Looking at the whole `environment` block, the gap is wider than Telegram, and there are two distinct failure modes.

**1. Declared in `docker/.env.example`, never forwarded — value is ignored**

- `NOTIFY_COOLDOWN_SEC`
- `ADMIN_IP_ALLOWLIST`
- `TELEGRAM_ENABLED`
- `TELEGRAM_BOT_TOKEN`
- `TELEGRAM_CHAT_ID`

All five are real `buildConfig()` keys (`src/server/config.ts`), so they work fine for bare-metal `.env` users — only Compose users are affected.

**2. Forwarded, but hardcoded so the `.env` value is overridden**

```yaml
CHECKIN_CRON: "0 8 * * *"
BALANCE_REFRESH_CRON: "0 * * * *"
```

`docker/.env.example` ends with:

```
# Auto check-in cron (default: 8:00 AM every day)
CHECKIN_CRON=0 8 * * *

# Balance refresh cron (default: every hour)
BALANCE_REFRESH_CRON=0 * * * *
```

Because the compose value is a literal rather than an interpolation, editing either of these in `.env` has no effect. This one is the most misleading of the set — the example file exists specifically to be edited, and these two lines carry explanatory comments inviting the user to change them.

## Change

One invariant: **every variable declared in `docker/.env.example` reaches the container, and the declared value is the one that wins.**

`docker/docker-compose.yml`:
- un-hardcode `CHECKIN_CRON` / `BALANCE_REFRESH_CRON` to `${VAR:-<same default>}`
- forward `NOTIFY_COOLDOWN_SEC`, `ADMIN_IP_ALLOWLIST`
- forward the full `TELEGRAM_*` set: `ENABLED`, `BOT_TOKEN`, `CHAT_ID`, `API_BASE_URL`, `MESSAGE_THREAD_ID`, `USE_SYSTEM_PROXY`
- forward `SYSTEM_PROXY_URL`, since `TELEGRAM_USE_SYSTEM_PROXY: true` is inert without it (`notifyService.ts:275` reads `config.systemProxyUrl` only when that flag is set)

`docker/.env.example`:
- add the three missing `TELEGRAM_*` keys, `SYSTEM_PROXY_URL`, and `TZ` (`TZ` was already forwarded but undocumented)

Every default is byte-identical to what compose produced before, so an existing `.env` that only sets `AUTH_TOKEN` / `PROXY_TOKEN` renders exactly the same config as on `main`. The `:?required` guards on both tokens are untouched.

### One adjacent fix, flagged explicitly

The port mapping was `"127.0.0.1:4000:4000"` with `PORT: ${PORT:-4000}` forwarded — so setting `PORT=5000` made the app listen on 5000 inside the container while the host still published 4000, breaking access. Changed to `"127.0.0.1:${PORT:-4000}:${PORT:-4000}"`.

This is a host-vs-container concern rather than env forwarding, so it's arguably a separate issue. I've included it because it's the same "declared value is ignored" family in the same block and it's one line. Happy to split it out if you'd rather keep this PR to the `environment` mapping alone.

## Design note

`docs/configuration.md` is clear that notification channels are primarily UI-configured (`系统 → 通知设置`), and DB-hydrated settings still take precedence via `runtimeSettingsHydration.ts` — this change doesn't touch that ordering. The env path matters for IaC-style deployments where the container should come up already configured, and for parity with the root `.env.example`. Given `docker/.env.example` already advertised three of these keys, making them functional seemed more consistent than removing them.

## Verification

Validated locally with `docker compose config` (Compose v2) against a scratch dir:

- **defaults** — with only `AUTH_TOKEN` / `PROXY_TOKEN` set, all resolved values match `main`'s output exactly
- **overrides** — `PORT=5000`, `CHECKIN_CRON=30 6 * * *`, `BALANCE_REFRESH_CRON=*/15 * * * *`, `NOTIFY_COOLDOWN_SEC=60`, `ADMIN_IP_ALLOWLIST=10.0.0.1,10.0.0.2`, `SYSTEM_PROXY_URL=http://127.0.0.1:7890`, and the full `TELEGRAM_*` set all appear in the rendered config; ports render `127.0.0.1:5000 -> 5000`
- **guard** — unsetting `AUTH_TOKEN` still fails with `required variable AUTH_TOKEN is missing a value`, same as `main`
- **special characters** — `TELEGRAM_BOT_TOKEN=123456:abcdef` (colon) and `TELEGRAM_CHAT_ID=@mychan` (leading `@`) survive interpolation intact; string-valued vars are quoted for this reason

No application code changed, so no test suite impact.

## Relationship to #601

`TELEGRAM_API_BASE_URL` is only read by `buildConfig()` after #601 merges. Forwarding it here is harmless in the meantime (compose passes it through; current `config.ts` on `main` ignores it), but this PR is best merged after #601 so the variable is live the moment it appears in the example file. No file overlap between the two branches — happy to reorder or rebase if you'd prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable container timezone, port, proxy settings, and Telegram API options.
  * Added environment-variable controls for scheduled tasks, notification cooldowns, and administrator IP allowlisting.
  * Added support for Telegram message thread configuration and optional system proxy usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->