### PR TITLE
fix: migrate star-history chart links to self-hosted star-history.dera.page

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ Metapi 完全自托管，所有数据（账号、令牌、路由、日志）均�
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=cita-777/metapi&type=date&legend=top-left&v=2)](https://www.star-history.com/#cita-777/metapi&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=cita-777/metapi&type=date&legend=top-left&v=2)](https://star-history.dera.page/#cita-777/metapi&type=date&legend=top-left)
 
 ---
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -590,7 +590,7 @@ Special thanks to all contributors:
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=cita-777/metapi&type=date&legend=top-left&v=2)](https://www.star-history.com/#cita-777/metapi&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=cita-777/metapi&type=date&legend=top-left&v=2)](https://star-history.dera.page/#cita-777/metapi&type=date&legend=top-left)
 
 ---
 


### PR DESCRIPTION
The current star history chart is broken because GitHub's stargazer API was restricted. This migrates the chart image and links in README.md and README_EN.md to the self-hosted star-history.dera.page domain (no API subdomain, /svg endpoint kept, hash-based link URLs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Star History chart links in the README files to use the new hosting address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->