### PR TITLE
fix(responses): strip file_id from input_image blocks that also carry image_url

### DIFF
--- a/src/server/transformers/openai/responses/normalization.test.ts
+++ b/src/server/transformers/openai/responses/normalization.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  normalizeResponsesInputForCompatibility,
+  normalizeResponsesMessageContent,
+} from './normalization.js';
+
+describe('responses input image normalization (issue #598)', () => {
+  it('strips file_id when an input_image block also carries image_url', () => {
+    const result = normalizeResponsesInputForCompatibility([
+      {
+        type: 'message',
+        role: 'user',
+        content: [
+          {
+            type: 'input_image',
+            file_id: 'file_remote_abc',
+            image_url: 'https://example.com/cat.png',
+          },
+        ],
+      },
+    ]) as Array<Record<string, unknown>>;
+
+    const content = result[0].content as Array<Record<string, unknown>>;
+    expect(content).toHaveLength(1);
+    expect(content[0]).toEqual({
+      type: 'input_image',
+      image_url: 'https://example.com/cat.png',
+    });
+    expect(content[0]).not.toHaveProperty('file_id');
+  });
+
+  it('strips file_id when an image_url-typed block also carries image_url', () => {
+    const result = normalizeResponsesInputForCompatibility([
+      {
+        type: 'message',
+        role: 'user',
+        content: [
+          {
+            type: 'image_url',
+            file_id: 'file_remote_abc',
+            image_url: 'https://example.com/cat.png',
+          },
+        ],
+      },
+    ]) as Array<Record<string, unknown>>;
+
+    const content = result[0].content as Array<Record<string, unknown>>;
+    expect(content).toHaveLength(1);
+    expect(content[0]).toEqual({
+      type: 'input_image',
+      image_url: 'https://example.com/cat.png',
+    });
+    expect(content[0]).not.toHaveProperty('file_id');
+  });
+
+  it('drops the conflicting file_id while preserving other siblings', () => {
+    const result = normalizeResponsesInputForCompatibility([
+      {
+        type: 'message',
+        role: 'user',
+        content: [
+          {
+            type: 'input_image',
+            file_id: 'file_remote_abc',
+            image_url: 'https://example.com/cat.png',
+            detail: 'high',
+          },
+        ],
+      },
+    ]) as Array<Record<string, unknown>>;
+
+    const content = result[0].content as Array<Record<string, unknown>>;
+    expect(content[0]).toEqual({
+      type: 'input_image',
+      image_url: 'https://example.com/cat.png',
+      detail: 'high',
+    });
+    expect(content[0]).not.toHaveProperty('file_id');
+  });
+});

--- a/src/server/transformers/openai/responses/normalization.ts
+++ b/src/server/transformers/openai/responses/normalization.ts
@@ -123,8 +123,9 @@ function normalizeResponsesContentItem(
   if (type === 'input_image' || type === 'image_url') {
     const imageUrl = normalizeImageUrlValue(item.image_url) ?? normalizeImageUrlValue(item.url);
     if (!imageUrl) return null;
+    const { file_id: _ignoredFileId, ...rest } = item as Record<string, unknown>;
     return {
-      ...item,
+      ...rest,
       type: 'input_image',
       image_url: imageUrl,
     };


### PR DESCRIPTION
### Summary

When the upstream client posts an OpenAI Responses request whose `input[]` content carries an `input_image` (or `image_url`) block with **both** `file_id` and `image_url`, the metapi normalizer preserved `file_id` alongside the normalized `image_url`. Codex Responses then rejects the upstream request with HTTP 400:

> "Missing mutually exclusive parameters: 'input[N].content[M]'. Ensure you are providing exactly one of: 'file_id' or 'image_url'."

The reproducer reported in #598 is `cpa -> metapi (codex reverse proxy)` calling codex; the regression surface is in `src/server/transformers/openai/responses/normalization.ts`.

### Root cause

`normalizeResponsesContentItem` spread the original item with `{ ...item, type: 'input_image', image_url }`. Anything else in the source block — including the now-conflicting `file_id` — survived unchanged.

### Fix

Drop `file_id` whenever we emit an `input_image` block, while keeping any unrelated sibling keys (e.g. `detail`) intact.

### Tests

- `strips file_id when an input_image block also carries image_url`
- `strips file_id when an image_url-typed block also carries image_url`
- `drops the conflicting file_id while preserving other siblings`

All three fail on `main` and pass with this patch. The full `src/server/transformers/openai/responses/**` suite (11 files / 141 tests) stays green.

Fixes #598

### Notes

- Only the `input_image` / `image_url` mutual exclusion is addressed. Other upstream mutual exclusion rules (e.g. `file_data` vs `image_url`) are intentionally left for follow-up work.
- The case of an `input_image` block carrying *only* `file_id` is currently dropped by `normalizeResponsesContentItem` because the function requires a resolvable `image_url`. That behaviour is pre-existing and out of scope for this fix.

Signed-off-by: simonyang08 <ppt5928@gmail.com>