### PR TITLE
feat: 完善图像生成模型接口

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -242,6 +242,24 @@ npx vitest run --pool=threads --poolOptions.threads.singleThread=true <test-file
 - **交付物**：代码与持续变更日志；无新增 PDF 或截图。
 - **状态**：已完成，已推送到 PR 分支；本次日志修正随当前文档提交同步。
 
+## 2026-09-04
+
+### 14. 修复 Issue #611：ESA 挑战诊断与签到可靠性
+
+- **类型**：缺陷修复
+- **需求来源**：[Issue #611](https://github.com/cita-777/metapi/issues/611)
+- **目标**：避免新版阿里云 ESA 挑战退化为 HTML JSON 解析错误，并修复批量签到不可观测及过期余额缓存导致的假奖励。
+- **实现范围**：识别 `aliyun_waf_aa/bb` 新版挑战并返回需要真实浏览器的稳定提示；保留旧版 `acw_sc__v2` 计算流程；批量签到结束写入汇总事件；仅在 5 分钟内刷新过余额时推导奖励。
+- **主要文件**：
+  - `src/server/services/platforms/newApiShield.ts`
+  - `src/server/services/platforms/newApi.ts`
+  - `src/server/services/platforms/newApi.test.ts`
+  - `src/server/services/checkinService.ts`
+  - `src/server/services/checkinService.autoRelogin.test.ts`
+- **验证**：聚焦 Vitest 通过（51 个测试）；`npm run typecheck:server` 通过；`npm run repo:drift-check` 通过（新增违规 0）。
+- **交付物**：代码、回归测试和本变更日志。
+- **状态**：已完成
+
 ## 后续记录模板
 
 复制下面模板追加到对应日期下，先记录需求来源，再补充实际实现和验证结果：

--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -260,6 +260,23 @@ npx vitest run --pool=threads --poolOptions.threads.singleThread=true <test-file
 - **交付物**：代码、回归测试和本变更日志。
 - **状态**：已完成
 
+## 2026-09-05
+
+### 15. 完善 Issue #605：图像生成模型接口
+
+- **类型**：功能完善与缺陷修复
+- **需求来源**：[Issue #605](https://github.com/cita-777/metapi/issues/605)
+- **目标**：提供可直接接入 OpenAI Images 客户端的图像生成接口，并避免无效请求或空图像响应被静默转发。
+- **实现范围**：校验 `/v1/images/generations` 的 JSON 请求体和必填 `prompt`；规范化默认及映射前的模型名和提示词；校验上游 2xx 响应包含 `data` 图像结果，不符合协议时复用现有渠道重试、失败记录和告警链路；补充客户端接入示例。
+- **主要文件**：
+  - `src/server/routes/proxy/images.ts`
+  - `src/server/routes/proxy/images.edits.test.ts`
+  - `docs/client-integration.md`
+  - `docs/change-log.md`
+- **验证**：图像路由聚焦测试通过；随后运行服务端类型检查和仓库漂移检查。
+- **交付物**：代码、回归测试、客户端接入文档和本变更日志。
+- **状态**：已完成
+
 ## 后续记录模板
 
 复制下面模板追加到对应日期下，先记录需求来源，再补充实际实现和验证结果：

--- a/docs/client-integration.md
+++ b/docs/client-integration.md
@@ -35,6 +35,19 @@ Metapi 暴露标准 OpenAI / Claude 兼容接口，下游客户端通常只需�
 | `/v1/images/generations` | POST | 图像生成 |
 | `/v1/models` | GET | 模型列表 |
 
+### 图像生成
+
+`POST /v1/images/generations` 遵循 OpenAI Images API 的 JSON 请求格式。`prompt` 为必填字段，`model` 未填写时使用 `gpt-image-1`；其余图像参数（例如 `size`、`quality`、`background` 和 `output_format`）会随请求透传到实际选中的上游模型。
+
+```bash
+curl https://your-domain.com/v1/images/generations \
+  -H "Authorization: Bearer $PROXY_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-image-1","prompt":"一只戴着太空头盔的橘猫","size":"1024x1024"}'
+```
+
+响应保持标准 `{ "created": ..., "data": [...] }` 结构，其中 `data` 项至少包含 `url` 或 `b64_json`。如果上游返回成功状态但没有图像数据，网关会将其视为异常并按渠道策略重试，避免客户端收到无法使用的空结果。
+
 ## 已验证兼容的客户端
 
 ### ChatGPT-Next-Web

--- a/src/server/routes/api/accounts.ts
+++ b/src/server/routes/api/accounts.ts
@@ -963,6 +963,15 @@ export async function accountsRoutes(app: FastifyInstance) {
         };
       }
 
+      // 适配器已经识别出的挑战/网络原因优先直接返回，避免被通用的
+      // “Session Token 验证失败” 覆盖，尤其是新版 ESA 浏览器验证提示。
+      if (typeof result.message === "string" && result.message.trim()) {
+        return {
+          success: false,
+          message: appendSessionTokenRebindHint(result.message),
+        };
+      }
+
       // Try to explain unknown failures: missing user id vs anti-bot challenge page.
       const detectVerifyFailureReason =
         async (): Promise<VerifyFailureReason> => {

--- a/src/server/routes/proxy/images.edits.test.ts
+++ b/src/server/routes/proxy/images.edits.test.ts
@@ -169,6 +169,62 @@ describe('/v1/images/edits route', () => {
     expect(targetUrl).toBe('https://upstream.example.com/v1/images/edits');
   });
 
+  it('forwards a normalized OpenAI image generation request and returns image data', async () => {
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({
+      created: 1,
+      data: [{ url: 'https://cdn.example.com/cat.png', revised_prompt: 'a cat' }],
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    }));
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/v1/images/generations',
+      headers: {
+        authorization: 'Bearer sk-demo',
+      },
+      payload: {
+        model: '  gpt-image-1  ',
+        prompt: '  draw a cat  ',
+        size: '1024x1024',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      created: 1,
+      data: [{ url: 'https://cdn.example.com/cat.png', revised_prompt: 'a cat' }],
+    });
+    const [, requestInit] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(String(requestInit.body))).toEqual({
+      model: 'upstream-gpt-image',
+      prompt: 'draw a cat',
+      size: '1024x1024',
+    });
+  });
+
+  it('rejects image generation requests without a prompt before selecting a channel', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/v1/images/generations',
+      headers: {
+        authorization: 'Bearer sk-demo',
+      },
+      payload: { model: 'gpt-image-1' },
+    });
+
+    expect(response.statusCode).toBe(400);
+    expect(response.json()).toEqual({
+      error: {
+        message: 'prompt is required',
+        type: 'invalid_request_error',
+      },
+    });
+    expect(selectChannelMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('retries the next channel when image generation JSON is malformed', async () => {
     selectNextChannelMock.mockReturnValueOnce({
       channel: { id: 12, routeId: 23 },
@@ -180,6 +236,49 @@ describe('/v1/images/edits route', () => {
     });
     fetchMock
       .mockResolvedValueOnce(new Response('not-json', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        created: 2,
+        data: [{ b64_json: 'ZmFsbGJhY2s=' }],
+      }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }));
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/v1/images/generations',
+      headers: {
+        authorization: 'Bearer sk-demo',
+      },
+      payload: {
+        model: 'gpt-image-1',
+        prompt: 'draw a cat',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({
+      created: 2,
+      data: [{ b64_json: 'ZmFsbGJhY2s=' }],
+    });
+    expect(selectNextChannelMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries when an upstream 2xx response does not contain image data', async () => {
+    selectNextChannelMock.mockReturnValueOnce({
+      channel: { id: 12, routeId: 23 },
+      site: { id: 45, name: 'fallback-site', url: 'https://fallback.example.com', platform: 'openai' },
+      account: { id: 34, username: 'fallback-user' },
+      tokenName: 'fallback',
+      tokenValue: 'sk-fallback',
+      actualModel: 'fallback-gpt-image',
+    });
+    fetchMock
+      .mockResolvedValueOnce(new Response(JSON.stringify({ created: 1, data: [] }), {
         status: 200,
         headers: { 'content-type': 'application/json' },
       }))

--- a/src/server/routes/proxy/images.ts
+++ b/src/server/routes/proxy/images.ts
@@ -17,6 +17,7 @@ import { buildUpstreamUrl } from './upstreamUrl.js';
 import { detectDownstreamClientContext, type DownstreamClientContext } from '../../proxy-core/downstreamClientContext.js';
 import { insertProxyLog } from '../../services/proxyLogStore.js';
 import { fetchWithObservedFirstByte, getObservedResponseMeta } from '../../proxy-core/firstByteTimeout.js';
+import { readRuntimeResponseText } from '../../proxy-core/executors/types.js';
 import { getProxyMaxChannelRetries } from '../../services/proxyChannelRetry.js';
 import { runWithSiteApiEndpointPool, SiteApiEndpointRequestError } from '../../services/siteApiEndpointService.js';
 import {
@@ -30,8 +31,14 @@ export async function imagesProxyRoute(app: FastifyInstance) {
   ensureMultipartBufferParser(app);
 
   app.post('/v1/images/generations', async (request: FastifyRequest, reply: FastifyReply) => {
-    const body = request.body as any;
-    const requestedModel = body?.model || 'gpt-image-1';
+    const input = normalizeImageGenerationRequest(request.body);
+    if (!input.ok) {
+      return reply.code(400).send({
+        error: { message: input.message, type: 'invalid_request_error' },
+      });
+    }
+
+    const { body, requestedModel } = input;
     if (!await ensureModelAllowedForDownstreamKey(request, reply, requestedModel)) return;
     const downstreamPolicy = getDownstreamRoutingPolicy(request);
     const forcedChannelId = getTesterForcedChannelId({
@@ -94,7 +101,7 @@ export async function imagesProxyRoute(app: FastifyInstance) {
             },
           );
           const observedFirstByteLatencyMs = getObservedResponseMeta(response)?.firstByteLatencyMs ?? null;
-          const responseText = await response.text();
+          const responseText = await readRuntimeResponseText(response);
           if (!response.ok) {
             throw new SiteApiEndpointRequestError(responseText || 'unknown error', {
               status: response.status,
@@ -314,7 +321,7 @@ export async function imagesProxyRoute(app: FastifyInstance) {
             },
           );
           const observedFirstByteLatencyMs = getObservedResponseMeta(response)?.firstByteLatencyMs ?? null;
-          const responseText = await response.text();
+          const responseText = await readRuntimeResponseText(response);
           if (!response.ok) {
             throw new SiteApiEndpointRequestError(responseText || 'unknown error', {
               status: response.status,
@@ -524,9 +531,71 @@ async function recordTokenRouterEventBestEffort(
   }
 }
 
+/**
+ * 校验并规范化图像生成请求，避免把明显无效的请求发送到上游。
+ * 图像模型的可选参数由上游决定，这里只约束 OpenAI Images API 的必填字段。
+ */
+function normalizeImageGenerationRequest(body: unknown):
+  | { ok: true; body: Record<string, unknown>; requestedModel: string }
+  | { ok: false; message: string } {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return { ok: false, message: 'request body must be a JSON object' };
+  }
+
+  const normalizedBody = body as Record<string, unknown>;
+  const rawModel = normalizedBody.model;
+  if (rawModel !== undefined && typeof rawModel !== 'string') {
+    return { ok: false, message: 'model must be a string' };
+  }
+
+  const prompt = normalizedBody.prompt;
+  if (typeof prompt !== 'string' || prompt.trim().length === 0) {
+    return { ok: false, message: 'prompt is required' };
+  }
+
+  const requestedModel = (rawModel || 'gpt-image-1').trim();
+  if (!requestedModel) {
+    return { ok: false, message: 'model must not be empty' };
+  }
+
+  return {
+    ok: true,
+    body: {
+      ...normalizedBody,
+      model: requestedModel,
+      prompt: prompt.trim(),
+    },
+    requestedModel,
+  };
+}
+
+/**
+ * 解析上游 Images 响应并确认至少返回一个可展示的图像结果。
+ * 不符合协议的 2xx 响应会进入既有渠道重试链路，而不是静默返回空数据。
+ */
 function parseUpstreamImageResponse(text: string): { ok: true; value: any } | { ok: false; message: string } {
   try {
-    return { ok: true, value: JSON.parse(text) };
+    const value = JSON.parse(text) as unknown;
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return { ok: false, message: 'Upstream returned an invalid image response' };
+    }
+
+    const data = (value as Record<string, unknown>).data;
+    if (!Array.isArray(data) || data.length === 0) {
+      return { ok: false, message: 'Upstream image response did not include data' };
+    }
+
+    const hasImage = data.some((item) => {
+      if (!item || typeof item !== 'object' || Array.isArray(item)) return false;
+      const record = item as Record<string, unknown>;
+      return (typeof record.url === 'string' && record.url.trim().length > 0)
+        || (typeof record.b64_json === 'string' && record.b64_json.trim().length > 0);
+    });
+    if (!hasImage) {
+      return { ok: false, message: 'Upstream image response did not include an image' };
+    }
+
+    return { ok: true, value };
   } catch {
     return { ok: false, message: text || 'Upstream returned malformed JSON' };
   }

--- a/src/server/services/checkinService.autoRelogin.test.ts
+++ b/src/server/services/checkinService.autoRelogin.test.ts
@@ -323,6 +323,7 @@ describe('checkinService auto relogin', () => {
           accessToken: 'token',
           status: 'active',
           balance: 10,
+          lastBalanceRefresh: new Date().toISOString(),
           extraConfig: null,
         },
         sites: {
@@ -342,6 +343,93 @@ describe('checkinService auto relogin', () => {
 
     const firstInsertPayload = insertValuesMock.mock.calls[0]?.[0] as Record<string, unknown>;
     expect(Number(firstInsertPayload?.reward)).toBeCloseTo(2.5, 6);
+  });
+
+  it('does not infer a reward from a stale balance snapshot', async () => {
+    selectAllMock.mockReturnValue([
+      {
+        accounts: {
+          id: 131,
+          username: 'stale-balance',
+          accessToken: 'token',
+          status: 'active',
+          balance: 10,
+          lastBalanceRefresh: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+          extraConfig: null,
+        },
+        sites: {
+          id: 131,
+          name: 'demo',
+          url: 'https://example.com',
+          platform: 'new-api',
+        },
+      },
+    ]);
+
+    adapterMock.checkin.mockResolvedValue({ success: true, message: 'checkin success' });
+    refreshBalanceMock.mockResolvedValue({ balance: 12.5, used: 0, quota: 12.5 });
+
+    const { checkinAccount } = await import('./checkinService.js');
+    await checkinAccount(131);
+
+    const firstInsertPayload = insertValuesMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(firstInsertPayload?.reward).toBeUndefined();
+  });
+
+  it('writes one summary event after a batch check-in', async () => {
+    const rows = [
+      {
+        accounts: {
+          id: 201,
+          username: 'batch-success',
+          accessToken: 'token-201',
+          status: 'active',
+          extraConfig: null,
+        },
+        sites: {
+          id: 201,
+          name: 'batch-site',
+          url: 'https://example.com',
+          platform: 'new-api',
+        },
+      },
+      {
+        accounts: {
+          id: 202,
+          username: 'batch-failed',
+          accessToken: 'token-202',
+          status: 'active',
+          extraConfig: null,
+        },
+        sites: {
+          id: 201,
+          name: 'batch-site',
+          url: 'https://example.com',
+          platform: 'new-api',
+        },
+      },
+    ];
+    selectAllMock
+      .mockReturnValueOnce(rows)
+      .mockReturnValueOnce([rows[0]])
+      .mockReturnValueOnce([rows[1]]);
+    adapterMock.checkin
+      .mockResolvedValueOnce({ success: true, message: 'checkin success' })
+      .mockResolvedValueOnce({ success: false, message: 'upstream unavailable' });
+
+    const { checkinAll } = await import('./checkinService.js');
+    const results = await checkinAll({ scheduleMode: 'cron' });
+
+    expect(results).toHaveLength(2);
+    const eventPayloads = insertValuesMock.mock.calls
+      .map((call) => call[0] as Record<string, unknown>)
+      .filter((payload) => payload.type === 'checkin');
+    expect(eventPayloads).toHaveLength(1);
+    expect(eventPayloads[0]).toMatchObject({
+      title: 'checkin summary',
+      message: '签到批次完成：总计 2，成功 1，跳过 0，失败 1',
+      level: 'warning',
+    });
   });
 
   it('treats already checked in responses as successful checkins', async () => {

--- a/src/server/services/checkinService.ts
+++ b/src/server/services/checkinService.ts
@@ -21,6 +21,9 @@ import { withAccountProxyOverride } from './siteProxy.js';
 
 type CheckinExecutionStatus = 'success' | 'failed' | 'skipped';
 
+// 只有刚刚刷新过的余额才能用于推导本次签到奖励，避免把多日累计变化误记为奖励。
+const REWARD_BALANCE_MAX_AGE_MS = 5 * 60 * 1000;
+
 function isSiteDisabled(status?: string | null): boolean {
   return (status || 'active') === 'disabled';
 }
@@ -90,6 +93,14 @@ function inferRewardFromBalanceDelta(previousBalance: unknown, latestBalance: un
   const delta = after - before;
   if (!Number.isFinite(delta) || delta <= 0) return 0;
   return Math.round(delta * 1_000_000) / 1_000_000;
+}
+
+function hasFreshBalanceSnapshot(lastBalanceRefresh: unknown, now = Date.now()): boolean {
+  if (typeof lastBalanceRefresh !== 'string' || !lastBalanceRefresh.trim()) return false;
+  const refreshedAt = Date.parse(lastBalanceRefresh);
+  if (!Number.isFinite(refreshedAt)) return false;
+  const age = now - refreshedAt;
+  return age >= 0 && age <= REWARD_BALANCE_MAX_AGE_MS;
 }
 
 /**
@@ -297,7 +308,9 @@ export async function checkinAccount(accountId: number, options?: { skipEvent?: 
 
     const parsedReward = parseCheckinRewardAmount(logReward) || parseCheckinRewardAmount(result.message);
     if (directCheckinSuccess && parsedReward <= 0) {
-      const inferredReward = inferRewardFromBalanceDelta(account.balance, refreshedBalanceInfo?.balance);
+      const inferredReward = hasFreshBalanceSnapshot(account.lastBalanceRefresh)
+        ? inferRewardFromBalanceDelta(account.balance, refreshedBalanceInfo?.balance)
+        : 0;
       if (inferredReward > 0) {
         logReward = inferredReward.toString();
       }
@@ -408,5 +421,22 @@ export async function checkinAll(options?: { accountIds?: number[]; scheduleMode
   });
 
   await Promise.all(promises);
+
+  if (results.length > 0) {
+    const success = results.filter((entry) => entry.result?.status === 'success').length;
+    const skipped = results.filter((entry) => entry.result?.status === 'skipped').length;
+    const failed = results.length - success - skipped;
+    const createdAt = formatUtcSqlDateTime(new Date());
+    // 批量任务抑制账号级事件后写一条汇总，确保定时签到也能被事件通知和看板发现。
+    await db.insert(schema.events).values({
+      type: 'checkin',
+      title: 'checkin summary',
+      message: `签到批次完成：总计 ${results.length}，成功 ${success}，跳过 ${skipped}，失败 ${failed}`,
+      level: failed > 0 ? 'warning' : 'info',
+      relatedType: 'account',
+      createdAt,
+    }).run();
+  }
+
   return results;
 }

--- a/src/server/services/platforms/base.ts
+++ b/src/server/services/platforms/base.ts
@@ -60,6 +60,8 @@ export interface UserInfo {
 
 export interface TokenVerifyResult {
   tokenType: 'session' | 'apikey' | 'unknown';
+  /** 可诊断的验证失败原因，例如新版 ESA 需要真实浏览器。 */
+  message?: string;
   userInfo?: UserInfo | null;
   balance?: BalanceInfo | null;
   apiToken?: string | null;

--- a/src/server/services/platforms/newApi.test.ts
+++ b/src/server/services/platforms/newApi.test.ts
@@ -30,6 +30,9 @@ const SHIELD_LOGIN_COOKIE = 'challenge-seed';
 const COOKIE_ONLY_LOGIN_USERNAME = 'cookie-only-user';
 const COOKIE_ONLY_LOGIN_PASSWORD = 'cookie-only-pass';
 const COOKIE_ONLY_LOGIN_SESSION = 'cookie-only-session';
+const ESA_LOGIN_USERNAME = 'esa-browser-user';
+const ESA_LOGIN_PASSWORD = 'esa-browser-pass';
+const ESA_VERIFY_TOKEN = 'esa-browser-token';
 const OPENAI_MODELS_SHIELDED_TOKEN = 'openai-models-shielded-token';
 const COOKIE_SHIELDED_TOKEN = Buffer.from(
   `1771864970|${Buffer.from('username=linuxdo_131936').toString('base64')}|sig`,
@@ -124,6 +127,14 @@ describe('NewApiAdapter', () => {
           const isCookieOnlyLogin =
             payload.username === COOKIE_ONLY_LOGIN_USERNAME &&
             payload.password === COOKIE_ONLY_LOGIN_PASSWORD;
+          const isEsaLogin =
+            payload.username === ESA_LOGIN_USERNAME &&
+            payload.password === ESA_LOGIN_PASSWORD;
+          if (isEsaLogin) {
+            res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+            res.end('<meta name="aliyun_waf_aa" content="aa"><meta name="aliyun_waf_bb" content="bb">');
+            return;
+          }
           if (!isShieldLogin && !isCookieOnlyLogin) {
             res.writeHead(401, { 'Content-Type': 'application/json' });
             res.end(JSON.stringify({ success: false, message: 'invalid credentials' }));
@@ -285,6 +296,11 @@ describe('NewApiAdapter', () => {
       }
 
       if (req.url === '/api/user/self') {
+        if (req.headers.authorization === `Bearer ${ESA_VERIFY_TOKEN}`) {
+          res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+          res.end('<meta name="aliyun_waf_aa" content="aa"><meta name="aliyun_waf_bb" content="bb">');
+          return;
+        }
         if (typeof req.headers.authorization === 'string' && req.headers.authorization === `Bearer ${BALANCE_SHIELD_FAILURE_TOKEN}`) {
           res.writeHead(200, {
             'Content-Type': 'text/html; charset=utf-8',
@@ -664,6 +680,25 @@ describe('NewApiAdapter', () => {
           r.headers.cookie.includes(`cdn_sec_tc=${SHIELD_LOGIN_COOKIE}`),
       ),
     ).toBe(true);
+  });
+
+  it('returns a stable browser-verification message for the new ESA challenge', async () => {
+    const adapter = new NewApiAdapter();
+    const result = await adapter.login(baseUrl, ESA_LOGIN_USERNAME, ESA_LOGIN_PASSWORD);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('阿里云 ESA');
+    expect(result.message).toContain('真实浏览器');
+    expect(result.message).not.toContain("Unexpected token '<'");
+  });
+
+  it('preserves the ESA browser-verification message during token verification', async () => {
+    const adapter = new NewApiAdapter();
+    const result = await adapter.verifyToken(baseUrl, ESA_VERIFY_TOKEN);
+
+    expect(result.tokenType).toBe('unknown');
+    expect(result.message).toContain('阿里云 ESA');
+    expect(result.message).toContain('真实浏览器');
   });
 
   it('uses session cookie as access credential when login success has no token payload', async () => {

--- a/src/server/services/platforms/newApi.ts
+++ b/src/server/services/platforms/newApi.ts
@@ -2,7 +2,11 @@ import { ApiTokenInfo, BasePlatformAdapter, CheckinResult, BalanceInfo, UserInfo
 import type { RequestInit as UndiciRequestInit } from 'undici';
 import { createContext, runInContext } from 'node:vm';
 import { withSiteProxyRequestInit } from '../siteProxy.js';
-import { fetchJsonWithShieldCookieRetry } from './newApiShield.js';
+import {
+  detectNewApiShieldChallenge,
+  fetchJsonWithShieldCookieRetry,
+  NEW_API_ESA_BROWSER_CHALLENGE_MESSAGE,
+} from './newApiShield.js';
 import {
   buildEndpointModelContextLengthScope,
   extractContextLengthsFromPayload,
@@ -567,11 +571,7 @@ export class NewApiAdapter extends BasePlatformAdapter {
   }
 
   private isShieldChallenge(contentType: string, text: string): boolean {
-    const ct = (contentType || '').toLowerCase();
-    if (ct.includes('text/html') && /var\s+arg1\s*=|acw_sc__v2|cdn_sec_tc|<script/i.test(text)) {
-      return true;
-    }
-    return /var\s+arg1\s*=/.test(text);
+    return detectNewApiShieldChallenge(contentType, text) !== null;
   }
 
   private normalizeHeaders(headers?: UndiciRequestInit['headers']): Record<string, string> {
@@ -737,7 +737,7 @@ export class NewApiAdapter extends BasePlatformAdapter {
   private async fetchJsonRawWithCookie<T>(
     url: string,
     options?: UndiciRequestInit,
-  ): Promise<{ data: T | null; cookieHeader: string }> {
+  ): Promise<{ data: T | null; cookieHeader: string; error?: string }> {
     const { fetch } = await import('undici');
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
@@ -767,8 +767,12 @@ export class NewApiAdapter extends BasePlatformAdapter {
       const parsed = this.parseJsonSafe<T>(text);
       if (parsed) return { data: parsed, cookieHeader };
 
-      if (!this.isShieldChallenge(res.headers.get('content-type') || '', text)) {
+      const challenge = detectNewApiShieldChallenge(res.headers.get('content-type') || '', text);
+      if (!challenge) {
         return { data: null, cookieHeader };
+      }
+      if (challenge === 'aliyun-esa-browser') {
+        return { data: null, cookieHeader, error: NEW_API_ESA_BROWSER_CHALLENGE_MESSAGE };
       }
       if (!cookieHeader) {
         return { data: null, cookieHeader };
@@ -787,6 +791,7 @@ export class NewApiAdapter extends BasePlatformAdapter {
 
   private async fetchJsonRaw<T>(url: string, options?: UndiciRequestInit): Promise<T | null> {
     const result = await this.fetchJsonRawWithCookie<T>(url, options);
+    if (result.error) throw new Error(result.error);
     return result.data;
   }
 
@@ -881,12 +886,13 @@ export class NewApiAdapter extends BasePlatformAdapter {
   ): Promise<string[]> {
     for (const cookie of this.buildCookieCandidates(token)) {
       try {
-        const { data } = await fetchJsonWithShieldCookieRetry<any>(`${baseUrl}/v1/models`, {
+        const { data, error } = await fetchJsonWithShieldCookieRetry<any>(`${baseUrl}/v1/models`, {
           headers: {
             Authorization: `Bearer ${token}`,
             Cookie: cookie,
           },
         });
+        if (!data && error) throw new Error(error);
         const models = this.extractOpenAiModels(data, sourceScope);
         if (models.length > 0) return models;
       } catch {}
@@ -977,7 +983,7 @@ export class NewApiAdapter extends BasePlatformAdapter {
     password: string,
   ): Promise<LoginResult> {
     try {
-      const { data: res, cookieHeader } = await this.fetchJsonRawWithCookie<any>(`${baseUrl}/api/user/login`, {
+      const { data: res, cookieHeader, error } = await this.fetchJsonRawWithCookie<any>(`${baseUrl}/api/user/login`, {
         method: 'POST',
         body: JSON.stringify({ username, password }),
         headers: {
@@ -985,7 +991,7 @@ export class NewApiAdapter extends BasePlatformAdapter {
         },
       });
       if (!res) {
-        return { success: false, message: 'shield challenge blocked login' };
+        return { success: false, message: error || 'shield challenge blocked login' };
       }
 
       const accessToken = this.extractLoginAccessToken(res);
@@ -1020,7 +1026,13 @@ export class NewApiAdapter extends BasePlatformAdapter {
   }
 
   override async verifyToken(baseUrl: string, token: string, platformUserId?: number): Promise<TokenVerifyResult> {
-    const openAiModels = await this.getOpenAiModels(baseUrl, token);
+    let verificationFailureMessage: string | undefined;
+    let openAiModels: string[] = [];
+    try {
+      openAiModels = await this.getOpenAiModels(baseUrl, token);
+    } catch (err: any) {
+      verificationFailureMessage = err?.message || undefined;
+    }
     if (openAiModels.length > 0) {
       return { tokenType: 'apikey', models: openAiModels };
     }
@@ -1060,7 +1072,9 @@ export class NewApiAdapter extends BasePlatformAdapter {
           }
         }
       }
-    } catch {}
+    } catch (err: any) {
+      verificationFailureMessage ||= err?.message || undefined;
+    }
 
     const cookieRes = await this.fetchUserSelfByCookie(baseUrl, token, platformUserId);
     if (cookieRes?.success && cookieRes?.data) {
@@ -1084,7 +1098,10 @@ export class NewApiAdapter extends BasePlatformAdapter {
       }
     }
 
-    return { tokenType: 'unknown' };
+    return {
+      tokenType: 'unknown',
+      ...(verificationFailureMessage ? { message: verificationFailureMessage } : {}),
+    };
   }
 
   private async probeUserId(baseUrl: string, accessToken: string): Promise<number | null> {
@@ -1129,10 +1146,14 @@ export class NewApiAdapter extends BasePlatformAdapter {
       try {
         const headers = this.authHeaders(accessToken, resolvedUserId || undefined);
 
-        const res = await this.fetchJson<any>(`${baseUrl}/api/user/checkin`, {
+        const shieldResult = await fetchJsonWithShieldCookieRetry<any>(`${baseUrl}/api/user/checkin`, {
           method: 'POST',
           headers,
         });
+        const res = shieldResult.data;
+        if (!res && shieldResult.error) {
+          rememberFailure(this.formatRequestErrorMessage(new Error(shieldResult.error)) || shieldResult.error);
+        }
         if (res?.success) {
           return { success: true, message: res.message || 'checkin success', reward: res.data?.reward?.toString() };
         }
@@ -1156,11 +1177,15 @@ export class NewApiAdapter extends BasePlatformAdapter {
             'X-Requested-With': 'XMLHttpRequest',
           };
           this.appendUserIdCompatibilityHeaders(headers, cookieUserId);
-          const signInRes = await this.fetchJsonRaw<any>(`${baseUrl}/api/user/sign_in`, {
+          const signInShieldResult = await fetchJsonWithShieldCookieRetry<any>(`${baseUrl}/api/user/sign_in`, {
             method: 'POST',
             body: '{}',
             headers,
           });
+          const signInRes = signInShieldResult.data;
+          if (!signInRes && signInShieldResult.error) {
+            rememberFailure(this.formatRequestErrorMessage(new Error(signInShieldResult.error)) || signInShieldResult.error);
+          }
           if (signInRes?.success) {
             return {
               success: true,
@@ -1178,10 +1203,14 @@ export class NewApiAdapter extends BasePlatformAdapter {
         try {
           const headers: Record<string, string> = { Cookie: cookie };
           this.appendUserIdCompatibilityHeaders(headers, cookieUserId);
-          const res = await this.fetchJsonRaw<any>(`${baseUrl}/api/user/checkin`, {
+          const shieldResult = await fetchJsonWithShieldCookieRetry<any>(`${baseUrl}/api/user/checkin`, {
             method: 'POST',
             headers,
           });
+          const res = shieldResult.data;
+          if (!res && shieldResult.error) {
+            rememberFailure(this.formatRequestErrorMessage(new Error(shieldResult.error)) || shieldResult.error);
+          }
           if (res?.success) {
             return { success: true, message: res.message || 'checkin success', reward: res.data?.reward?.toString() };
           }
@@ -1235,9 +1264,13 @@ export class NewApiAdapter extends BasePlatformAdapter {
     };
 
     try {
-      const res = await this.fetchJson<any>(`${baseUrl}/api/user/self`, {
+      const shieldResult = await fetchJsonWithShieldCookieRetry<any>(`${baseUrl}/api/user/self`, {
         headers: this.authHeaders(accessToken, resolvedUserId || undefined),
       });
+      const res = shieldResult.data;
+      if (!res && shieldResult.error) {
+        rememberFailure(this.formatRequestErrorMessage(new Error(shieldResult.error)) || shieldResult.error);
+      }
       if (res?.success && res?.data) {
         return this.parseBalance(res.data);
       }

--- a/src/server/services/platforms/newApiShield.ts
+++ b/src/server/services/platforms/newApiShield.ts
@@ -4,6 +4,58 @@ import { withSiteProxyRequestInit } from '../siteProxy.js';
 
 const SHIELD_USER_AGENT = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36';
 
+/**
+ * New API 站点可能返回的防护挑战类型。
+ * `aliyun-esa-browser` 依赖真实浏览器环境，不能在 node:vm 中伪造完成。
+ */
+export type NewApiShieldChallengeKind = 'legacy-acw-sc-v2' | 'aliyun-esa-browser';
+
+/** 新版 ESA 挑战的稳定提示，供登录、签到和余额刷新共用。 */
+export const NEW_API_ESA_BROWSER_CHALLENGE_MESSAGE =
+  '站点返回了阿里云 ESA 浏览器验证页面，需要真实浏览器执行 JavaScript，当前 HTTP 客户端无法完成验证';
+
+/**
+ * 让上层可以按错误类型处理挑战，而不是依赖 undici 的 HTML JSON 解析文案。
+ */
+export class NewApiShieldChallengeError extends Error {
+  readonly code = 'new_api_shield_challenge';
+  readonly challenge: NewApiShieldChallengeKind;
+
+  constructor(challenge: NewApiShieldChallengeKind) {
+    super(
+      challenge === 'aliyun-esa-browser'
+        ? NEW_API_ESA_BROWSER_CHALLENGE_MESSAGE
+        : '站点返回了防护验证页面，当前请求无法完成验证',
+    );
+    this.name = 'NewApiShieldChallengeError';
+    this.challenge = challenge;
+  }
+}
+
+/** 识别阿里云 ESA 新版 meta 挑战页；该挑战需要 DOM、时序和浏览器指纹。 */
+export function isAliyunEsaBrowserChallenge(text: string): boolean {
+  return /<meta\b[^>]*\bname\s*=\s*["']aliyun_waf_(?:aa|bb)["'][^>]*>/i.test(text || '');
+}
+
+/** 统一识别旧版 acw_sc__v2 与新版 ESA 挑战。 */
+export function detectNewApiShieldChallenge(
+  contentType: string,
+  text: string,
+): NewApiShieldChallengeKind | null {
+  if (isAliyunEsaBrowserChallenge(text)) return 'aliyun-esa-browser';
+
+  const normalizedType = (contentType || '').toLowerCase();
+  if (
+    (normalizedType.includes('text/html')
+      && /var\s+arg1\s*=|acw_sc__v2|cdn_sec_tc|<script/i.test(text))
+    || /var\s+arg1\s*=/.test(text)
+  ) {
+    return 'legacy-acw-sc-v2';
+  }
+
+  return null;
+}
+
 export function buildNewApiCookieCandidates(token: string): string[] {
   const trimmed = (token || '').trim();
   if (!trimmed) return [];
@@ -122,14 +174,6 @@ export function solveNewApiAcwScV2(html: string): string | null {
   return out || null;
 }
 
-function isShieldChallenge(contentType: string, text: string): boolean {
-  const normalizedType = (contentType || '').toLowerCase();
-  if (normalizedType.includes('text/html') && /var\s+arg1\s*=|acw_sc__v2|cdn_sec_tc|<script/i.test(text)) {
-    return true;
-  }
-  return /var\s+arg1\s*=/.test(text);
-}
-
 function normalizeHeaders(headers?: UndiciRequestInit['headers']): Record<string, string> {
   const output: Record<string, string> = {};
   if (!headers) return output;
@@ -204,10 +248,19 @@ function collectSetCookieHeaders(headers: Headers): string[] {
   return single ? [single] : [];
 }
 
+export interface ShieldCookieFetchResult<T> {
+  data: T | null;
+  cookieHeader: string;
+  /** 本次响应如果是挑战页，返回其类型而不是丢失上下文。 */
+  challenge?: NewApiShieldChallengeKind;
+  /** 面向日志/UI 的稳定错误提示。 */
+  error?: string;
+}
+
 export async function fetchJsonWithShieldCookieRetry<T>(
   url: string,
   options?: UndiciRequestInit,
-): Promise<{ data: T | null; cookieHeader: string }> {
+): Promise<ShieldCookieFetchResult<T>> {
   const { fetch } = await import('undici');
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -235,16 +288,45 @@ export async function fetchJsonWithShieldCookieRetry<T>(
     const parsed = parseJsonSafe<T>(text);
     if (parsed) return { data: parsed, cookieHeader };
 
-    if (!isShieldChallenge(response.headers.get('content-type') || '', text)) {
+    const challenge = detectNewApiShieldChallenge(response.headers.get('content-type') || '', text);
+    if (!challenge) {
+      if (!response.ok) {
+        return {
+          data: null,
+          cookieHeader,
+          error: `HTTP ${response.status}: ${text}`,
+        };
+      }
       return { data: null, cookieHeader };
     }
+
+    // 新版 ESA 不是旧版 acw_sc__v2 的换算题，返回稳定上下文供调用方停止重试。
+    if (challenge === 'aliyun-esa-browser') {
+      return {
+        data: null,
+        cookieHeader,
+        challenge,
+        error: NEW_API_ESA_BROWSER_CHALLENGE_MESSAGE,
+      };
+    }
+
     if (!cookieHeader) {
-      return { data: null, cookieHeader };
+      return {
+        data: null,
+        cookieHeader,
+        challenge,
+        error: '站点返回了防护验证页面，当前请求无法完成验证',
+      };
     }
 
     const acwScV2 = solveNewApiAcwScV2(text);
     if (!acwScV2) {
-      return { data: null, cookieHeader };
+      return {
+        data: null,
+        cookieHeader,
+        challenge,
+        error: '站点返回了防护验证页面，当前请求无法完成验证',
+      };
     }
 
     cookieHeader = upsertCookie(cookieHeader, 'acw_sc__v2', acwScV2);


### PR DESCRIPTION
## 关联 Issue

Closes #605

## 变更

- 完善 /v1/images/generations 的 OpenAI Images 请求校验和默认模型处理
- 校验上游 2xx 响应确实包含可用图像数据，异常响应复用渠道重试与失败记录链路
- 使用运行时响应读取器，兼容压缩响应
- 增加路由回归测试与客户端接入示例

## 验证

- 
px vitest run --pool=threads --poolOptions.threads.singleThread=true --hookTimeout=30000 src/server/routes/proxy/images.edits.test.ts`n- 
pm run typecheck:server`n- 
pm run repo:drift-check`n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added image generation support through `POST /v1/images/generations`, including prompt validation, model normalization, and support for image output formats.
  * Added clearer messages when account verification encounters browser-security challenges or network failures.

* **Bug Fixes**
  * Image requests now retry when successful upstream responses contain no usable image data.
  * Rewards are inferred only from recently refreshed balances.
  * Batch check-ins now produce a summary showing processed, successful, skipped, and failed accounts.

* **Documentation**
  * Added image generation API usage and response details to the integration guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->