### PR TITLE
fix: use the user id returned by login instead of guessing it

### DIFF
--- a/src/server/routes/api/accounts.ts
+++ b/src/server/routes/api/accounts.ts
@@ -11,12 +11,12 @@ import {
 import {
   getCredentialModeFromExtraConfig,
   getProxyUrlFromExtraConfig,
-  guessPlatformUserIdFromUsername,
   hasOauthProvider,
   getSub2ApiAuthFromExtraConfig,
   mergeAccountExtraConfig,
   normalizeCredentialMode as normalizeCredentialModeInput,
   resolvePlatformUserId,
+  resolvePlatformUserIdFromLogin,
   type AccountCredentialMode,
 } from "../../services/accountExtraConfig.js";
 import { encryptAccountPassword } from "../../services/accountCredentialService.js";
@@ -538,8 +538,10 @@ export async function accountsRoutes(app: FastifyInstance) {
       // The id reported by the site itself is authoritative; guessing from the
       // username only works when it ends with the id (e.g. `linuxdo_80305`)
       // and silently fails for addresses like `alice@example.com`.
-      const guessedPlatformUserId =
-        loginResult.platformUserId || guessPlatformUserIdFromUsername(username);
+      const guessedPlatformUserId = resolvePlatformUserIdFromLogin(
+        loginResult.platformUserId,
+        username,
+      );
 
       // Auto-fetch API token(s)
       let apiToken: string | null = null;

--- a/src/server/routes/api/accounts.ts
+++ b/src/server/routes/api/accounts.ts
@@ -535,7 +535,11 @@ export async function accountsRoutes(app: FastifyInstance) {
         };
       }
 
-      const guessedPlatformUserId = guessPlatformUserIdFromUsername(username);
+      // The id reported by the site itself is authoritative; guessing from the
+      // username only works when it ends with the id (e.g. `linuxdo_80305`)
+      // and silently fails for addresses like `alice@example.com`.
+      const guessedPlatformUserId =
+        loginResult.platformUserId || guessPlatformUserIdFromUsername(username);
 
       // Auto-fetch API token(s)
       let apiToken: string | null = null;

--- a/src/server/services/accountExtraConfig.test.ts
+++ b/src/server/services/accountExtraConfig.test.ts
@@ -13,6 +13,7 @@ import {
   mergeAccountExtraConfig,
   normalizeCredentialMode,
   resolvePlatformUserId,
+  resolvePlatformUserIdFromLogin,
   requiresManagedAccountTokens,
   supportsDirectAccountRoutingConnection,
 } from './accountExtraConfig.js';
@@ -34,6 +35,11 @@ describe('accountExtraConfig', () => {
 
   it('prefers configured user id over guessed user id', () => {
     expect(resolvePlatformUserId(JSON.stringify({ platformUserId: 5001 }), 'linuxdo_7659')).toBe(5001);
+  });
+
+  it('prefers the login-reported user id over the username fallback', () => {
+    expect(resolvePlatformUserIdFromLogin(500123, 'alice_1999')).toBe(500123);
+    expect(resolvePlatformUserIdFromLogin(undefined, 'alice_1999')).toBe(1999);
   });
 
   it('merges platformUserId into existing config without dropping keys', () => {

--- a/src/server/services/accountExtraConfig.ts
+++ b/src/server/services/accountExtraConfig.ts
@@ -345,6 +345,20 @@ export function resolvePlatformUserId(extraConfig?: ExtraConfigInput, username?:
   return getPlatformUserIdFromExtraConfig(extraConfig) || guessPlatformUserIdFromUsername(username);
 }
 
+/**
+ * Resolve the platform identity returned by a login, with the legacy username
+ * suffix guess retained only as a compatibility fallback.
+ *
+ * Keeping this policy in the account service layer prevents HTTP route adapters
+ * from encoding platform-specific identity rules themselves.
+ */
+export function resolvePlatformUserIdFromLogin(
+  reportedPlatformUserId: number | undefined,
+  username?: string | null,
+): number | undefined {
+  return normalizeUserId(reportedPlatformUserId) || guessPlatformUserIdFromUsername(username);
+}
+
 export function mergeAccountExtraConfig(
   extraConfig: ExtraConfigInput,
   patch: Record<string, unknown>,

--- a/src/server/services/balanceService.autoRelogin.test.ts
+++ b/src/server/services/balanceService.autoRelogin.test.ts
@@ -147,7 +147,7 @@ describe('balanceService auto relogin', () => {
     expect(reportTokenExpiredMock).not.toHaveBeenCalled();
   });
 
-  it('preserves account configuration updated while auto relogin is in flight', async () => {
+  it('does not replay the relogin config snapshot after the balance retry', async () => {
     const autoRelogin = { username: 'alice@example.com', passwordCipher: 'cipher' };
     let currentExtraConfig = JSON.stringify({
       autoRelogin,
@@ -174,12 +174,19 @@ describe('balanceService auto relogin', () => {
 
     adapterMock.getBalance
       .mockRejectedValueOnce(new Error('HTTP 401: access token required'))
-      .mockResolvedValueOnce({ balance: 12, used: 1, quota: 13 });
+      .mockImplementationOnce(async () => {
+        currentExtraConfig = JSON.stringify({
+          autoRelogin,
+          platformUserId: 500123,
+          proxyUrl: 'http://changed-during-retry.example',
+        });
+        return { balance: 12, used: 1, quota: 13 };
+      });
     decryptPasswordMock.mockReturnValue('plain-password');
     adapterMock.login.mockImplementation(async () => {
       currentExtraConfig = JSON.stringify({
         autoRelogin,
-        proxyUrl: 'http://new-proxy.example',
+        proxyUrl: 'http://changed-during-login.example',
       });
       return {
         success: true,
@@ -192,18 +199,83 @@ describe('balanceService auto relogin', () => {
     await refreshBalance(14);
 
     expect(selectGetMock).toHaveBeenCalledTimes(1);
-    const writtenConfigs = updateSetMock.mock.calls
-      .map((call) => call[0]?.extraConfig)
-      .filter((value): value is string => typeof value === 'string')
-      .map((value) => JSON.parse(value) as Record<string, unknown>);
-    expect(writtenConfigs.length).toBeGreaterThan(0);
-    for (const config of writtenConfigs) {
-      expect(config).toMatchObject({
-        autoRelogin,
-        platformUserId: 500123,
-        proxyUrl: 'http://new-proxy.example',
+    const reloginWrite = updateSetMock.mock.calls
+      .map((call) => call[0] as Record<string, unknown>)
+      .find((payload) => payload.accessToken === 'fresh-token');
+    expect(JSON.parse(String(reloginWrite?.extraConfig))).toMatchObject({
+      autoRelogin,
+      platformUserId: 500123,
+      proxyUrl: 'http://changed-during-login.example',
+    });
+
+    const finalBalanceWrite = updateSetMock.mock.calls
+      .map((call) => call[0] as Record<string, unknown>)
+      .find((payload) => payload.balance === 12);
+    expect(finalBalanceWrite?.extraConfig).toBeUndefined();
+  });
+
+  it('merges final balance metadata into configuration changed during the retry', async () => {
+    const autoRelogin = { username: 'alice@example.com', passwordCipher: 'cipher' };
+    let currentExtraConfig = JSON.stringify({
+      autoRelogin,
+      proxyUrl: 'http://old-proxy.example',
+    });
+    selectAllMock.mockReturnValue([
+      {
+        accounts: {
+          id: 16,
+          username: 'alice@example.com',
+          accessToken: 'stale-token',
+          status: 'active',
+          extraConfig: currentExtraConfig,
+        },
+        sites: {
+          id: 16,
+          name: 'concurrent-settings-with-income',
+          url: 'https://example.com',
+          platform: 'new-api',
+        },
+      },
+    ]);
+    selectGetMock.mockImplementation(() => ({ extraConfig: currentExtraConfig }));
+
+    adapterMock.getBalance
+      .mockRejectedValueOnce(new Error('HTTP 401: access token required'))
+      .mockImplementationOnce(async () => {
+        currentExtraConfig = JSON.stringify({
+          autoRelogin,
+          platformUserId: 500123,
+          proxyUrl: 'http://changed-during-retry.example',
+        });
+        return { balance: 12, used: 1, quota: 13, todayIncome: 2.5 };
       });
-    }
+    decryptPasswordMock.mockReturnValue('plain-password');
+    adapterMock.login.mockImplementation(async () => {
+      currentExtraConfig = JSON.stringify({
+        autoRelogin,
+        proxyUrl: 'http://changed-during-login.example',
+      });
+      return {
+        success: true,
+        accessToken: 'fresh-token',
+        platformUserId: 500123,
+      };
+    });
+
+    const { refreshBalance } = await import('./balanceService.js');
+    await refreshBalance(16);
+
+    expect(selectGetMock).toHaveBeenCalledTimes(2);
+    const finalBalanceWrite = updateSetMock.mock.calls
+      .map((call) => call[0] as Record<string, unknown>)
+      .find((payload) => payload.balance === 12);
+    const finalExtraConfig = JSON.parse(String(finalBalanceWrite?.extraConfig));
+    expect(finalExtraConfig).toMatchObject({
+      autoRelogin,
+      platformUserId: 500123,
+      proxyUrl: 'http://changed-during-retry.example',
+    });
+    expect(finalExtraConfig.todayIncomeSnapshot?.latest).toBe(2.5);
   });
 
   it('reports token expired when relogin is unavailable', async () => {

--- a/src/server/services/balanceService.autoRelogin.test.ts
+++ b/src/server/services/balanceService.autoRelogin.test.ts
@@ -6,6 +6,7 @@ const adapterMock = {
 };
 
 const selectAllMock = vi.fn();
+const selectGetMock = vi.fn();
 const updateSetMock = vi.fn();
 const insertValuesMock = vi.fn();
 const reportTokenExpiredMock = vi.fn();
@@ -18,6 +19,7 @@ const undiciFetchMock = vi.fn();
 vi.mock('../db/index.js', () => {
   const selectChain = {
     all: () => selectAllMock(),
+    get: () => selectGetMock(),
     where: () => selectChain,
     innerJoin: () => selectChain,
     from: () => selectChain,
@@ -51,7 +53,7 @@ vi.mock('../db/index.js', () => {
       insert: () => insertChain,
     },
     schema: {
-      accounts: { id: 'id', siteId: 'siteId', status: 'status' },
+      accounts: { id: 'id', siteId: 'siteId', status: 'status', extraConfig: 'extraConfig' },
       sites: { id: 'id' },
       events: {},
     },
@@ -88,6 +90,7 @@ describe('balanceService auto relogin', () => {
     adapterMock.getBalance.mockReset();
     adapterMock.login.mockReset();
     selectAllMock.mockReset();
+    selectGetMock.mockReset();
     updateSetMock.mockReset();
     insertValuesMock.mockReset();
     reportTokenExpiredMock.mockReset();
@@ -142,6 +145,65 @@ describe('balanceService auto relogin', () => {
     expect(adapterMock.getBalance.mock.calls[1][1]).toBe('fresh-token');
     expect(updateSetMock.mock.calls.some((call) => call[0]?.accessToken === 'fresh-token')).toBe(true);
     expect(reportTokenExpiredMock).not.toHaveBeenCalled();
+  });
+
+  it('preserves account configuration updated while auto relogin is in flight', async () => {
+    const autoRelogin = { username: 'alice@example.com', passwordCipher: 'cipher' };
+    let currentExtraConfig = JSON.stringify({
+      autoRelogin,
+      proxyUrl: 'http://old-proxy.example',
+    });
+    selectAllMock.mockReturnValue([
+      {
+        accounts: {
+          id: 14,
+          username: 'alice@example.com',
+          accessToken: 'stale-token',
+          status: 'active',
+          extraConfig: currentExtraConfig,
+        },
+        sites: {
+          id: 14,
+          name: 'concurrent-settings',
+          url: 'https://example.com',
+          platform: 'new-api',
+        },
+      },
+    ]);
+    selectGetMock.mockImplementation(() => ({ extraConfig: currentExtraConfig }));
+
+    adapterMock.getBalance
+      .mockRejectedValueOnce(new Error('HTTP 401: access token required'))
+      .mockResolvedValueOnce({ balance: 12, used: 1, quota: 13 });
+    decryptPasswordMock.mockReturnValue('plain-password');
+    adapterMock.login.mockImplementation(async () => {
+      currentExtraConfig = JSON.stringify({
+        autoRelogin,
+        proxyUrl: 'http://new-proxy.example',
+      });
+      return {
+        success: true,
+        accessToken: 'fresh-token',
+        platformUserId: 500123,
+      };
+    });
+
+    const { refreshBalance } = await import('./balanceService.js');
+    await refreshBalance(14);
+
+    expect(selectGetMock).toHaveBeenCalledTimes(1);
+    const writtenConfigs = updateSetMock.mock.calls
+      .map((call) => call[0]?.extraConfig)
+      .filter((value): value is string => typeof value === 'string')
+      .map((value) => JSON.parse(value) as Record<string, unknown>);
+    expect(writtenConfigs.length).toBeGreaterThan(0);
+    for (const config of writtenConfigs) {
+      expect(config).toMatchObject({
+        autoRelogin,
+        platformUserId: 500123,
+        proxyUrl: 'http://new-proxy.example',
+      });
+    }
   });
 
   it('reports token expired when relogin is unavailable', async () => {

--- a/src/server/services/balanceService.ts
+++ b/src/server/services/balanceService.ts
@@ -224,9 +224,17 @@ async function tryAutoRelogin(account: any, site: any): Promise<string | null> {
   );
   if (!loginResult.success || !loginResult.accessToken) return null;
 
+  // Persist the id the site reported during re-login as well; otherwise the
+  // account keeps whatever (possibly wrong) id it had and every subsequent
+  // `/api/user/self` call has to rediscover it.
+  const reloginExtraConfig = loginResult.platformUserId
+    ? mergeAccountExtraConfig(account.extraConfig, { platformUserId: loginResult.platformUserId })
+    : undefined;
+
   await db.update(schema.accounts)
     .set({
       accessToken: loginResult.accessToken,
+      ...(reloginExtraConfig ? { extraConfig: reloginExtraConfig } : {}),
       status: account.status === 'expired' ? 'active' : account.status,
       updatedAt: new Date().toISOString(),
     })

--- a/src/server/services/balanceService.ts
+++ b/src/server/services/balanceService.ts
@@ -423,14 +423,32 @@ export async function refreshBalance(accountId: number) {
     } catch {}
   }
 
+  const hasTodayIncomeUpdate =
+    typeof balanceInfo.todayIncome === 'number' && Number.isFinite(balanceInfo.todayIncome);
+  const hasSubscriptionUpdate =
+    !!balanceInfo.subscriptionSummary && isSub2ApiPlatform(site.platform);
   let nextExtraConfig = activeExtraConfig;
-  if (typeof balanceInfo.todayIncome === 'number' && Number.isFinite(balanceInfo.todayIncome)) {
-    nextExtraConfig = updateTodayIncomeSnapshot(nextExtraConfig, balanceInfo.todayIncome);
-  }
-  if (balanceInfo.subscriptionSummary && isSub2ApiPlatform(site.platform)) {
-    nextExtraConfig = mergeAccountExtraConfig(nextExtraConfig, {
-      sub2apiSubscription: buildStoredSub2ApiSubscriptionSummary(balanceInfo.subscriptionSummary),
-    });
+  let shouldPersistNextExtraConfig = false;
+
+  if (hasTodayIncomeUpdate || hasSubscriptionUpdate) {
+    // A retried balance request or income fallback may outlive another settings
+    // update. Merge only the new balance metadata into the latest configuration
+    // instead of replaying the snapshot captured immediately after re-login.
+    const latestAccount = await db.select({ extraConfig: schema.accounts.extraConfig })
+      .from(schema.accounts)
+      .where(eq(schema.accounts.id, account.id))
+      .get();
+    nextExtraConfig = latestAccount ? latestAccount.extraConfig : activeExtraConfig;
+
+    if (hasTodayIncomeUpdate) {
+      nextExtraConfig = updateTodayIncomeSnapshot(nextExtraConfig, balanceInfo.todayIncome!);
+    }
+    if (hasSubscriptionUpdate) {
+      nextExtraConfig = mergeAccountExtraConfig(nextExtraConfig, {
+        sub2apiSubscription: buildStoredSub2ApiSubscriptionSummary(balanceInfo.subscriptionSummary!),
+      });
+    }
+    shouldPersistNextExtraConfig = true;
   }
 
   const existingRuntimeHealth = extractRuntimeHealth(nextExtraConfig);
@@ -444,7 +462,7 @@ export async function refreshBalance(accountId: number) {
     lastBalanceRefresh: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
   };
-  if (nextExtraConfig !== account.extraConfig) {
+  if (shouldPersistNextExtraConfig) {
     updates.extraConfig = nextExtraConfig;
   }
 

--- a/src/server/services/balanceService.ts
+++ b/src/server/services/balanceService.ts
@@ -208,7 +208,22 @@ async function fetchTodayIncomeFromLogs(params: {
   return Math.round(totalIncome * 1_000_000) / 1_000_000;
 }
 
-async function tryAutoRelogin(account: any, site: any): Promise<string | null> {
+/**
+ * Result of a successful automatic re-login.
+ *
+ * The access token alone is not enough: the login may also have reported the
+ * authoritative `platformUserId`. Callers need it for the retry that follows,
+ * and they need the merged `extraConfig` so their own later
+ * `mergeAccountExtraConfig(account.extraConfig, ...)` writes do not put the
+ * pre-login copy back and undo what was just persisted.
+ */
+type AutoReloginResult = {
+  accessToken: string;
+  platformUserId?: number;
+  extraConfig?: string;
+};
+
+async function tryAutoRelogin(account: any, site: any): Promise<AutoReloginResult | null> {
   const adapter = getAdapter(site.platform);
   if (!adapter) return null;
 
@@ -241,7 +256,11 @@ async function tryAutoRelogin(account: any, site: any): Promise<string | null> {
     .where(eq(schema.accounts.id, account.id))
     .run();
 
-  return loginResult.accessToken;
+  return {
+    accessToken: loginResult.accessToken,
+    platformUserId: loginResult.platformUserId,
+    extraConfig: reloginExtraConfig,
+  };
 }
 
 export async function refreshBalance(accountId: number) {
@@ -285,7 +304,7 @@ export async function refreshBalance(accountId: number) {
     };
   }
 
-  const platformUserId = resolvePlatformUserId(account.extraConfig, account.username);
+  let platformUserId = resolvePlatformUserId(account.extraConfig, account.username);
   let activeAccessToken = account.accessToken;
   let activeExtraConfig = account.extraConfig;
   let balanceInfo: BalanceInfo | null = null;
@@ -351,9 +370,16 @@ export async function refreshBalance(accountId: number) {
         await handleBalanceError(retryErr);
       }
     } else if (shouldAttemptAutoRelogin(message)) {
-      const refreshedAccessToken = await tryAutoRelogin(account, site);
-      if (refreshedAccessToken) {
-        activeAccessToken = refreshedAccessToken;
+      const relogin = await tryAutoRelogin(account, site);
+      if (relogin) {
+        activeAccessToken = relogin.accessToken;
+        // Adopt the id the re-login reported and advance activeExtraConfig.
+        // `readBalance` closes over `platformUserId`, so without this the retry
+        // still sends the stale `New-Api-User`; and `nextExtraConfig` further down
+        // starts from `activeExtraConfig`, so the pre-login copy would be written
+        // back over the id tryAutoRelogin() just persisted.
+        if (relogin.platformUserId) platformUserId = relogin.platformUserId;
+        if (relogin.extraConfig) activeExtraConfig = relogin.extraConfig;
         try {
           balanceInfo = await readBalance(activeAccessToken);
         } catch (retryErr: any) {

--- a/src/server/services/balanceService.ts
+++ b/src/server/services/balanceService.ts
@@ -239,11 +239,20 @@ async function tryAutoRelogin(account: any, site: any): Promise<AutoReloginResul
   );
   if (!loginResult.success || !loginResult.accessToken) return null;
 
-  // Persist the id the site reported during re-login as well; otherwise the
-  // account keeps whatever (possibly wrong) id it had and every subsequent
-  // `/api/user/self` call has to rediscover it.
+  // Re-read after the network request: account settings may have changed while
+  // login was in flight, and merging into the original snapshot would overwrite
+  // those newer fields when the whole extraConfig value is persisted.
+  const latestAccount = loginResult.platformUserId
+    ? await db.select({ extraConfig: schema.accounts.extraConfig })
+      .from(schema.accounts)
+      .where(eq(schema.accounts.id, account.id))
+      .get()
+    : undefined;
   const reloginExtraConfig = loginResult.platformUserId
-    ? mergeAccountExtraConfig(account.extraConfig, { platformUserId: loginResult.platformUserId })
+    ? mergeAccountExtraConfig(
+      latestAccount ? latestAccount.extraConfig : account.extraConfig,
+      { platformUserId: loginResult.platformUserId },
+    )
     : undefined;
 
   await db.update(schema.accounts)

--- a/src/server/services/checkinService.autoRelogin.test.ts
+++ b/src/server/services/checkinService.autoRelogin.test.ts
@@ -130,6 +130,58 @@ describe('checkinService auto relogin', () => {
     expect(updateSetMock).toHaveBeenCalledWith(expect.objectContaining({ accessToken: 'fresh-token' }));
   });
 
+  it('prefers the id reported by relogin over the guess, and never writes the guess back', async () => {
+    // `alice_1999` ends in digits that are not the account id — precisely the case
+    // guessPlatformUserIdFromUsername() gets wrong, since its /(\d{3,8})$/ only
+    // knows how to read a trailing number.
+    selectAllMock.mockReturnValue([
+      {
+        accounts: {
+          id: 1,
+          username: 'alice_1999',
+          accessToken: 'expired-token',
+          status: 'active',
+          extraConfig: JSON.stringify({
+            autoRelogin: { username: 'alice_1999', passwordCipher: 'cipher' },
+          }),
+        },
+        sites: {
+          id: 3,
+          name: 'kfc',
+          url: 'https://kfc-api.sxxe.net',
+          platform: 'new-api',
+        },
+      },
+    ]);
+
+    adapterMock.checkin
+      .mockResolvedValueOnce({ success: false, message: '无权进行此操作，未登录且未提供 access token' })
+      .mockResolvedValueOnce({ success: true, message: 'checked in' });
+    decryptPasswordMock.mockReturnValue('plain-password');
+    adapterMock.login.mockResolvedValue({
+      success: true,
+      accessToken: 'fresh-token',
+      platformUserId: 500123,
+    });
+
+    const { checkinAccount } = await import('./checkinService.js');
+    await checkinAccount(1);
+
+    // The first attempt has nothing better than the guess...
+    expect(adapterMock.checkin.mock.calls[0][2]).toBe(1999);
+    // ...but the retry must use the id the site itself reported.
+    expect(adapterMock.checkin.mock.calls[1][2]).toBe(500123);
+
+    // And no later write may put the guess back over it.
+    const writtenIds = updateSetMock.mock.calls
+      .map((call) => (call[0] as Record<string, unknown> | undefined)?.extraConfig)
+      .filter((cfg): cfg is string => typeof cfg === 'string')
+      .map((cfg) => (JSON.parse(cfg) as { platformUserId?: number }).platformUserId);
+    expect(writtenIds.length).toBeGreaterThan(0);
+    expect(writtenIds).toContain(500123);
+    expect(writtenIds).not.toContain(1999);
+  });
+
   it('passes guessed platform user id when config does not include it', async () => {
     selectAllMock.mockReturnValue([
       {

--- a/src/server/services/checkinService.autoRelogin.test.ts
+++ b/src/server/services/checkinService.autoRelogin.test.ts
@@ -11,12 +11,14 @@ const refreshBalanceMock = vi.fn();
 const decryptPasswordMock = vi.fn();
 
 const selectAllMock = vi.fn();
+const selectGetMock = vi.fn();
 const insertValuesMock = vi.fn();
 const updateSetMock = vi.fn();
 
 vi.mock('../db/index.js', () => {
   const selectChain = {
     all: () => selectAllMock(),
+    get: () => selectGetMock(),
     where: () => selectChain,
     innerJoin: () => selectChain,
     from: () => selectChain,
@@ -50,7 +52,7 @@ vi.mock('../db/index.js', () => {
       }),
     },
     schema: {
-      accounts: { id: 'id', siteId: 'siteId', checkinEnabled: 'checkinEnabled', status: 'status' },
+      accounts: { id: 'id', siteId: 'siteId', checkinEnabled: 'checkinEnabled', status: 'status', extraConfig: 'extraConfig' },
       sites: { id: 'id' },
       checkinLogs: {},
       events: {},
@@ -87,6 +89,7 @@ describe('checkinService auto relogin', () => {
     refreshBalanceMock.mockReset();
     decryptPasswordMock.mockReset();
     selectAllMock.mockReset();
+    selectGetMock.mockReset();
     insertValuesMock.mockReset();
     updateSetMock.mockReset();
   });
@@ -193,6 +196,65 @@ describe('checkinService auto relogin', () => {
     const writtenIds = writtenConfigs.map((cfg) => cfg.platformUserId);
     expect(writtenIds).toContain(500123);
     expect(writtenIds).not.toContain(1999);
+  });
+
+  it('preserves account configuration updated while auto relogin is in flight', async () => {
+    const autoRelogin = { username: 'alice@example.com', passwordCipher: 'cipher' };
+    let currentExtraConfig = JSON.stringify({
+      autoRelogin,
+      proxyUrl: 'http://old-proxy.example',
+    });
+    selectAllMock.mockReturnValue([
+      {
+        accounts: {
+          id: 15,
+          username: 'alice@example.com',
+          accessToken: 'expired-token',
+          status: 'active',
+          extraConfig: currentExtraConfig,
+        },
+        sites: {
+          id: 15,
+          name: 'concurrent-settings',
+          url: 'https://example.com',
+          platform: 'new-api',
+        },
+      },
+    ]);
+    selectGetMock.mockImplementation(() => ({ extraConfig: currentExtraConfig }));
+
+    adapterMock.checkin
+      .mockResolvedValueOnce({ success: false, message: 'access token required' })
+      .mockResolvedValueOnce({ success: true, message: 'checked in' });
+    decryptPasswordMock.mockReturnValue('plain-password');
+    adapterMock.login.mockImplementation(async () => {
+      currentExtraConfig = JSON.stringify({
+        autoRelogin,
+        proxyUrl: 'http://new-proxy.example',
+      });
+      return {
+        success: true,
+        accessToken: 'fresh-token',
+        platformUserId: 500123,
+      };
+    });
+
+    const { checkinAccount } = await import('./checkinService.js');
+    await checkinAccount(15);
+
+    expect(selectGetMock).toHaveBeenCalled();
+    const writtenConfigs = updateSetMock.mock.calls
+      .map((call) => call[0]?.extraConfig)
+      .filter((value): value is string => typeof value === 'string')
+      .map((value) => JSON.parse(value) as Record<string, unknown>);
+    expect(writtenConfigs.length).toBeGreaterThan(0);
+    for (const config of writtenConfigs) {
+      expect(config).toMatchObject({
+        autoRelogin,
+        proxyUrl: 'http://new-proxy.example',
+      });
+    }
+    expect(writtenConfigs.some((config) => config.platformUserId === 500123)).toBe(true);
   });
 
   it('passes guessed platform user id when config does not include it', async () => {

--- a/src/server/services/checkinService.autoRelogin.test.ts
+++ b/src/server/services/checkinService.autoRelogin.test.ts
@@ -172,14 +172,23 @@ describe('checkinService auto relogin', () => {
     // ...but the retry must use the id the site itself reported.
     expect(adapterMock.checkin.mock.calls[1][2]).toBe(500123);
 
-    // And no later write may put the guess back over it.
-    const writtenIds = updateSetMock.mock.calls
+    // And no later write may put the guess back over it. Parse the whole config,
+    // not just the id: a write that *replaced* extraConfig with only
+    // `{ platformUserId }` would satisfy an id-only assertion while dropping the
+    // autoRelogin credentials, leaving nothing to re-login with next time.
+    const writtenConfigs = updateSetMock.mock.calls
       .map((call) => (call[0] as Record<string, unknown> | undefined)?.extraConfig)
       .filter((cfg): cfg is string => typeof cfg === 'string')
-      .map((cfg) => (JSON.parse(cfg) as { platformUserId?: number }).platformUserId);
-    expect(writtenIds.length).toBeGreaterThan(0);
-    expect(writtenIds).toContain(500123);
-    expect(writtenIds).not.toContain(1999);
+      .map((cfg) => JSON.parse(cfg) as {
+        platformUserId?: number;
+        autoRelogin?: { username?: string; passwordCipher?: string };
+      });
+    expect(writtenConfigs.length).toBeGreaterThan(0);
+    expect(writtenConfigs.map((cfg) => cfg.platformUserId)).not.toContain(1999);
+    expect(writtenConfigs).toContainEqual(expect.objectContaining({
+      platformUserId: 500123,
+      autoRelogin: { username: 'alice_1999', passwordCipher: 'cipher' },
+    }));
   });
 
   it('passes guessed platform user id when config does not include it', async () => {

--- a/src/server/services/checkinService.autoRelogin.test.ts
+++ b/src/server/services/checkinService.autoRelogin.test.ts
@@ -184,11 +184,15 @@ describe('checkinService auto relogin', () => {
         autoRelogin?: { username?: string; passwordCipher?: string };
       });
     expect(writtenConfigs.length).toBeGreaterThan(0);
-    expect(writtenConfigs.map((cfg) => cfg.platformUserId)).not.toContain(1999);
-    expect(writtenConfigs).toContainEqual(expect.objectContaining({
-      platformUserId: 500123,
-      autoRelogin: { username: 'alice_1999', passwordCipher: 'cipher' },
-    }));
+    // Credentials must survive *every* write. `toContainEqual` would only prove one
+    // write got it right, while a later one could still drop them — and a single
+    // drop leaves nothing to re-login with next round.
+    for (const cfg of writtenConfigs) {
+      expect(cfg.autoRelogin).toEqual({ username: 'alice_1999', passwordCipher: 'cipher' });
+    }
+    const writtenIds = writtenConfigs.map((cfg) => cfg.platformUserId);
+    expect(writtenIds).toContain(500123);
+    expect(writtenIds).not.toContain(1999);
   });
 
   it('passes guessed platform user id when config does not include it', async () => {

--- a/src/server/services/checkinService.ts
+++ b/src/server/services/checkinService.ts
@@ -92,7 +92,22 @@ function inferRewardFromBalanceDelta(previousBalance: unknown, latestBalance: un
   return Math.round(delta * 1_000_000) / 1_000_000;
 }
 
-async function tryAutoRelogin(account: any, site: any): Promise<string | null> {
+/**
+ * Result of a successful automatic re-login.
+ *
+ * The access token alone is not enough: the login may also have reported the
+ * authoritative `platformUserId`. Callers need it for the retry that follows,
+ * and they need the merged `extraConfig` so their own later
+ * `mergeAccountExtraConfig(account.extraConfig, ...)` writes do not put the
+ * pre-login copy back and undo what was just persisted.
+ */
+type AutoReloginResult = {
+  accessToken: string;
+  platformUserId?: number;
+  extraConfig?: string;
+};
+
+async function tryAutoRelogin(account: any, site: any): Promise<AutoReloginResult | null> {
   const adapter = getAdapter(site.platform);
   if (!adapter) return null;
 
@@ -125,7 +140,11 @@ async function tryAutoRelogin(account: any, site: any): Promise<string | null> {
     .where(eq(schema.accounts.id, account.id))
     .run();
 
-  return result.accessToken;
+  return {
+    accessToken: result.accessToken,
+    platformUserId: result.platformUserId,
+    extraConfig: reloginExtraConfig,
+  };
 }
 
 export async function checkinAccount(accountId: number, options?: { skipEvent?: boolean; scheduleMode?: 'cron' | 'interval' }) {
@@ -183,7 +202,7 @@ export async function checkinAccount(accountId: number, options?: { skipEvent?: 
   const guessedPlatformUserId = storedPlatformUserId
     ? undefined
     : guessPlatformUserIdFromUsername(account.username);
-  const platformUserId = resolvePlatformUserId(account.extraConfig, account.username);
+  let platformUserId = resolvePlatformUserId(account.extraConfig, account.username);
 
   const accountProxyUrl = resolveProxyUrlFromExtraConfig(account.extraConfig);
   let activeAccessToken = account.accessToken;
@@ -191,9 +210,15 @@ export async function checkinAccount(accountId: number, options?: { skipEvent?: 
     () => adapter.checkin(site.url, activeAccessToken, platformUserId));
 
   if (!result.success && shouldAttemptAutoRelogin(result.message)) {
-    const refreshedAccessToken = await tryAutoRelogin(account, site);
-    if (refreshedAccessToken) {
-      activeAccessToken = refreshedAccessToken;
+    const relogin = await tryAutoRelogin(account, site);
+    if (relogin) {
+      activeAccessToken = relogin.accessToken;
+      // Adopt whatever the re-login reported before retrying, and refresh our
+      // in-memory copy of extraConfig — the merge writes further down start from
+      // `account.extraConfig`, so leaving the stale copy here would overwrite the
+      // id tryAutoRelogin() just persisted.
+      if (relogin.platformUserId) platformUserId = relogin.platformUserId;
+      if (relogin.extraConfig) account.extraConfig = relogin.extraConfig;
       result = await withAccountProxyOverride(accountProxyUrl,
         () => adapter.checkin(site.url, activeAccessToken, platformUserId));
     }

--- a/src/server/services/checkinService.ts
+++ b/src/server/services/checkinService.ts
@@ -257,7 +257,13 @@ export async function checkinAccount(accountId: number, options?: { skipEvent?: 
     if (shouldAdvanceLastCheckinAt) {
       updates.lastCheckinAt = new Date().toISOString();
     }
-    if (!storedPlatformUserId && guessedPlatformUserId) {
+    // Both ids above were computed before any re-login. If a re-login has since
+    // reported the authoritative one, `account.extraConfig` already carries it,
+    // and persisting the guess here would replace a known-good id with digits
+    // scraped off the end of the username. Check the current config, not the
+    // pre-login snapshot. (`guessedPlatformUserId` is only set when
+    // `storedPlatformUserId` was empty, so this stays equivalent otherwise.)
+    if (guessedPlatformUserId && !getPlatformUserIdFromExtraConfig(account.extraConfig)) {
       updates.extraConfig = mergeAccountExtraConfig(account.extraConfig, {
         platformUserId: guessedPlatformUserId,
       });

--- a/src/server/services/checkinService.ts
+++ b/src/server/services/checkinService.ts
@@ -123,11 +123,20 @@ async function tryAutoRelogin(account: any, site: any): Promise<AutoReloginResul
   );
   if (!result.success || !result.accessToken) return null;
 
-  // Persist the id the site reported during re-login as well; otherwise the
-  // account keeps whatever (possibly wrong) id it had and every subsequent
-  // `/api/user/self` call has to rediscover it.
+  // Re-read after the network request: account settings may have changed while
+  // login was in flight, and merging into the original snapshot would overwrite
+  // those newer fields when the whole extraConfig value is persisted.
+  const latestAccount = result.platformUserId
+    ? await db.select({ extraConfig: schema.accounts.extraConfig })
+      .from(schema.accounts)
+      .where(eq(schema.accounts.id, account.id))
+      .get()
+    : undefined;
   const reloginExtraConfig = result.platformUserId
-    ? mergeAccountExtraConfig(account.extraConfig, { platformUserId: result.platformUserId })
+    ? mergeAccountExtraConfig(
+      latestAccount ? latestAccount.extraConfig : account.extraConfig,
+      { platformUserId: result.platformUserId },
+    )
     : undefined;
 
   await db.update(schema.accounts)

--- a/src/server/services/checkinService.ts
+++ b/src/server/services/checkinService.ts
@@ -108,9 +108,17 @@ async function tryAutoRelogin(account: any, site: any): Promise<string | null> {
   );
   if (!result.success || !result.accessToken) return null;
 
+  // Persist the id the site reported during re-login as well; otherwise the
+  // account keeps whatever (possibly wrong) id it had and every subsequent
+  // `/api/user/self` call has to rediscover it.
+  const reloginExtraConfig = result.platformUserId
+    ? mergeAccountExtraConfig(account.extraConfig, { platformUserId: result.platformUserId })
+    : undefined;
+
   await db.update(schema.accounts)
     .set({
       accessToken: result.accessToken,
+      ...(reloginExtraConfig ? { extraConfig: reloginExtraConfig } : {}),
       updatedAt: new Date().toISOString(),
       status: account.status === 'expired' ? 'active' : account.status,
     })

--- a/src/server/services/platforms/base.ts
+++ b/src/server/services/platforms/base.ts
@@ -42,6 +42,13 @@ interface LoginResult {
   accessToken?: string;
   username?: string;
   message?: string;
+  /**
+   * Site-side user id (the value of the `New-Api-User` header).
+   * Most New API compatible sites return it in the login payload as
+   * `data.id`, so adapters can surface it here instead of forcing callers
+   * to guess it from the username or re-discover it on every request.
+   */
+  platformUserId?: number;
 }
 
 export interface UserInfo {

--- a/src/server/services/platforms/base.ts
+++ b/src/server/services/platforms/base.ts
@@ -163,6 +163,42 @@ export abstract class BasePlatformAdapter implements PlatformAdapter {
     }
   }
 
+  /**
+   * Pull the site-side user id out of the login payload.
+   *
+   * New API compatible sites return `{ success: true, data: { id, ... } }` on
+   * `/api/user/login`, so the id is already there at login time. Without it,
+   * callers fall back to `guessPlatformUserIdFromUsername()`, which only works
+   * when the username happens to end with the id.
+   *
+   * This lives on the base adapter so every subclass benefits. Veloera, for
+   * one, inherits `login()` as-is, yet its `authHeaders()` only sends
+   * `Veloera-User` / `New-API-User` / `User-id` when an id was resolved — so
+   * without this it hits the same e-mail-login failure.
+   */
+  protected extractLoginUserId(payload: any): number | undefined {
+    const candidates: unknown[] = [
+      payload?.data?.id,
+      payload?.data?.user?.id,
+      payload?.user?.id,
+      payload?.id,
+    ];
+    for (const candidate of candidates) {
+      if (typeof candidate === 'number') {
+        if (Number.isSafeInteger(candidate) && candidate > 0) return candidate;
+        continue;
+      }
+      // Only accept a string that is *entirely* digits. `Number.parseInt` would
+      // happily turn "80305abc" or "80305.9" into 80305 and we would then send a
+      // wrong `New-Api-User` header.
+      if (typeof candidate === 'string' && /^\d+$/.test(candidate.trim())) {
+        const value = Number(candidate.trim());
+        if (Number.isSafeInteger(value) && value > 0) return value;
+      }
+    }
+    return undefined;
+  }
+
   async login(baseUrl: string, username: string, password: string): Promise<LoginResult> {
     try {
       const res = await this.fetchJson<any>(`${baseUrl}/api/user/login`, {
@@ -174,6 +210,7 @@ export abstract class BasePlatformAdapter implements PlatformAdapter {
           success: true,
           accessToken: typeof res.data === 'string' ? res.data : res.data.token || res.data.access_token,
           username,
+          platformUserId: this.extractLoginUserId(res),
         };
       }
       return { success: false, message: res?.message || '登录失败' };

--- a/src/server/services/platforms/base.ts
+++ b/src/server/services/platforms/base.ts
@@ -37,7 +37,7 @@ export interface BalanceInfo {
   subscriptionSummary?: SubscriptionSummary;
 }
 
-interface LoginResult {
+export interface LoginResult {
   success: boolean;
   accessToken?: string;
   username?: string;

--- a/src/server/services/platforms/newApi.ts
+++ b/src/server/services/platforms/newApi.ts
@@ -355,6 +355,31 @@ export class NewApiAdapter extends BasePlatformAdapter {
     return { balance: quota, used, quota: total, todayIncome, todayQuotaConsumption };
   }
 
+  /**
+   * Pull the site-side user id out of the login payload.
+   *
+   * New API returns `{ success: true, data: { id, username, ... } }` on
+   * `/api/user/login`, so the id is already available at login time. Without
+   * it callers fall back to `guessPlatformUserIdFromUsername()`, which only
+   * works when the username happens to end with the id, or they pay for an
+   * extra `discoverUserId()` round trip on every checkin/balance call.
+   */
+  private extractLoginUserId(payload: any): number | undefined {
+    const candidates: unknown[] = [
+      payload?.data?.id,
+      payload?.data?.user?.id,
+      payload?.user?.id,
+      payload?.id,
+    ];
+    for (const candidate of candidates) {
+      const value = typeof candidate === 'string' ? Number.parseInt(candidate, 10) : candidate;
+      if (typeof value === 'number' && Number.isInteger(value) && value > 0) {
+        return value;
+      }
+    }
+    return undefined;
+  }
+
   private extractLoginAccessToken(payload: any): string | null {
     const candidates: unknown[] = [
       payload?.data,
@@ -946,7 +971,13 @@ export class NewApiAdapter extends BasePlatformAdapter {
     baseUrl: string,
     username: string,
     password: string,
-  ): Promise<{ success: boolean; accessToken?: string; username?: string; message?: string }> {
+  ): Promise<{
+    success: boolean;
+    accessToken?: string;
+    username?: string;
+    message?: string;
+    platformUserId?: number;
+  }> {
     try {
       const { data: res, cookieHeader } = await this.fetchJsonRawWithCookie<any>(`${baseUrl}/api/user/login`, {
         method: 'POST',
@@ -960,11 +991,13 @@ export class NewApiAdapter extends BasePlatformAdapter {
       }
 
       const accessToken = this.extractLoginAccessToken(res);
+      const platformUserId = this.extractLoginUserId(res);
       if (res?.success && accessToken) {
         return {
           success: true,
           accessToken,
           username,
+          platformUserId,
         };
       }
       if (res?.success && this.hasUsableSessionCookie(cookieHeader)) {
@@ -972,6 +1005,7 @@ export class NewApiAdapter extends BasePlatformAdapter {
           success: true,
           accessToken: cookieHeader,
           username,
+          platformUserId,
         };
       }
 

--- a/src/server/services/platforms/newApi.ts
+++ b/src/server/services/platforms/newApi.ts
@@ -1,4 +1,4 @@
-import { ApiTokenInfo, BasePlatformAdapter, CheckinResult, BalanceInfo, UserInfo, TokenVerifyResult, CreateApiTokenOptions, type SiteAnnouncement } from './base.js';
+import { ApiTokenInfo, BasePlatformAdapter, CheckinResult, BalanceInfo, UserInfo, TokenVerifyResult, CreateApiTokenOptions, type SiteAnnouncement, type LoginResult } from './base.js';
 import type { RequestInit as UndiciRequestInit } from 'undici';
 import { createContext, runInContext } from 'node:vm';
 import { withSiteProxyRequestInit } from '../siteProxy.js';
@@ -372,9 +372,16 @@ export class NewApiAdapter extends BasePlatformAdapter {
       payload?.id,
     ];
     for (const candidate of candidates) {
-      const value = typeof candidate === 'string' ? Number.parseInt(candidate, 10) : candidate;
-      if (typeof value === 'number' && Number.isInteger(value) && value > 0) {
-        return value;
+      if (typeof candidate === 'number') {
+        if (Number.isSafeInteger(candidate) && candidate > 0) return candidate;
+        continue;
+      }
+      // Only accept a string that is *entirely* digits. `Number.parseInt` would
+      // happily turn "80305abc" or "80305.9" into 80305 and we would then send a
+      // wrong `New-Api-User` header.
+      if (typeof candidate === 'string' && /^\d+$/.test(candidate.trim())) {
+        const value = Number(candidate.trim());
+        if (Number.isSafeInteger(value) && value > 0) return value;
       }
     }
     return undefined;
@@ -971,13 +978,7 @@ export class NewApiAdapter extends BasePlatformAdapter {
     baseUrl: string,
     username: string,
     password: string,
-  ): Promise<{
-    success: boolean;
-    accessToken?: string;
-    username?: string;
-    message?: string;
-    platformUserId?: number;
-  }> {
+  ): Promise<LoginResult> {
     try {
       const { data: res, cookieHeader } = await this.fetchJsonRawWithCookie<any>(`${baseUrl}/api/user/login`, {
         method: 'POST',

--- a/src/server/services/platforms/newApi.ts
+++ b/src/server/services/platforms/newApi.ts
@@ -355,38 +355,6 @@ export class NewApiAdapter extends BasePlatformAdapter {
     return { balance: quota, used, quota: total, todayIncome, todayQuotaConsumption };
   }
 
-  /**
-   * Pull the site-side user id out of the login payload.
-   *
-   * New API returns `{ success: true, data: { id, username, ... } }` on
-   * `/api/user/login`, so the id is already available at login time. Without
-   * it callers fall back to `guessPlatformUserIdFromUsername()`, which only
-   * works when the username happens to end with the id, or they pay for an
-   * extra `discoverUserId()` round trip on every checkin/balance call.
-   */
-  private extractLoginUserId(payload: any): number | undefined {
-    const candidates: unknown[] = [
-      payload?.data?.id,
-      payload?.data?.user?.id,
-      payload?.user?.id,
-      payload?.id,
-    ];
-    for (const candidate of candidates) {
-      if (typeof candidate === 'number') {
-        if (Number.isSafeInteger(candidate) && candidate > 0) return candidate;
-        continue;
-      }
-      // Only accept a string that is *entirely* digits. `Number.parseInt` would
-      // happily turn "80305abc" or "80305.9" into 80305 and we would then send a
-      // wrong `New-Api-User` header.
-      if (typeof candidate === 'string' && /^\d+$/.test(candidate.trim())) {
-        const value = Number(candidate.trim());
-        if (Number.isSafeInteger(value) && value > 0) return value;
-      }
-    }
-    return undefined;
-  }
-
   private extractLoginAccessToken(payload: any): string | null {
     const candidates: unknown[] = [
       payload?.data,


### PR DESCRIPTION
## 问题

`/api/user/login` 的响应里 `data.id` 就是站点侧的 user id（也就是 `New-Api-User` 头要用的那个值），但 `login()` 只从响应里提取 access token，其余整个丢掉。

于是创建账号时回退到猜测：

```ts
const guessedPlatformUserId = guessPlatformUserIdFromUsername(username);
```

那个正则取用户名末尾的连续数字，只在用户名恰好以 id 结尾时才对 —— `linuxdo_80305` 可以，但邮箱登录（`alice@example.com`）拿不到任何东西，或者抓到一段与 id 无关的数字。

后果是连锁的：

1. 请求不带（或带错）`New-Api-User` 头
2. 这类站点的 `/api/user/self` 直接返回 401 `未提供 New-Api-User`
3. 余额恒为 0，账号健康状态被判为 unhealthy
4. session 被误判为已过期 → **每一轮调度都退回完整的密码登录**

第 4 点在有登录频率限制的站点上会自我放大：越失败越频繁打 `/login`，越容易被限流，然后更失败。

## 改动

- `LoginResult` 增加可选字段 `platformUserId`
- `NewApiAdapter.login()` 从登录响应里提取它。新增的 `extractLoginUserId()` 风格对齐既有的 `extractLoginAccessToken()`，候选路径覆盖 `data.id` / `data.user.id` / `user.id` / `id`，字符串形式的数字也接受
- 创建账号时优先用它，原来的猜测退为兜底
- 自动重登时一并落库，用 `mergeAccountExtraConfig` 合并而非覆盖 —— 直接写会抹掉 `autoRelogin` 里已存的凭据

## 附带的好处

`checkin()` 和 `getBalance()` 现在都会调 `discoverUserId()`，那里面最多要跑三个探测请求（JWT 解码、`/api/user/self` 的两种鉴权方式、cookie 方式）来得到同一个 id。登录时把它存下来，账号建好之后这些请求就不必再跑了。

## 兼容性

纯增量：新字段可选；`login()` 的返回值只是多带一个字段。响应里没有 `id` 的站点不受影响 —— 取不到就是 `undefined`，走原来的猜测路径。不引入任何依赖。

## 验证

- 改动的 5 个文件 `tsc --noEmit` 无新增错误（仓库里既有的 TS 报错都在 `transformers/openai/responses/*` 和几个 test 文件，与本 PR 无关）
- `npm run build:server` 与 `npm run build:web` 均通过
- 在自建部署上跑 4 个账号 / 2 个站点，余额与健康状态自此稳定；邮箱形式的用户名不再需要人工补 `platformUserId`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account creation and automatic re-login by recognizing platform-provided user IDs.
  * Preserved platform account identifiers when refreshing login credentials or account settings.
  * Improved account matching and session continuity when platform information is available.
  * Added reliable fallback handling when a platform does not provide a user ID.
  * Ensured retry operations use the latest account details and platform identifier without overwriting confirmed information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->