### PR TITLE
fix: tolerate corrupted site announcement cache rows

### DIFF
--- a/src/server/routes/api/siteAnnouncements.ts
+++ b/src/server/routes/api/siteAnnouncements.ts
@@ -1,11 +1,15 @@
 import { FastifyInstance } from 'fastify';
-import { and, desc, eq } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import { db, schema } from '../../db/index.js';
 import { startBackgroundTask } from '../../services/backgroundTaskService.js';
 import { formatUtcSqlDateTime, getResolvedTimeZone } from '../../services/localTimeService.js';
 import { syncSiteAnnouncements } from '../../services/siteAnnouncementService.js';
+import {
+  loadSiteAnnouncements,
+  type SiteAnnouncementListRow,
+} from '../../services/siteAnnouncementStore.js';
 
-type SiteAnnouncementRow = typeof schema.siteAnnouncements.$inferSelect;
+type SiteAnnouncementRow = SiteAnnouncementListRow;
 type SiteAnnouncementsResponseFilters = {
   read?: string;
   status?: string;
@@ -125,22 +129,13 @@ export async function siteAnnouncementsRoutes(app: FastifyInstance) {
   }>('/api/site-announcements', async (request) => {
     const limit = Math.max(1, Math.min(500, Number.parseInt(request.query.limit || '50', 10)));
     const offset = Math.max(0, Number.parseInt(request.query.offset || '0', 10));
-    const filters: any[] = [];
-
     const siteId = Number.parseInt(String(request.query.siteId || ''), 10);
-    if (Number.isFinite(siteId) && siteId > 0) {
-      filters.push(eq(schema.siteAnnouncements.siteId, siteId));
-    }
-
     const platform = String(request.query.platform || '').trim();
-    if (platform) {
-      filters.push(eq(schema.siteAnnouncements.platform, platform));
-    }
 
-    const base = db.select().from(schema.siteAnnouncements);
-    const rows = filters.length > 0
-      ? await base.where(and(...filters)).orderBy(desc(schema.siteAnnouncements.firstSeenAt)).all()
-      : await base.orderBy(desc(schema.siteAnnouncements.firstSeenAt)).all();
+    const rows = await loadSiteAnnouncements({
+      siteId: Number.isFinite(siteId) && siteId > 0 ? siteId : undefined,
+      platform: platform || undefined,
+    });
 
     const filtered = buildSiteAnnouncementsResponseRows(rows, {
       read: request.query.read,

--- a/src/server/services/siteAnnouncementStore.test.ts
+++ b/src/server/services/siteAnnouncementStore.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  getSiteAnnouncementListSelectFields,
+  isPostgresToastCorruptionError,
+  loadRowsWithPostgresToastFallback,
+} from './siteAnnouncementStore.js';
+
+function toastError(message = 'missing chunk number 0 for toast value 396265 in pg_toast_54541') {
+  return Object.assign(new Error(message), { code: 'XX001' });
+}
+
+describe('siteAnnouncementStore', () => {
+  it('keeps raw upstream payload out of the list projection', () => {
+    expect(Object.keys(getSiteAnnouncementListSelectFields())).not.toContain('rawPayload');
+  });
+
+  it('recognizes only the precise PostgreSQL missing-TOAST-chunk diagnostic', () => {
+    expect(isPostgresToastCorruptionError(toastError())).toBe(true);
+    expect(isPostgresToastCorruptionError({
+      code: 'XX001',
+      message: 'index corruption detected',
+    })).toBe(false);
+    expect(isPostgresToastCorruptionError({
+      code: '23505',
+      message: 'missing chunk number 0 for toast value 396265 in pg_toast_54541',
+    })).toBe(false);
+    expect(isPostgresToastCorruptionError({
+      message: 'Failed query',
+      cause: toastError(),
+    })).toBe(true);
+  });
+
+  it('skips only rows that continue to raise TOAST corruption after fallback', async () => {
+    const logger = { warn: vi.fn() };
+    const loadAll = vi.fn().mockRejectedValue(new Error(
+      'Failed query: missing chunk number 0 for toast value 396265 in pg_toast_54541',
+    ));
+    const loadIds = vi.fn().mockResolvedValue([1, 2, 3]);
+    const loadOne = vi.fn(async (id: number) => {
+      if (id === 2) throw toastError();
+      return { id };
+    });
+
+    await expect(loadRowsWithPostgresToastFallback(loadAll, loadIds, loadOne, logger)).resolves.toEqual([
+      { id: 1 },
+      { id: 3 },
+    ]);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('TOAST corruption'),
+      { announcementIds: [2] },
+    );
+  });
+
+  it('rethrows non-TOAST errors instead of hiding database failures', async () => {
+    const failure = new Error('connection terminated unexpectedly');
+    await expect(loadRowsWithPostgresToastFallback(
+      vi.fn().mockRejectedValue(failure),
+      vi.fn(),
+      vi.fn(),
+    )).rejects.toBe(failure);
+
+    const rowFailure = new Error('permission denied for relation site_announcements');
+    await expect(loadRowsWithPostgresToastFallback(
+      vi.fn().mockRejectedValue(toastError()),
+      vi.fn().mockResolvedValue([1]),
+      vi.fn().mockRejectedValue(rowFailure),
+    )).rejects.toBe(rowFailure);
+  });
+});

--- a/src/server/services/siteAnnouncementStore.ts
+++ b/src/server/services/siteAnnouncementStore.ts
@@ -1,0 +1,190 @@
+import { and, desc, eq } from 'drizzle-orm';
+import { db, schema } from '../db/index.js';
+
+/**
+ * The announcements page does not inspect the upstream payload.  Keeping this
+ * projection explicit also means a damaged TOAST value in `raw_payload` does
+ * not make an otherwise readable announcement list fail.
+ */
+export function getSiteAnnouncementListSelectFields() {
+  return {
+    id: schema.siteAnnouncements.id,
+    siteId: schema.siteAnnouncements.siteId,
+    platform: schema.siteAnnouncements.platform,
+    sourceKey: schema.siteAnnouncements.sourceKey,
+    title: schema.siteAnnouncements.title,
+    content: schema.siteAnnouncements.content,
+    level: schema.siteAnnouncements.level,
+    sourceUrl: schema.siteAnnouncements.sourceUrl,
+    startsAt: schema.siteAnnouncements.startsAt,
+    endsAt: schema.siteAnnouncements.endsAt,
+    upstreamCreatedAt: schema.siteAnnouncements.upstreamCreatedAt,
+    upstreamUpdatedAt: schema.siteAnnouncements.upstreamUpdatedAt,
+    firstSeenAt: schema.siteAnnouncements.firstSeenAt,
+    lastSeenAt: schema.siteAnnouncements.lastSeenAt,
+    readAt: schema.siteAnnouncements.readAt,
+    dismissedAt: schema.siteAnnouncements.dismissedAt,
+  } as const;
+}
+
+export type SiteAnnouncementListRow = Omit<
+  typeof schema.siteAnnouncements.$inferSelect,
+  'rawPayload'
+>;
+
+export type SiteAnnouncementListFilters = {
+  siteId?: number;
+  platform?: string;
+};
+
+type ToastFallbackLogger = Pick<Console, 'warn'>;
+
+const POSTGRES_TOAST_CORRUPTION_PATTERN = /missing chunk number \d+ for toast value \d+ in pg_toast_\d+/i;
+
+function readErrorProperty(value: unknown, property: string): unknown {
+  if (!value || typeof value !== 'object') return undefined;
+  try {
+    return (value as Record<string, unknown>)[property];
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Drizzle wraps the native PostgreSQL error, so inspect a small, cycle-safe
+ * cause chain.  The exact PostgreSQL TOAST diagnostic is required; a generic
+ * `XX001` data-corruption error must still propagate to the caller.
+ */
+export function isPostgresToastCorruptionError(error: unknown): boolean {
+  const messages: string[] = [];
+  const codes: string[] = [];
+  const queue: unknown[] = [error];
+  const seen = new Set<object>();
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (typeof current === 'string') {
+      messages.push(current);
+      continue;
+    }
+    if (!current || typeof current !== 'object') continue;
+
+    if (seen.has(current)) continue;
+    seen.add(current);
+
+    const message = readErrorProperty(current, 'message');
+    if (typeof message === 'string') messages.push(message);
+    const detail = readErrorProperty(current, 'detail');
+    if (typeof detail === 'string') messages.push(detail);
+    const code = readErrorProperty(current, 'code');
+    if (typeof code === 'string' && code.trim()) codes.push(code.trim().toUpperCase());
+
+    for (const property of ['cause', 'originalError', 'error']) {
+      const nested = readErrorProperty(current, property);
+      if (nested && nested !== current) queue.push(nested);
+    }
+  }
+
+  if (!messages.some((message) => POSTGRES_TOAST_CORRUPTION_PATTERN.test(message))) {
+    return false;
+  }
+
+  return codes.length === 0 || codes.every((code) => code === 'XX001');
+}
+
+/**
+ * Run a normal list query and, only for a PostgreSQL missing-TOAST-chunk
+ * failure, retry one row at a time.  A row that still raises the same precise
+ * corruption diagnostic is omitted; every other error is rethrown unchanged.
+ * This generic seam keeps the recovery behavior straightforward to test
+ * without requiring a live PostgreSQL instance.
+ */
+export async function loadRowsWithPostgresToastFallback<T extends { id: number }>(
+  loadAll: () => Promise<T[]>,
+  loadIds: () => Promise<number[]>,
+  loadOne: (id: number) => Promise<T | undefined>,
+  logger: ToastFallbackLogger = console,
+): Promise<T[]> {
+  try {
+    return await loadAll();
+  } catch (error) {
+    if (!isPostgresToastCorruptionError(error)) {
+      throw error;
+    }
+  }
+
+  const ids = await loadIds();
+  const rows: T[] = [];
+  const skippedIds: number[] = [];
+
+  for (const id of ids) {
+    try {
+      const row = await loadOne(id);
+      if (row) rows.push(row);
+    } catch (error) {
+      if (!isPostgresToastCorruptionError(error)) {
+        throw error;
+      }
+      skippedIds.push(id);
+    }
+  }
+
+  if (skippedIds.length > 0) {
+    logger.warn('[SiteAnnouncements] skipped rows with PostgreSQL TOAST corruption', {
+      announcementIds: skippedIds,
+    });
+  }
+
+  return rows;
+}
+
+function buildFilters(filters: SiteAnnouncementListFilters): any[] {
+  const conditions: any[] = [];
+  if (Number.isFinite(filters.siteId) && (filters.siteId || 0) > 0) {
+    conditions.push(eq(schema.siteAnnouncements.siteId, filters.siteId as number));
+  }
+  const platform = String(filters.platform || '').trim();
+  if (platform) {
+    conditions.push(eq(schema.siteAnnouncements.platform, platform));
+  }
+  return conditions;
+}
+
+function buildListQuery(filters: SiteAnnouncementListFilters) {
+  const conditions = buildFilters(filters);
+  const base = db.select(getSiteAnnouncementListSelectFields()).from(schema.siteAnnouncements);
+  return conditions.length > 0
+    ? base.where(and(...conditions)).orderBy(desc(schema.siteAnnouncements.firstSeenAt))
+    : base.orderBy(desc(schema.siteAnnouncements.firstSeenAt));
+}
+
+async function loadAnnouncementIds(filters: SiteAnnouncementListFilters): Promise<number[]> {
+  const conditions = buildFilters(filters);
+  const base = db.select({ id: schema.siteAnnouncements.id }).from(schema.siteAnnouncements);
+  const query = conditions.length > 0
+    ? base.where(and(...conditions)).orderBy(desc(schema.siteAnnouncements.firstSeenAt))
+    : base.orderBy(desc(schema.siteAnnouncements.firstSeenAt));
+  const rows = await query.all();
+  return rows
+    .map((row) => Number(row.id))
+    .filter((id) => Number.isFinite(id) && id > 0);
+}
+
+async function loadAnnouncementById(id: number): Promise<SiteAnnouncementListRow | undefined> {
+  const rows = await db.select(getSiteAnnouncementListSelectFields())
+    .from(schema.siteAnnouncements)
+    .where(eq(schema.siteAnnouncements.id, id))
+    .limit(1)
+    .all();
+  return rows[0] as SiteAnnouncementListRow | undefined;
+}
+
+export async function loadSiteAnnouncements(
+  filters: SiteAnnouncementListFilters = {},
+): Promise<SiteAnnouncementListRow[]> {
+  return loadRowsWithPostgresToastFallback(
+    () => buildListQuery(filters).all() as Promise<SiteAnnouncementListRow[]>,
+    () => loadAnnouncementIds(filters),
+    (id) => loadAnnouncementById(id),
+  );
+}


### PR DESCRIPTION
## Summary

- keep the site-announcement list projection limited to fields used by the console
- tolerate a precise PostgreSQL `missing chunk ... in pg_toast_...` error by retrying rows individually and skipping only corrupted rows
- preserve normal database errors and add regression coverage for the fallback classifier/loader

The live cita1 PostgreSQL database had four missing TOAST values in three cached announcement rows. The affected cache fields were repaired separately: two invalid `raw_payload` values were cleared and one stale row with unreadable `content` was removed. No schema change is required.

## Verification

- `npm test` (463 files passed, 2682 tests passed, 8 skipped)
- `npm run typecheck:server`
- `npm run typecheck:web`
- `npm run typecheck:web:test`
- `npm run repo:drift-check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved site announcement loading when announcement data is corrupted, allowing valid announcements to remain available while isolating affected entries.
  - Preserved filtering by site and platform, with announcements displayed from newest to oldest.
  - Non-related database errors continue to be reported instead of being silently ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->